### PR TITLE
NY 100 Southern terminus fix.

### DIFF
--- a/hwy_data/NY/usany/ny.ny100.wpt
+++ b/hwy_data/NY/usany/ny.ny100.wpt
@@ -1,4 +1,4 @@
-I-87 http://www.openstreetmap.org/?lat=40.931485&lon=-73.856685
+I-87 http://www.openstreetmap.org/?lat=40.934792&lon=-73.856127
 PalRd http://www.openstreetmap.org/?lat=40.945006&lon=-73.850420
 SprBroPkwy_Tuc http://www.openstreetmap.org/?lat=40.946403&lon=-73.849690
 TucRd http://www.openstreetmap.org/?lat=40.953346&lon=-73.843017


### PR DESCRIPTION
Moved southern terminus from NYST Exit 4 to NYST Exit 5.