### PR TITLE
QC A-20 extension

### DIFF
--- a/hwy_data/QC/canqca/qc.a020.wpt
+++ b/hwy_data/QC/canqca/qc.a020.wpt
@@ -152,3 +152,6 @@ IleCla http://www.openstreetmap.org/?lat=45.400348&lon=-73.958266
 514 http://www.openstreetmap.org/?lat=47.903627&lon=-69.481230
 521 +QC132 http://www.openstreetmap.org/?lat=47.952570&lon=-69.434838
 527 http://www.openstreetmap.org/?lat=47.994000&lon=-69.371324
+531 http://www.openstreetmap.org/?lat=48.006244&lon=-69.318066
+539 http://www.openstreetmap.org/?lat=48.060145&lon=-69.257560
+543 http://www.openstreetmap.org/?lat=48.081864&lon=-69.225615


### PR DESCRIPTION
Route extended east from old east end at exit 527, to new exit 543 (Route Drapeau) in Notre-Dame-des-Nieges.

Update entry:

2015-11-12;(Canada) Quebec;A-20;qc.a020;Route extended east to new exit 543 (Route Drapeau) in Notre-Dame-des-Nieges