### PR TITLE
ME26 truncation

### DIFF
--- a/hwy_data/ME/usame/me.me026.wpt
+++ b/hwy_data/ME/usame/me.me026.wpt
@@ -1,5 +1,4 @@
-ConSt http://www.openstreetmap.org/?lat=43.663304&lon=-70.251029
-CumAve http://www.openstreetmap.org/?lat=43.664022&lon=-70.251453
+CumAve +ConSt http://www.openstreetmap.org/?lat=43.664022&lon=-70.251453
 FoxSt http://www.openstreetmap.org/?lat=43.667588&lon=-70.253347
 I-295_S http://www.openstreetmap.org/?lat=43.674805&lon=-70.256310
 I-295_N http://www.openstreetmap.org/?lat=43.679227&lon=-70.256297

--- a/updates.csv
+++ b/updates.csv
@@ -1,5 +1,5 @@
 YY-MM-DD;Country;Route;Root;Description
-15-08-12;(USA) Maine;ME 26;Truncated between the old southern end at Congress Street and the new end at Cumberland Avenue
+15-08-12;(USA) Maine;ME 26;me.me026;Truncated between the old southern end at Congress Street and the new end at Cumberland Avenue.
 15-08-11;(USA) New York;NY 205;ny.ny205;NY23_W and NY23_E labels were backwards, fixed
 15-08-11;(USA) Wyoming;US310;wy.us310;Route truncated at east end from eastern junction with US14/16 to (formerly western) junction with US14/16
 15-08-03;(USA) Arizona;I-11 Future (Hoover Dam);az.i011futhoo;New Route

--- a/updates.csv
+++ b/updates.csv
@@ -1,4 +1,5 @@
 YY-MM-DD;Country;Route;Root;Description
+15-08-12;(USA) Maine;ME 26;Truncated between the old southern end at Congress Street and the new end at Cumberland Avenue
 15-08-11;(USA) New York;NY 205;ny.ny205;NY23_W and NY23_E labels were backwards, fixed
 15-08-11;(USA) Wyoming;US310;wy.us310;Route truncated at east end from eastern junction with US14/16 to (formerly western) junction with US14/16
 15-08-03;(USA) Arizona;I-11 Future (Hoover Dam);az.i011futhoo;New Route


### PR DESCRIPTION
(USA) Maine ME 26: Truncated between the old southern end at Congress Street and the new end at Cumberland Avenue.