### PR TITLE
Fixes Datacheck errors in WI 35

### DIFF
--- a/hwy_data/WI/usawi/wi.wi035.wpt
+++ b/hwy_data/WI/usawi/wi.wi035.wpt
@@ -84,8 +84,8 @@ CRD_Pie http://www.openstreetmap.org/?lat=44.588206&lon=-92.395964
 +X10 http://www.openstreetmap.org/?lat=44.594685&lon=-92.420983
 CREE_Pie http://www.openstreetmap.org/?lat=44.585516&lon=-92.450724
 CRC_Pie http://www.openstreetmap.org/?lat=44.594257&lon=-92.497244
-CRVV http://www.openstreetmap.org/?lat=44.604952&lon=-92.538099
 US63 http://www.openstreetmap.org/?lat=44.601255&lon=-92.527928
+CRVV http://www.openstreetmap.org/?lat=44.604952&lon=-92.538099
 CRO_Pie http://www.openstreetmap.org/?lat=44.627313&lon=-92.582645
 +X11 http://www.openstreetmap.org/?lat=44.653391&lon=-92.635088
 +X12 http://www.openstreetmap.org/?lat=44.672559&lon=-92.646675


### PR DESCRIPTION
Two points in the just-updated WI 35 file were switched. I switched them back. CHM Waypoints editor indicates that removes the Datacheck
errors.