### PR TITLE
WV: Label corrections

### DIFF
--- a/hwy_data/WV/usaus/wv.us048.wpt
+++ b/hwy_data/WV/usaus/wv.us048.wpt
@@ -1,4 +1,4 @@
-Gra/Tuc http://www.openstreetmap.org/?lat=39.195453&lon=-79.292327
+Tuc/Gra http://www.openstreetmap.org/?lat=39.195453&lon=-79.292327
 WV93_E http://www.openstreetmap.org/?lat=39.209196&lon=-79.273696
 +X018(US48) http://www.openstreetmap.org/?lat=39.212272&lon=-79.268621
 WV93 http://www.openstreetmap.org/?lat=39.213714&lon=-79.248692

--- a/hwy_data/WV/usawv/wv.wv093.wpt
+++ b/hwy_data/WV/usawv/wv.wv093.wpt
@@ -4,7 +4,7 @@ WV32 http://www.openstreetmap.org/?lat=39.134350&lon=-79.476009
 AFraRd http://www.openstreetmap.org/?lat=39.185172&lon=-79.368217
 +X002(WV93) http://www.openstreetmap.org/?lat=39.200334&lon=-79.322705
 CR90/1 http://www.openstreetmap.org/?lat=39.195296&lon=-79.295589
-US48_Tuc http://www.openstreetmap.org/?lat=39.195453&lon=-79.292327
+US48_Gra http://www.openstreetmap.org/?lat=39.195453&lon=-79.292327
 US48_E http://www.openstreetmap.org/?lat=39.209196&lon=-79.273696
 +X003(WV93) http://www.openstreetmap.org/?lat=39.208153&lon=-79.253059
 US48 http://www.openstreetmap.org/?lat=39.213714&lon=-79.248692


### PR DESCRIPTION
@ovoss brought up that I accidentally flipped the county label on US-48's file in #85.  Here's a very quick fix for it.  Also tweaked WV-93's file to match.