### PR TITLE
Hi 380 relocation retry

### DIFF
--- a/hwy_data/HI/usahi/hi.hi036.wpt
+++ b/hwy_data/HI/usahi/hi.hi036.wpt
@@ -2,13 +2,13 @@ HI32 http://www.openstreetmap.org/?lat=20.892666&lon=-156.463899
 HI32A http://www.openstreetmap.org/?lat=20.891143&lon=-156.461413
 HI36A http://www.openstreetmap.org/?lat=20.888361&lon=-156.457371
 HI380 http://www.openstreetmap.org/?lat=20.885514&lon=-156.452862
-AirAccRd http://www.openstreetmap.org/?lat=20.883313&lon=-156.449083
+KAirAccRd http://www.openstreetmap.org/?lat=20.883313&lon=-156.449083
 HooSt http://www.openstreetmap.org/?lat=20.881458&lon=-156.445227
 HanRd http://www.openstreetmap.org/?lat=20.879806&lon=-156.431386
 HI37 http://www.openstreetmap.org/?lat=20.885986&lon=-156.426316
 SprRd http://www.openstreetmap.org/?lat=20.903596&lon=-156.415097
 BalAve http://www.openstreetmap.org/?lat=20.916099&lon=-156.381239
-HooBeaPark http://www.openstreetmap.org/?lat=20.934323&lon=-156.354634
+HooBeaPark http://www.openstreetmap.org/?lat=20.934363&lon=-156.354607
 HaiRd_W http://www.openstreetmap.org/?lat=20.933005&lon=-156.331731
 WestKuiRd http://www.openstreetmap.org/?lat=20.930254&lon=-156.309713
 HaiRd_E http://www.openstreetmap.org/?lat=20.920153&lon=-156.299762

--- a/hwy_data/HI/usahi/hi.hi036.wpt
+++ b/hwy_data/HI/usahi/hi.hi036.wpt
@@ -2,6 +2,7 @@ HI32 http://www.openstreetmap.org/?lat=20.892666&lon=-156.463899
 HI32A http://www.openstreetmap.org/?lat=20.891143&lon=-156.461413
 HI36A http://www.openstreetmap.org/?lat=20.888361&lon=-156.457371
 HI380 http://www.openstreetmap.org/?lat=20.885514&lon=-156.452862
+AirAccRd http://www.openstreetmap.org/?lat=20.883313&lon=-156.449083
 HooSt http://www.openstreetmap.org/?lat=20.881458&lon=-156.445227
 HanRd http://www.openstreetmap.org/?lat=20.879806&lon=-156.431386
 HI37 http://www.openstreetmap.org/?lat=20.885986&lon=-156.426316

--- a/hwy_data/HI/usahi/hi.hi380.wpt
+++ b/hwy_data/HI/usahi/hi.hi380.wpt
@@ -1,5 +1,8 @@
 HI36A http://www.openstreetmap.org/?lat=20.887835&lon=-156.451695
 HI36 http://www.openstreetmap.org/?lat=20.885514&lon=-156.452862
+*DaiRd http://www.openstreetmap.org/?lat=20.878912&lon=-156.457790
+PakSt http://www.openstreetmap.org/?lat=20.878386&lon=-156.457420
+AirAccRd http://www.openstreetmap.org/?lat=20.878055&lon=-156.458643
 HI311/3500 http://www.openstreetmap.org/?lat=20.876292&lon=-156.460447
 WaiRd http://www.openstreetmap.org/?lat=20.848762&lon=-156.484850
 HI30 http://www.openstreetmap.org/?lat=20.816765&lon=-156.506925

--- a/hwy_data/HI/usahi/hi.hi380.wpt
+++ b/hwy_data/HI/usahi/hi.hi380.wpt
@@ -1,7 +1,7 @@
 HI36A http://www.openstreetmap.org/?lat=20.887835&lon=-156.451695
 HI36 http://www.openstreetmap.org/?lat=20.885514&lon=-156.452862
-*DaiRd http://www.openstreetmap.org/?lat=20.878912&lon=-156.457790
-PakSt http://www.openstreetmap.org/?lat=20.878386&lon=-156.457420
+PakSt_N http://www.openstreetmap.org/?lat=20.878912&lon=-156.457790
+PakSt_S http://www.openstreetmap.org/?lat=20.878386&lon=-156.457420
 AirAccRd http://www.openstreetmap.org/?lat=20.878055&lon=-156.458643
 HI311/3500 http://www.openstreetmap.org/?lat=20.876292&lon=-156.460447
 WaiRd http://www.openstreetmap.org/?lat=20.848762&lon=-156.484850


### PR DESCRIPTION
Short part of HI 380 closed and relocated to tie route into new Airport Access Rd. (route signage unknown). Waypoint for access road added to HI 36 route file.

Update entry (needed only for HI 380):

2015-11-17;(USA) Hawaii;HI 380;hi.hi380;Route relocated from closed Dairy Rd. segment between waypoints AirAccRd and PakSt_N, onto parts of Airport Access Rd. and Pakaula St.