### PR TITLE
Datacheck error fixes for IL 97, MO 5

### DIFF
--- a/hwy_data/IL/usail/il.il097.wpt
+++ b/hwy_data/IL/usail/il.il097.wpt
@@ -1,5 +1,5 @@
 I-55BL http://www.openstreetmap.org/?lat=39.803294&lon=-89.643159
-WalSt+ IL29_N http://www.openstreetmap.org/?lat=39.804184&lon=-89.663501
+WalSt_Spr +IL29_N http://www.openstreetmap.org/?lat=39.804184&lon=-89.663501
 IL4 http://www.openstreetmap.org/?lat=39.815887&lon=-89.700880
 IL125 http://www.openstreetmap.org/?lat=39.837772&lon=-89.789543
 +X01 http://www.openstreetmap.org/?lat=39.885405&lon=-89.790273
@@ -17,7 +17,7 @@ IL123_E http://www.openstreetmap.org/?lat=40.012989&lon=-89.848423
 CR12 http://www.openstreetmap.org/?lat=40.102531&lon=-89.962964
 +X09 http://www.openstreetmap.org/?lat=40.109621&lon=-89.964724
 +X10 http://www.openstreetmap.org/?lat=40.144600&lon=-90.005064
-WalSt http://www.openstreetmap.org/?lat=40.152276&lon=-90.005150
+WalSt_Kil http://www.openstreetmap.org/?lat=40.152276&lon=-90.005150
 CR1200 http://www.openstreetmap.org/?lat=40.231938&lon=-90.008841
 +X11 http://www.openstreetmap.org/?lat=40.237900&lon=-90.008755
 US136_E http://www.openstreetmap.org/?lat=40.294224&lon=-90.056348

--- a/hwy_data/MO/usamo/mo.mo005.wpt
+++ b/hwy_data/MO/usamo/mo.mo005.wpt
@@ -114,13 +114,13 @@ MO240_E http://www.openstreetmap.org/?lat=39.152943&lon=-92.691607
 +X34 http://www.openstreetmap.org/?lat=39.200450&lon=-92.724609
 MO3 http://www.openstreetmap.org/?lat=39.215015&lon=-92.728772
 +X35 http://www.openstreetmap.org/?lat=39.230159&lon=-92.749844
-MO240Bus http://www.openstreetmap.org/?lat=39.232768&lon=-92.791858
 MO240Bus_E http://www.openstreetmap.org/?lat=39.233233&lon=-92.772375
+MO240Bus http://www.openstreetmap.org/?lat=39.232768&lon=-92.791858
 +X36 http://www.openstreetmap.org/?lat=39.222180&lon=-92.808037
 MO87_S http://www.openstreetmap.org/?lat=39.216777&lon=-92.840567
 MO240_W http://www.openstreetmap.org/?lat=39.222031&lon=-92.846875
 1stSt_N http://www.openstreetmap.org/?lat=39.227412&lon=-92.846843
-MO240Bus_E http://www.openstreetmap.org/?lat=39.227209&lon=-92.844751
+MO240Bus_W http://www.openstreetmap.org/?lat=39.227209&lon=-92.844751
 MOsV_Cha http://www.openstreetmap.org/?lat=39.251315&lon=-92.842927
 MOsKK_Cha http://www.openstreetmap.org/?lat=39.257429&lon=-92.853270
 +X37 http://www.openstreetmap.org/?lat=39.304915&lon=-92.836533


### PR DESCRIPTION
Fixes for duplicate label and sharp angle Datacheck errors in MO 5 (one of Jeff's updates earlier this weekend) and IL 97 (unchanged from CHM). 

MO 5 changes:: switched two out-of-order waypoints, renamed MO240Bus_E to MO240Bus_W. 

IL 97 changes:: renamed WalSt+ and WalSt to, respectively, WalSt_Spr and WalSt_Kil

None of renamed point labels are in use. No Updates items required.