### PR TITLE
Wahoo bypass

### DIFF
--- a/hwy_data/NE/usane/ne.ne092.wpt
+++ b/hwy_data/NE/usane/ne.ne092.wpt
@@ -162,10 +162,7 @@ NE79_N http://www.openstreetmap.org/?lat=41.206015&lon=-96.813084
 S78D http://www.openstreetmap.org/?lat=41.205054&lon=-96.745852
 S78E http://www.openstreetmap.org/?lat=41.205434&lon=-96.717077
 US77_S http://www.openstreetmap.org/?lat=41.206560&lon=-96.636155
-1stSt_E http://www.openstreetmap.org/?lat=41.206176&lon=-96.622674
-CheSt_N http://www.openstreetmap.org/?lat=41.216491&lon=-96.621934
-CRL http://www.openstreetmap.org/?lat=41.217050&lon=-96.611541
-CR16 http://www.openstreetmap.org/?lat=41.229743&lon=-96.602627
+17thAve http://www.openstreetmap.org/?lat=41.231896&lon=-96.631102
 NE109 http://www.openstreetmap.org/?lat=41.234615&lon=-96.602783
 US77_N http://www.openstreetmap.org/?lat=41.234163&lon=-96.502887
 ElmSt http://www.openstreetmap.org/?lat=41.234095&lon=-96.490484

--- a/hwy_data/NE/usaus/ne.us077.wpt
+++ b/hwy_data/NE/usaus/ne.us077.wpt
@@ -45,10 +45,7 @@ CRF http://www.openstreetmap.org/?lat=41.133082&lon=-96.630480
 NE66 http://www.openstreetmap.org/?lat=41.147622&lon=-96.630834
 CRH_Sau http://www.openstreetmap.org/?lat=41.162255&lon=-96.631199
 NE92_W http://www.openstreetmap.org/?lat=41.206560&lon=-96.636155
-1stSt_E http://www.openstreetmap.org/?lat=41.206176&lon=-96.622674
-CheSt_N http://www.openstreetmap.org/?lat=41.216491&lon=-96.621934
-CRL http://www.openstreetmap.org/?lat=41.217050&lon=-96.611541
-CR16 http://www.openstreetmap.org/?lat=41.229743&lon=-96.602627
+17thAve http://www.openstreetmap.org/?lat=41.231896&lon=-96.631102
 NE109_S http://www.openstreetmap.org/?lat=41.234615&lon=-96.602783
 NE92_E http://www.openstreetmap.org/?lat=41.234163&lon=-96.502887
 NE64 http://www.openstreetmap.org/?lat=41.306835&lon=-96.502683


### PR DESCRIPTION
15-09-28;(USA) Nebraska;US 77;ne.us077;Removed from 1st St, Chestnut St, 12th St, and CR 16 and relocated onto the northwestern Wahoo bypass, between NE 92 West and NE 109 South.
15-09-28;(USA) Nebraska;NE 92;ne.ne092;Removed from 1st St, Chestnut St, 12th St, and CR 16 and relocated onto the northwestern Wahoo bypass, between US 77 South and NE 109.