### PR TITLE
Fall River part 2

### DIFF
--- a/hwy_data/MA/usama/ma.ma079.wpt
+++ b/hwy_data/MA/usama/ma.ma079.wpt
@@ -1,6 +1,7 @@
 I-195 http://www.openstreetmap.org/?lat=41.703486&lon=-71.160207
+US6_E http://www.openstreetmap.org/?lat=41.716549&lon=-71.154992
 *BriSt http://www.openstreetmap.org/?lat=41.722339&lon=-71.152567
-US6 http://www.openstreetmap.org/?lat=41.725546&lon=-71.149473
+US6_W +US6 http://www.openstreetmap.org/?lat=41.725546&lon=-71.149473
 MainSt http://www.openstreetmap.org/?lat=41.729267&lon=-71.138062
 MA24(7) http://www.openstreetmap.org/?lat=41.746093&lon=-71.121948
 MA24(8A) +MA24(8) http://www.openstreetmap.org/?lat=41.753954&lon=-71.117699

--- a/hwy_data/MA/usaus/ma.us006.wpt
+++ b/hwy_data/MA/usaus/ma.us006.wpt
@@ -9,7 +9,7 @@ LeesRivAve http://www.openstreetmap.org/?lat=41.737952&lon=-71.182480
 MA103/138 http://www.openstreetmap.org/?lat=41.727812&lon=-71.156012
 MA79 http://www.openstreetmap.org/?lat=41.725546&lon=-71.149473
 BriSt http://www.openstreetmap.org/?lat=41.722339&lon=-71.152568
-MA138_S http://www.openstreetmap.org/?lat=41.716549&lon=-71.154993
+MA79/138 +MA138_S http://www.openstreetmap.org/?lat=41.716549&lon=-71.154993
 MainSt_Fal http://www.openstreetmap.org/?lat=41.715902&lon=-71.151026
 RobSt http://www.openstreetmap.org/?lat=41.714090&lon=-71.140895
 MA24 http://www.openstreetmap.org/?lat=41.711399&lon=-71.123986


### PR DESCRIPTION
Following up on #204. Nothing newsworthy.

The MA79/138 concurrency was still broken between I-195 & US6_E.
Added MA MA79 US6_E:
* To fix the broken concurrency.
* Because it was really needed anyway, #BecauseTexas.

Deprecated existing US6 label in favor of US6_W.

On US6, MA138_S +-> MA79/138.