### PR TITLE
Watertown & other NY issues

### DIFF
--- a/hwy_data/NY/usai/ny.i790.wpt
+++ b/hwy_data/NY/usai/ny.i790.wpt
@@ -1,4 +1,3 @@
-LelAve http://www.openstreetmap.org/?lat=43.112701&lon=-75.207338
-GenSt http://www.openstreetmap.org/?lat=43.114831&lon=-75.212402
-NY8/12 http://www.openstreetmap.org/?lat=43.122005&lon=-75.230727
 NY5A/5S http://www.openstreetmap.org/?lat=43.105965&lon=-75.238967
+NY8/12 http://www.openstreetmap.org/?lat=43.122005&lon=-75.230727
+GenSt +LelAve http://www.openstreetmap.org/?lat=43.114831&lon=-75.212402

--- a/hwy_data/NY/usany/ny.ny003.wpt
+++ b/hwy_data/NY/usany/ny.ny003.wpt
@@ -38,7 +38,9 @@ SmiRd http://www.openstreetmap.org/?lat=43.926985&lon=-76.107960
 DodAve http://www.openstreetmap.org/?lat=43.953220&lon=-76.081738
 NY180 http://www.openstreetmap.org/?lat=43.957175&lon=-76.057556
 I-81 http://www.openstreetmap.org/?lat=43.975738&lon=-75.948486
-US11 http://www.openstreetmap.org/?lat=43.974905&lon=-75.910807
+US11_S http://www.openstreetmap.org/?lat=43.976503&lon=-75.916847
+WasSt  +US11 http://www.openstreetmap.org/?lat=43.974905&lon=-75.910807
+US11_N http://www.openstreetmap.org/?lat=43.974391&lon=-75.908194
 NY12_S http://www.openstreetmap.org/?lat=43.967384&lon=-75.881506
 WatSt http://www.openstreetmap.org/?lat=43.981730&lon=-75.868278
 NY342 http://www.openstreetmap.org/?lat=44.001629&lon=-75.811994

--- a/hwy_data/NY/usany/ny.ny012.wpt
+++ b/hwy_data/NY/usany/ny.ny012.wpt
@@ -1,4 +1,4 @@
-US11 http://www.openstreetmap.org/?lat=42.161877&lon=-75.893512
+US11_S +US11 http://www.openstreetmap.org/?lat=42.161877&lon=-75.893512
 NY12A http://www.openstreetmap.org/?lat=42.168302&lon=-75.887632
 BroRd http://www.openstreetmap.org/?lat=42.190436&lon=-75.881324
 KatRd http://www.openstreetmap.org/?lat=42.200070&lon=-75.859480
@@ -80,10 +80,9 @@ BroDr http://www.openstreetmap.org/?lat=43.933120&lon=-75.866261
 +X11 http://www.openstreetmap.org/?lat=43.945063&lon=-75.874972
 NY126 http://www.openstreetmap.org/?lat=43.965515&lon=-75.874929
 NY3_E http://www.openstreetmap.org/?lat=43.967384&lon=-75.881506
-NY3_W http://www.openstreetmap.org/?lat=43.974441&lon=-75.908189
-NY283 http://www.openstreetmap.org/?lat=43.975306&lon=-75.907888
-US11_A http://www.openstreetmap.org/?lat=43.979367&lon=-75.906558
-US11_N http://www.openstreetmap.org/?lat=43.981390&lon=-75.913854
+NY3_W +NY283 http://www.openstreetmap.org/?lat=43.974391&lon=-75.908194
+US11_N http://www.openstreetmap.org/?lat=43.981386&lon=-75.913800
+NY12E_S http://www.openstreetmap.org/?lat=43.983740&lon=-75.917212
 I-81(47) http://www.openstreetmap.org/?lat=44.001027&lon=-75.919690
 NY342 http://www.openstreetmap.org/?lat=44.029538&lon=-75.935419
 ParRd http://www.openstreetmap.org/?lat=44.061224&lon=-75.953250
@@ -91,7 +90,7 @@ NY180_S http://www.openstreetmap.org/?lat=44.097078&lon=-75.998054
 StLawRd http://www.openstreetmap.org/?lat=44.151174&lon=-76.078091
 BaldRockRd http://www.openstreetmap.org/?lat=44.186420&lon=-76.081738
 ClaSt http://www.openstreetmap.org/?lat=44.216724&lon=-76.069894
-NY12E http://www.openstreetmap.org/?lat=44.236160&lon=-76.084099
+NY12E_N  +NY12E http://www.openstreetmap.org/?lat=44.236160&lon=-76.084099
 +X12 http://www.openstreetmap.org/?lat=44.258294&lon=-76.012301
 NY180_N http://www.openstreetmap.org/?lat=44.272800&lon=-76.000285
 I-81(50) http://www.openstreetmap.org/?lat=44.293200&lon=-75.972390

--- a/hwy_data/NY/usany/ny.ny012e.wpt
+++ b/hwy_data/NY/usany/ny.ny012e.wpt
@@ -1,4 +1,4 @@
-NY12_S http://www.openstreetmap.org/?lat=43.983860&lon=-75.917287
+NY12_S http://www.openstreetmap.org/?lat=43.983740&lon=-75.917212
 TealRd http://www.openstreetmap.org/?lat=43.998001&lon=-75.933080
 BriSt http://www.openstreetmap.org/?lat=44.001798&lon=-75.981188
 +X02 http://www.openstreetmap.org/?lat=44.003033&lon=-76.004019

--- a/hwy_data/NY/usany/ny.ny012f.wpt
+++ b/hwy_data/NY/usany/ny.ny012f.wpt
@@ -2,4 +2,4 @@ NY180 http://www.openstreetmap.org/?lat=44.001397&lon=-76.045132
 WatIntAir http://www.openstreetmap.org/?lat=43.996909&lon=-76.023116
 BriSt http://www.openstreetmap.org/?lat=43.999483&lon=-75.982003
 I-81 http://www.openstreetmap.org/?lat=43.988770&lon=-75.944195
-US11 http://www.openstreetmap.org/?lat=43.978827&lon=-75.915270
+US11/12 +US11 http://www.openstreetmap.org/?lat=43.978727&lon=-75.915238

--- a/hwy_data/NY/usany/ny.ny026.wpt
+++ b/hwy_data/NY/usany/ny.ny026.wpt
@@ -51,11 +51,11 @@ NY5 http://www.openstreetmap.org/?lat=43.073198&lon=-75.502167
 LowRd http://www.openstreetmap.org/?lat=43.138875&lon=-75.500579
 DixRd http://www.openstreetmap.org/?lat=43.165768&lon=-75.480409
 NY365_W http://www.openstreetmap.org/?lat=43.188176&lon=-75.487618
-NY365_E http://www.openstreetmap.org/?lat=43.188771&lon=-75.481009
+SJamSt http://www.openstreetmap.org/?lat=43.188771&lon=-75.481009
 NY49/69 http://www.openstreetmap.org/?lat=43.191200&lon=-75.450411
-NY46/69 http://www.openstreetmap.org/?lat=43.208961&lon=-75.457363
+NY46/49 +NY46/69 http://www.openstreetmap.org/?lat=43.208961&lon=-75.457363
 NY46_N http://www.openstreetmap.org/?lat=43.215623&lon=-75.449896
-BloSt http://www.openstreetmap.org/?lat=43.216696&lon=-75.452063
+NJamSt http://www.openstreetmap.org/?lat=43.216696&lon=-75.452063
 TufRd http://www.openstreetmap.org/?lat=43.391846&lon=-75.488820
 NY294 http://www.openstreetmap.org/?lat=43.461369&lon=-75.462084
 CroRd http://www.openstreetmap.org/?lat=43.527755&lon=-75.467577

--- a/hwy_data/NY/usany/ny.ny049.wpt
+++ b/hwy_data/NY/usany/ny.ny049.wpt
@@ -16,7 +16,7 @@ LauRd http://www.openstreetmap.org/?lat=43.226119&lon=-75.595937
 NY46_W http://www.openstreetmap.org/?lat=43.210458&lon=-75.589027
 NY69_W http://www.openstreetmap.org/?lat=43.229428&lon=-75.493670
 NY26/46 http://www.openstreetmap.org/?lat=43.208961&lon=-75.457363
-NY365_W http://www.openstreetmap.org/?lat=43.191200&lon=-75.450411
+NY26/365 +NY365_W http://www.openstreetmap.org/?lat=43.191200&lon=-75.450411
 NY69/233 http://www.openstreetmap.org/?lat=43.194033&lon=-75.437129
 NY365_E http://www.openstreetmap.org/?lat=43.203278&lon=-75.426679
 NY825 http://www.openstreetmap.org/?lat=43.203950&lon=-75.410607

--- a/hwy_data/NY/usany/ny.ny069.wpt
+++ b/hwy_data/NY/usany/ny.ny069.wpt
@@ -18,10 +18,10 @@ NY13_S http://www.openstreetmap.org/?lat=43.334356&lon=-75.747986
 NY13_N http://www.openstreetmap.org/?lat=43.335869&lon=-75.748158
 MorPostRd http://www.openstreetmap.org/?lat=43.336192&lon=-75.736442
 +X06 http://www.openstreetmap.org/?lat=43.312677&lon=-75.695672
-NY285 http://www.openstreetmap.org/?lat=43.308118&lon=-75.628123
-NY49_N http://www.openstreetmap.org/?lat=43.229428&lon=-75.493670
+TabRd http://www.openstreetmap.org/?lat=43.308118&lon=-75.628123
+NY46/49 http://www.openstreetmap.org/?lat=43.229428&lon=-75.493670
 NY26/46 http://www.openstreetmap.org/?lat=43.208961&lon=-75.457363
-NY365_W http://www.openstreetmap.org/?lat=43.191200&lon=-75.450411
+NY26/365 +NY365_W http://www.openstreetmap.org/?lat=43.191200&lon=-75.450411
 NY49/233 http://www.openstreetmap.org/?lat=43.194033&lon=-75.437129
 +X07 http://www.openstreetmap.org/?lat=43.185818&lon=-75.391188
 UtiSt http://www.openstreetmap.org/?lat=43.168867&lon=-75.346169

--- a/hwy_data/NY/usany/ny.ny283.wpt
+++ b/hwy_data/NY/usany/ny.ny283.wpt
@@ -1,4 +1,4 @@
-NY12 http://www.openstreetmap.org/?lat=43.975306&lon=-75.907888
+US11/12 +NY12 http://www.openstreetmap.org/?lat=43.975016&lon=-75.907952
 +X01 http://www.openstreetmap.org/?lat=43.998731&lon=-75.858793
 FiveCorRd http://www.openstreetmap.org/?lat=44.021561&lon=-75.825362
 NY342 http://www.openstreetmap.org/?lat=44.022703&lon=-75.814869

--- a/hwy_data/NY/usany/ny.ny365.wpt
+++ b/hwy_data/NY/usany/ny.ny365.wpt
@@ -3,9 +3,9 @@ NY365A http://www.openstreetmap.org/?lat=43.090536&lon=-75.630097
 I-90 http://www.openstreetmap.org/?lat=43.121304&lon=-75.592246
 NY31 http://www.openstreetmap.org/?lat=43.129980&lon=-75.578341
 BlaCorRd http://www.openstreetmap.org/?lat=43.162763&lon=-75.550275
-NY26_W http://www.openstreetmap.org/?lat=43.188176&lon=-75.487618
-NY26_E http://www.openstreetmap.org/?lat=43.188771&lon=-75.481009
-NY49/69 http://www.openstreetmap.org/?lat=43.191200&lon=-75.450411
+NY26_S +NY26_W http://www.openstreetmap.org/?lat=43.188176&lon=-75.487618
+JamSt +NY26_E http://www.openstreetmap.org/?lat=43.188771&lon=-75.481009
+NY26/46 +NY49/69 http://www.openstreetmap.org/?lat=43.191200&lon=-75.450411
 NY69/233 http://www.openstreetmap.org/?lat=43.194033&lon=-75.437129
 NY49_E http://www.openstreetmap.org/?lat=43.203278&lon=-75.426679
 ShaGroTr http://www.openstreetmap.org/?lat=43.204926&lon=-75.415521

--- a/hwy_data/NY/usaus/ny.us009.wpt
+++ b/hwy_data/NY/usaus/ny.us009.wpt
@@ -184,5 +184,4 @@ SheLn http://www.openstreetmap.org/?lat=44.866237&lon=-73.420472
 NY191 http://www.openstreetmap.org/?lat=44.894674&lon=-73.436866
 NY9B http://www.openstreetmap.org/?lat=44.932208&lon=-73.439183
 US11 http://www.openstreetmap.org/?lat=44.978308&lon=-73.446651
-I-87(43) http://www.openstreetmap.org/?lat=44.998098&lon=-73.455276
-End http://www.openstreetmap.org/?lat=45.004240&lon=-73.451736
+I-87(43) +End http://www.openstreetmap.org/?lat=44.999342&lon=-73.453715

--- a/hwy_data/NY/usaus/ny.us011.wpt
+++ b/hwy_data/NY/usaus/ny.us011.wpt
@@ -85,8 +85,10 @@ KelRd http://www.openstreetmap.org/?lat=43.884167&lon=-75.993118
 +X14 http://www.openstreetmap.org/?lat=43.914863&lon=-75.942564
 NY232 http://www.openstreetmap.org/?lat=43.931312&lon=-75.938787
 BroRd http://www.openstreetmap.org/?lat=43.944799&lon=-75.915785
-NY3 http://www.openstreetmap.org/?lat=43.974905&lon=-75.910807
-NY12_N http://www.openstreetmap.org/?lat=43.981390&lon=-75.913854
+WinSt http://www.openstreetmap.org/?lat=43.968453&lon=-75.912067
+NY3 http://www.openstreetmap.org/?lat=43.975536&lon=-75.913134
+NY12_N http://www.openstreetmap.org/?lat=43.980112&lon=-75.910383
+MillSt http://www.openstreetmap.org/?lat=43.993424&lon=-75.905061
 NY37_W http://www.openstreetmap.org/?lat=44.002663&lon=-75.899520
 SanRd http://www.openstreetmap.org/?lat=44.020437&lon=-75.851669
 NY342 http://www.openstreetmap.org/?lat=44.034141&lon=-75.843859


### PR DESCRIPTION
Addressing issues #7, #57, #67 & #145.

2015-11-19;(USA) New York;I-790;ny.i790;Truncated at east end from Leland Ave to Genesee St
2015-11-19;(USA) New York;US 9;ny.us009;Truncated at north end from a cul-de-sac/turnaround about 1/3 mile north of the I-87 Exit 43 interchange, to the I-87 Exit 43 interchange

Updates for issues #7 & #67 are all non-newsworthy.