### PR TITLE
Lake Elsinore CA I-15 BL changes

### DIFF
--- a/hwy_data/CA/usaib/ca.i015bllak.wpt
+++ b/hwy_data/CA/usaib/ca.i015bllak.wpt
@@ -1,7 +1,4 @@
-I-15_S http://www.openstreetmap.org/?lat=33.662262&lon=-117.298708
+I-15 +I-15_S http://www.openstreetmap.org/?lat=33.662262&lon=-117.298708
 MisTr http://www.openstreetmap.org/?lat=33.659996&lon=-117.300253
 MainSt http://www.openstreetmap.org/?lat=33.667961&lon=-117.327719
-CA74_W http://www.openstreetmap.org/?lat=33.684540&lon=-117.366557
-ColAve_N http://www.openstreetmap.org/?lat=33.694974&lon=-117.346215
-CenAve http://www.openstreetmap.org/?lat=33.690021&lon=-117.339778
-I-15_N http://www.openstreetmap.org/?lat=33.692011&lon=-117.337546
+CA74 +CA74_W +I-15_N http://www.openstreetmap.org/?lat=33.684540&lon=-117.366557

--- a/hwy_data/CA/usaib/ca.i015bllke.wpt
+++ b/hwy_data/CA/usaib/ca.i015bllke.wpt
@@ -1,0 +1,2 @@
+I-15 http://www.openstreetmap.org/?lat=33.677263&lon=-117.323642
+GraAve http://www.openstreetmap.org/?lat=33.667961&lon=-117.327719

--- a/hwy_data/_systems/usaib.csv
+++ b/hwy_data/_systems/usaib.csv
@@ -32,6 +32,7 @@ usaib;TX;I-10;BL;Bal;Balmorhea, TX;tx.i010blbal;
 usaib;TX;I-10;BL;For;Fort Stockton, TX;tx.i010blfor;
 usaib;CA;I-15;BL;Esc;Escondido, CA;ca.i015blesc;
 usaib;CA;I-15;BL;Lak;Lake Elsinore, CA;ca.i015bllak;
+usaib;CA;I-15;BL;LkE;Lake Elsinore, CA (Main St.);ca.i015bllke;
 usaib;CA;I-15;BL;Nor;Norco, CA;ca.i015blnor;
 usaib;CA;I-15;BL;Vic;Victorville, CA;ca.i015blvic;
 usaib;CA;I-15;BL;Bar;Barstow, CA;ca.i015blbar;

--- a/hwy_data/_systems/usaib_con.csv
+++ b/hwy_data/_systems/usaib_con.csv
@@ -31,6 +31,7 @@ usaib;I-10;BL;Balmorhea, TX;tx.i010blbal
 usaib;I-10;BL;Fort Stockton, TX;tx.i010blfor
 usaib;I-15;BL;Escondido, CA;ca.i015blesc
 usaib;I-15;BL;Lake Elsinore, CA;ca.i015bllak
+usaib;I-15;BL;Lake Elsinore, CA (Main St.);ca.i015bllke
 usaib;I-15;BL;Norco, CA;ca.i015blnor
 usaib;I-15;BL;Victorville, CA;ca.i015blvic
 usaib;I-15;BL;Barstow, CA;ca.i015blbar


### PR DESCRIPTION
Truncate existing BL to CA 74@Lakeshore Dr, and add branch BL on Main
St. between Lakeshore Dr. and I-15

Updates entries:

15-08-13;(USA) California;I-15BL (Lake Elsinore);ca.i15bllak;Truncated north end of route from I-15 exit 77 to CA 74@Lakeshore Dr.

15-08-13;(USA) California;I-15BL (Lake Elsinore - Main St. branch);ca.i15bllke;.New route