### PR TITLE
Extension of QC A-73 (St-Georges)

### DIFF
--- a/hwy_data/QC/canqca/qc.a073stg.wpt
+++ b/hwy_data/QC/canqca/qc.a073stg.wpt
@@ -1,3 +1,4 @@
 QC204 http://www.openstreetmap.org/?lat=46.134441&lon=-70.643967
 +X564199 http://www.openstreetmap.org/?lat=46.157941&lon=-70.652561
 48 http://www.openstreetmap.org/?lat=46.167587&lon=-70.679287
+RtePetPie http://www.openstreetmap.org/?lat=46.204584&lon=-70.710073


### PR DESCRIPTION
5 km northward extension of A-73's St-Georges segment just opened. Exit number of new interchange with Route Petite-Pierrette not yet known.

There is still a gap in A-73, planned completion in autumn 2016.

Updates item:

2015-11-11;(Canada) Quebec;A-73 (St-Georges);qc.a073stg;Extended north about 5 km to Notre-Dame-des-Pins