### PR TITLE
GA: Updating incorrect exit numbers on I-16.

### DIFF
--- a/hwy_data/GA/usai/ga.i016.wpt
+++ b/hwy_data/GA/usai/ga.i016.wpt
@@ -1,5 +1,5 @@
-I-75 +0 http://www.openstreetmap.org/?lat=32.856248&lon=-83.640558
-1 http://www.openstreetmap.org/?lat=32.847469&lon=-83.626739
+1 +I-75 +0 http://www.openstreetmap.org/?lat=32.856248&lon=-83.640558
+1A http://www.openstreetmap.org/?lat=32.847469&lon=-83.626739
 1B http://www.openstreetmap.org/?lat=32.843034&lon=-83.623574
 2 http://www.openstreetmap.org/?lat=32.839816&lon=-83.619497
 6 http://www.openstreetmap.org/?lat=32.799946&lon=-83.569500

--- a/hwy_data/GA/usaus/ga.us023.wpt
+++ b/hwy_data/GA/usaus/ga.us023.wpt
@@ -70,7 +70,7 @@ JefRd http://www.openstreetmap.org/?lat=32.848704&lon=-83.602223
 US80_W http://www.openstreetmap.org/?lat=32.848163&lon=-83.616700
 US129Alt_N http://www.openstreetmap.org/?lat=32.848204&lon=-83.620934
 US129_N http://www.openstreetmap.org/?lat=32.848253&lon=-83.626170
-I-16(1) http://www.openstreetmap.org/?lat=32.847469&lon=-83.626739
+I-16(1A) +I-16(1) http://www.openstreetmap.org/?lat=32.847469&lon=-83.626739
 US129_S http://www.openstreetmap.org/?lat=32.843314&lon=-83.630322
 ForAve http://www.openstreetmap.org/?lat=32.855288&lon=-83.644533
 I-75(167A) http://www.openstreetmap.org/?lat=32.871572&lon=-83.661162

--- a/hwy_data/GA/usaus/ga.us129.wpt
+++ b/hwy_data/GA/usaus/ga.us129.wpt
@@ -80,7 +80,7 @@ US41Bus_N http://www.openstreetmap.org/?lat=32.836485&lon=-83.622270
 US80_E http://www.openstreetmap.org/?lat=32.837752&lon=-83.621170
 GA22 http://www.openstreetmap.org/?lat=32.840570&lon=-83.625680
 US23_N http://www.openstreetmap.org/?lat=32.843314&lon=-83.630322
-I-16 +I-16(1) http://www.openstreetmap.org/?lat=32.847469&lon=-83.626739
+I-16(1A) +I-16 +I-16(1) http://www.openstreetmap.org/?lat=32.847469&lon=-83.626739
 US23_S http://www.openstreetmap.org/?lat=32.848253&lon=-83.626170
 US129Alt_N http://www.openstreetmap.org/?lat=32.851230&lon=-83.620784
 GA49_N http://www.openstreetmap.org/?lat=32.859627&lon=-83.614934


### PR DESCRIPTION
Moved I-16 '1' to the interchange with I-75.  Corrected former label for US-23/US-129 interchange from 1 > 1A.

http://clinched.s2.bizhat.com/viewtopic.php?p=16088

Hopefully I've done everything correctly.