### PR TITLE
LA US371

### DIFF
--- a/hwy_data/LA/usaus/la.us084.wpt
+++ b/hwy_data/LA/usaus/la.us084.wpt
@@ -19,8 +19,8 @@ I-49 http://www.openstreetmap.org/?lat=32.063265&lon=-93.562167
 LA510 http://www.openstreetmap.org/?lat=32.065374&lon=-93.550429
 LA1_N http://www.openstreetmap.org/?lat=32.086901&lon=-93.473353
 BloRd http://www.openstreetmap.org/?lat=32.066065&lon=-93.430588
-US371/177 http://www.openstreetmap.org/?lat=32.039731&lon=-93.406706
-LA1_S http://www.openstreetmap.org/?lat=32.005456&lon=-93.380785
+LA177 +US371/177 http://www.openstreetmap.org/?lat=32.039731&lon=-93.406706
+US84/1 +LA1_S http://www.openstreetmap.org/?lat=32.005456&lon=-93.380785
 US371_N http://www.openstreetmap.org/?lat=32.014553&lon=-93.346410
 LA480_N http://www.openstreetmap.org/?lat=32.014699&lon=-93.342183
 LA480_S http://www.openstreetmap.org/?lat=32.014899&lon=-93.340938

--- a/hwy_data/LA/usaus/la.us371.wpt
+++ b/hwy_data/LA/usaus/la.us371.wpt
@@ -1,7 +1,8 @@
 I-49 http://www.openstreetmap.org/?lat=31.963122&lon=-93.450179
 LA510 http://www.openstreetmap.org/?lat=31.987986&lon=-93.442841
-US84/177 http://www.openstreetmap.org/?lat=32.039731&lon=-93.406706
-LA1_S http://www.openstreetmap.org/?lat=32.005456&lon=-93.380785
+LA177_N http://www.openstreetmap.org/?lat=32.001744&lon=-93.437262
++X669700 http://www.openstreetmap.org/?lat=32.010332&lon=-93.402414
+US84/1 +LA1_S http://www.openstreetmap.org/?lat=32.005456&lon=-93.380785
 US84_E http://www.openstreetmap.org/?lat=32.014553&lon=-93.346410
 LA480 http://www.openstreetmap.org/?lat=32.018192&lon=-93.344479
 US71_S http://www.openstreetmap.org/?lat=32.024378&lon=-93.339930


### PR DESCRIPTION
15-10-10;(USA) Louisiana;US 371;la.us371;Removed from LA 177 and US84 and relocated onto a new two-lane east-west roadway between the LA 177 north split and the US 84 / LA 1 junction.

-----

I lined WPTedit up to the NAIP imagery and did a little Alt+Tabbing to aid in waypoint placement.