### PR TITLE
ND200: deleted 23rdSt; added 24thSt & 130thAve

### DIFF
--- a/hwy_data/ND/usand/nd.nd200.wpt
+++ b/hwy_data/ND/usand/nd.nd200.wpt
@@ -11,10 +11,11 @@ US85BusAle_S http://www.openstreetmap.org/?lat=47.823831&lon=-103.649268
 ND68 http://www.openstreetmap.org/?lat=47.806453&lon=-103.645610
 136thAve http://www.openstreetmap.org/?lat=47.804890&lon=-103.497756
 MainSt_Arn http://www.openstreetmap.org/?lat=47.804652&lon=-103.441815
+130thAve http://www.openstreetmap.org/?lat=47.804764&lon=-103.369042
 US85BusWat http://www.openstreetmap.org/?lat=47.801633&lon=-103.356414
 +X681921 http://www.openstreetmap.org/?lat=47.769305&lon=-103.342193
 US85Bus/23 http://www.openstreetmap.org/?lat=47.764026&lon=-103.292406
-23rdSt http://www.openstreetmap.org/?lat=47.746805&lon=-103.283157
+24thSt http://www.openstreetmap.org/?lat=47.754351&lon=-103.283178
 19thSt http://www.openstreetmap.org/?lat=47.695606&lon=-103.283211
 14thSt http://www.openstreetmap.org/?lat=47.619106&lon=-103.269521
 SceDr http://www.openstreetmap.org/?lat=47.599775&lon=-103.255187


### PR DESCRIPTION
Edits omitted from #133 as pointed out by @the-spui-ninja in #127.
Fixes the broken US85 concurrency.