### PR TITLE
Minor CA and NJ US route changes

### DIFF
--- a/hwy_data/NJ/usaus/nj.us009.wpt
+++ b/hwy_data/NJ/usaus/nj.us009.wpt
@@ -1,4 +1,4 @@
-DE/NJ http://www.openstreetmap.org/?lat=38.968587&lon=-74.959652
+CapeMayFry +DE/NJ http://www.openstreetmap.org/?lat=38.968587&lon=-74.959652
 LinBlvd http://www.openstreetmap.org/?lat=38.973623&lon=-74.957126
 BayRd http://www.openstreetmap.org/?lat=38.973208&lon=-74.942333
 SeaRd http://www.openstreetmap.org/?lat=38.968750&lon=-74.921313

--- a/hwy_data/_systems/usaus.csv
+++ b/hwy_data/_systems/usaus.csv
@@ -749,7 +749,7 @@ usaus;OK;US385;;;;ok.us385;
 usaus;CO;US385;;;;co.us385;
 usaus;NE;US385;;;;ne.us385;
 usaus;SD;US385;;;;sd.us385;
-usaus;CA;US395;;;;ca.us395;
+usaus;CA;US395;;;Bishop, CA;ca.us395;
 usaus;NV;US395;;;;nv.us395;
 usaus;CA;US395;;Sus;Susanville, CA;ca.us395sus;US395Alt,US395_N
 usaus;OR;US395;;;;or.us395;


### PR DESCRIPTION
-- usaus .csv file edited to add Bishop, CA as city name for southern US 395 segment (northern segment city name is Susanville, CA, so there is a
city name for both segments); no filename change, so connecting routes csv file is unchanged

-- primary label for NJ US 9 south end changed from DE/NJ to CapeMayFry (matching label for DE US9 north end); old label hidden

No Updates entries needed.