### PR TITLE
SC: US-521 reroute in Sumter, SC.

### DIFF
--- a/hwy_data/SC/usaus/sc.us015.wpt
+++ b/hwy_data/SC/usaus/sc.us015.wpt
@@ -31,10 +31,10 @@ IngRd http://www.openstreetmap.org/?lat=33.713355&lon=-80.349046
 SC261 http://www.openstreetmap.org/?lat=33.738574&lon=-80.357241
 OldStoRd http://www.openstreetmap.org/?lat=33.786602&lon=-80.354884
 SouDr http://www.openstreetmap.org/?lat=33.835393&lon=-80.372902
-US15/521Con http://www.openstreetmap.org/?lat=33.880976&lon=-80.351087
-US521_S http://www.openstreetmap.org/?lat=33.895733&lon=-80.338641
+US521 http://www.openstreetmap.org/?lat=33.884124&lon=-80.348881
+ManAve +US521_S http://www.openstreetmap.org/?lat=33.895733&lon=-80.338641
 US76Bus http://www.openstreetmap.org/?lat=33.920233&lon=-80.335913
-US401/521_N http://www.openstreetmap.org/?lat=33.924158&lon=-80.336344
+US401 +US401/521_N http://www.openstreetmap.org/?lat=33.924158&lon=-80.336344
 US76/378 http://www.openstreetmap.org/?lat=33.945782&lon=-80.342587
 BreRd http://www.openstreetmap.org/?lat=33.982569&lon=-80.328997
 S-31-9 http://www.openstreetmap.org/?lat=34.078306&lon=-80.317069

--- a/hwy_data/SC/usaus/sc.us401.wpt
+++ b/hwy_data/SC/usaus/sc.us401.wpt
@@ -1,4 +1,4 @@
-US521/76Bus http://www.openstreetmap.org/?lat=33.924480&lon=-80.344325
+US76Bus +US521/76Bus http://www.openstreetmap.org/?lat=33.924480&lon=-80.344325
 US15 http://www.openstreetmap.org/?lat=33.924158&lon=-80.336344
 CalStExt http://www.openstreetmap.org/?lat=33.925091&lon=-80.328774
 US76/378 http://www.openstreetmap.org/?lat=33.937100&lon=-80.319556

--- a/hwy_data/SC/usaus/sc.us521.wpt
+++ b/hwy_data/SC/usaus/sc.us521.wpt
@@ -27,13 +27,10 @@ I-95(122) http://www.openstreetmap.org/?lat=33.739874&lon=-80.208660
 US301/521Con http://www.openstreetmap.org/?lat=33.752024&lon=-80.221811
 12BriRd http://www.openstreetmap.org/?lat=33.811753&lon=-80.280061
 +X002(US521) http://www.openstreetmap.org/?lat=33.866640&lon=-80.316886
-SGuiPkwy http://www.openstreetmap.org/?lat=33.877907&lon=-80.335846
-US15_S http://www.openstreetmap.org/?lat=33.895733&lon=-80.338641
-US76Bus http://www.openstreetmap.org/?lat=33.920233&lon=-80.335913
-US15/401_N http://www.openstreetmap.org/?lat=33.924158&lon=-80.336344
-US401/76Bus_E http://www.openstreetmap.org/?lat=33.924480&lon=-80.344325
-MoiDr http://www.openstreetmap.org/?lat=33.927331&lon=-80.344308
-US15/521Con http://www.openstreetmap.org/?lat=33.945202&lon=-80.372460
+ManRd +SGuiPkwy http://www.openstreetmap.org/?lat=33.877938&lon=-80.335894
+US15 http://www.openstreetmap.org/?lat=33.884124&lon=-80.348881
+SC763 http://www.openstreetmap.org/?lat=33.919975&lon=-80.359755
+US76Bus_E +US15/521Con http://www.openstreetmap.org/?lat=33.945202&lon=-80.372460
 US76Bus_W http://www.openstreetmap.org/?lat=33.954970&lon=-80.379865
 US76/378 http://www.openstreetmap.org/?lat=33.957253&lon=-80.379771
 JefRd http://www.openstreetmap.org/?lat=33.958712&lon=-80.379786

--- a/hwy_data/SC/usausb/sc.us076bussum.wpt
+++ b/hwy_data/SC/usausb/sc.us076bussum.wpt
@@ -1,9 +1,9 @@
 US76_W http://www.openstreetmap.org/?lat=33.956583&lon=-80.384403
 US521_N http://www.openstreetmap.org/?lat=33.954970&lon=-80.379865
-US15/521Con http://www.openstreetmap.org/?lat=33.945202&lon=-80.372460
+US521_S +US15/521Con http://www.openstreetmap.org/?lat=33.945202&lon=-80.372460
 MoiDr http://www.openstreetmap.org/?lat=33.927331&lon=-80.344308
-US401/521_S http://www.openstreetmap.org/?lat=33.924480&lon=-80.344325
+US401 +US401/521_S http://www.openstreetmap.org/?lat=33.924480&lon=-80.344325
 SC763_W http://www.openstreetmap.org/?lat=33.920606&lon=-80.344645
-US15/521 http://www.openstreetmap.org/?lat=33.920233&lon=-80.335913
+US15 +US15/521 http://www.openstreetmap.org/?lat=33.920233&lon=-80.335913
 SC763_E http://www.openstreetmap.org/?lat=33.920737&lon=-80.326709
 US76_E http://www.openstreetmap.org/?lat=33.928616&lon=-80.307079


### PR DESCRIPTION
http://clinched.s2.bizhat.com/viewtopic.php?t=2322&mforum=clinched

Only route that needs a mention in the change log is US-521.

15-09-29;(USA) South Carolina;US 521;sc.us521;Removed from Broad Street (US 76 Business), Calhoun Street (US 401), Lafayette Drive (US 15), & Manning Road in Sumter SC, and relocated to the southwest onto Bultman Drive, Guignard Drive, & Guignard Parkway, between the intersections of Broad Street/Bultman Drive & Manning Road/Guignard Parkway.