### PR TITLE
PA: PA-35 tweaks in Mifflin/Mifflintown.

### DIFF
--- a/hwy_data/PA/usapa/pa.pa035.wpt
+++ b/hwy_data/PA/usapa/pa.pa035.wpt
@@ -6,9 +6,10 @@ PA850 http://www.openstreetmap.org/?lat=40.436267&lon=-77.610083
 McKRunRd http://www.openstreetmap.org/?lat=40.464385&lon=-77.585320
 GroValRd http://www.openstreetmap.org/?lat=40.506915&lon=-77.527943
 PA333_E http://www.openstreetmap.org/?lat=40.560512&lon=-77.410612
-PA333_W http://www.openstreetmap.org/?lat=40.566197&lon=-77.404733
-JunSt http://www.openstreetmap.org/?lat=40.566177&lon=-77.402523
-MainSt_S http://www.openstreetmap.org/?lat=40.566014&lon=-77.396429
+PA333_W http://www.openstreetmap.org/?lat=40.566311&lon=-77.404744
+ParSt http://www.openstreetmap.org/?lat=40.566293&lon=-77.403370
+*JunSt http://www.openstreetmap.org/?lat=40.566275&lon=-77.402512
+MainSt_S http://www.openstreetmap.org/?lat=40.564751&lon=-77.396086
 MainSt_N http://www.openstreetmap.org/?lat=40.570036&lon=-77.396944
 US22/322 http://www.openstreetmap.org/?lat=40.580658&lon=-77.372375
 PA235_S http://www.openstreetmap.org/?lat=40.636517&lon=-77.274764

--- a/hwy_data/PA/usapa/pa.pa333.wpt
+++ b/hwy_data/PA/usapa/pa.pa333.wpt
@@ -7,7 +7,7 @@ RisRd http://www.openstreetmap.org/?lat=40.580519&lon=-77.531977
 +X6 http://www.openstreetmap.org/?lat=40.599775&lon=-77.446747
 +X7 http://www.openstreetmap.org/?lat=40.604044&lon=-77.440159
 +X8 http://www.openstreetmap.org/?lat=40.587408&lon=-77.413316
-PA35_N http://www.openstreetmap.org/?lat=40.566197&lon=-77.404733
+PA35_N http://www.openstreetmap.org/?lat=40.566311&lon=-77.404744
 PA35_S http://www.openstreetmap.org/?lat=40.560512&lon=-77.410612
 LicSt http://www.openstreetmap.org/?lat=40.546809&lon=-77.416534
 PA75_N http://www.openstreetmap.org/?lat=40.528785&lon=-77.392180


### PR DESCRIPTION
http://clinched.s2.bizhat.com/viewtopic.php?t=2278&mforum=clinched

Just finally updating locations for the new PA-35 bridge reroute that was done in Mifflin/Mifflintown.  Tim had already put in a ruff alignment for this reroute.  These changes finally put the route on it's true alignment since OSM (I made the fixes awhile back) was updated to show the proper new alignment.

So, no mentions needed for the update page.