### PR TITLE
Jteresco ny205 fix 2

### DIFF
--- a/hwy_data/NY/usany/ny.ny205.wpt
+++ b/hwy_data/NY/usany/ny.ny205.wpt
@@ -1,7 +1,7 @@
 I-88 http://www.openstreetmap.org/?lat=42.440856&lon=-75.103505
 NY7 http://www.openstreetmap.org/?lat=42.442588&lon=-75.107861
-NY23_W http://www.openstreetmap.org/?lat=42.457864&lon=-75.103054
-NY23_E http://www.openstreetmap.org/?lat=42.468629&lon=-75.102882
+NY23_E http://www.openstreetmap.org/?lat=42.457864&lon=-75.103054
+NY23_W http://www.openstreetmap.org/?lat=42.468629&lon=-75.102882
 +X01 http://www.openstreetmap.org/?lat=42.515679&lon=-75.094471
 CR46 http://www.openstreetmap.org/?lat=42.570304&lon=-75.054528
 NY80_W http://www.openstreetmap.org/?lat=42.732401&lon=-75.049131

--- a/updates.csv
+++ b/updates.csv
@@ -1,4 +1,5 @@
 YY-MM-DD;Country;Route;Root;Description
+15-08-11;(USA) New York;NY 205;ny.ny205;NY23_W and NY23_E labels were backwards, fixed
 15-08-11;(USA) Wyoming;US310;wy.us310;Route truncated at east end from eastern junction with US14/16 to (formerly western) junction with US14/16
 15-08-03;(USA) Arizona;I-11 Future (Hoover Dam);az.i011futhoo;New Route
 15-08-03;(USA) Arizona;I-11 Future (Kingman);az.i011futkin;New Route


### PR DESCRIPTION
Fix for issue in old CHM forum where NY 205's labels for the ends of its concurrency with NY 23 were reversed.