### PR TITLE
Ontario updates

### DIFF
--- a/hwy_data/ON/canon/on.on028.wpt
+++ b/hwy_data/ON/canon/on.on028.wpt
@@ -2,12 +2,11 @@ ON7 http://www.openstreetmap.org/?lat=44.316865&lon=-78.199096
 RR8 http://www.openstreetmap.org/?lat=44.368458&lon=-78.224172
 RR4 http://www.openstreetmap.org/?lat=44.371180&lon=-78.225483
 RR33 http://www.openstreetmap.org/?lat=44.421390&lon=-78.249178
-RR29 http://www.openstreetmap.org/?lat=44.445288&lon=-78.260384
-+X000(ON28) http://www.openstreetmap.org/?lat=44.448940&lon=-78.257064
-RR6 http://www.openstreetmap.org/?lat=44.450567&lon=-78.251552
+*OldON28 http://www.openstreetmap.org/?lat=44.442038&lon=-78.258930
+RR6/29 http://www.openstreetmap.org/?lat=44.450367&lon=-78.250707
 +X001(ON28) http://www.openstreetmap.org/?lat=44.483894&lon=-78.233447
 RR20 http://www.openstreetmap.org/?lat=44.490337&lon=-78.236027
-NSchRd http://www.openstreetmap.org/?lat=44.496626&lon=-78.238347
+SchRd http://www.openstreetmap.org/?lat=44.496626&lon=-78.238347
 CleLakeRd http://www.openstreetmap.org/?lat=44.503420&lon=-78.219287
 KawParkRd http://www.openstreetmap.org/?lat=44.532750&lon=-78.207464
 +X002(ON28) http://www.openstreetmap.org/?lat=44.543857&lon=-78.198366

--- a/hwy_data/ON/canonf/on.on404.wpt
+++ b/hwy_data/ON/canonf/on.on404.wpt
@@ -17,3 +17,7 @@
 49 http://www.openstreetmap.org/?lat=44.049870&lon=-79.416560
 51 http://www.openstreetmap.org/?lat=44.068360&lon=-79.420442
 53 http://www.openstreetmap.org/?lat=44.086950&lon=-79.423910
++X003(ON404) http://www.openstreetmap.org/?lat=44.110434&lon=-79.421990
+59 http://www.openstreetmap.org/?lat=44.141681&lon=-79.437622
++X004(ON404) http://www.openstreetmap.org/?lat=44.177711&lon=-79.448555
+65 http://www.openstreetmap.org/?lat=44.192521&lon=-79.438137


### PR DESCRIPTION
With these updates, this will bring me up-to-date with submissions that I had made to Tim, but didn't get processed on the old CHM website.  From now on, any updates I submit will be 'new' work.

15-08-21;(Canada) Ontario;ON 404;on.on404;Extended northward from the interchange with Green Lane (Exit 53) to Woodbine Avenue (Exit 65).

15-08-21;(Canada) Ontario;ON 28;on.on028;Removed from Peterborough Road 29 just NorthEast of Lakefield, ON, and relocated onto a brand new alignment SouthEast of Peterborough Road 29 between the closed intersection of *OldON28 and the intersection of Peterborough Road 6/Peterborough Road 29 (RR6/29).