### PR TITLE
NM US and I- BL routes updates

### DIFF
--- a/hwy_data/NM/usaib/nm.i040blgra.wpt
+++ b/hwy_data/NM/usaib/nm.i040blgra.wpt
@@ -1,7 +1,7 @@
 I-40_W http://www.openstreetmap.org/?lat=35.182350&lon=-107.901256
-NM122_W http://www.openstreetmap.org/?lat=35.183174&lon=-107.896729
-AspSt http://www.openstreetmap.org/?lat=35.164301&lon=-107.887373
+NM122_W http://www.openstreetmap.org/?lat=35.183187&lon=-107.896842
+AspSt http://www.openstreetmap.org/?lat=35.164288&lon=-107.887378
 NM53 http://www.openstreetmap.org/?lat=35.157460&lon=-107.871537
-5thSt http://www.openstreetmap.org/?lat=35.152618&lon=-107.853770
+NM547 http://www.openstreetmap.org/?lat=35.150288&lon=-107.849393
 NM117 +NM117_E http://www.openstreetmap.org/?lat=35.139950&lon=-107.828965
 I-40_E http://www.openstreetmap.org/?lat=35.123945&lon=-107.829695

--- a/hwy_data/NM/usaus/nm.us064.wpt
+++ b/hwy_data/NM/usaus/nm.us064.wpt
@@ -11,10 +11,9 @@ BIA362 http://www.openstreetmap.org/?lat=36.746725&lon=-108.536510
 CR6800 http://www.openstreetmap.org/?lat=36.759800&lon=-108.449446
 CR489 http://www.openstreetmap.org/?lat=36.731120&lon=-108.314563
 NM170 http://www.openstreetmap.org/?lat=36.737887&lon=-108.252089
-NM5001_W http://www.openstreetmap.org/?lat=36.731730&lon=-108.233185
-NM371 http://www.openstreetmap.org/?lat=36.728067&lon=-108.218282
-ScoAve http://www.openstreetmap.org/?lat=36.728429&lon=-108.192501
-NM5001_E http://www.openstreetmap.org/?lat=36.719348&lon=-108.183060
+US64Bus_W +NM5001_W http://www.openstreetmap.org/?lat=36.731592&lon=-108.232627
+NM371 http://www.openstreetmap.org/?lat=36.722314&lon=-108.221555
+US64Bus_E +NM5001_E http://www.openstreetmap.org/?lat=36.719357&lon=-108.182652
 NM516 http://www.openstreetmap.org/?lat=36.718660&lon=-108.157589
 CR5500 http://www.openstreetmap.org/?lat=36.702146&lon=-108.094568
 CR5290 http://www.openstreetmap.org/?lat=36.701156&lon=-108.055301

--- a/hwy_data/NM/usaus/nm.us070.wpt
+++ b/hwy_data/NM/usaus/nm.us070.wpt
@@ -5,8 +5,7 @@ CRA024 http://www.openstreetmap.org/?lat=32.490090&lon=-108.844954
 NM464 http://www.openstreetmap.org/?lat=32.397220&lon=-108.726518
 NM90 http://www.openstreetmap.org/?lat=32.380360&lon=-108.708172
 I-10BL_W http://www.openstreetmap.org/?lat=32.350419&lon=-108.709373
-I-10BL_E http://www.openstreetmap.org/?lat=32.350247&lon=-108.708676
-I-10(22) http://www.openstreetmap.org/?lat=32.342406&lon=-108.713021
+NM494 +I-10BL_E http://www.openstreetmap.org/?lat=32.350247&lon=-108.708676
 I-10(24) http://www.openstreetmap.org/?lat=32.339288&lon=-108.679161
 I-10(29) http://www.openstreetmap.org/?lat=32.312053&lon=-108.607492
 I-10(34) http://www.openstreetmap.org/?lat=32.270079&lon=-108.536124

--- a/hwy_data/NM/usausb/nm.us064busfar.wpt
+++ b/hwy_data/NM/usausb/nm.us064busfar.wpt
@@ -1,0 +1,4 @@
+US64_W http://www.openstreetmap.org/?lat=36.731592&lon=-108.232627
+LakeSt +NM371 http://www.openstreetmap.org/?lat=36.728033&lon=-108.218271
+ScoAve http://www.openstreetmap.org/?lat=36.728210&lon=-108.192308
+US64_E http://www.openstreetmap.org/?lat=36.719357&lon=-108.182652

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -490,6 +490,7 @@ usausb;MO;US63;Bus;Mob;Moberly, MO;mo.us063busmob;
 usausb;MO;US63;Bus;Kir;Kirksville, MO;mo.us063buskir;
 usausb;IA;US63;Bus;Ott;Ottumwa, IA;ia.us063busott;
 usausb;IA;US63;Bus;NHa;New Hampton, IA;ia.us063busnha;
+usausb;NM;US64;Bus;Far;Farmington, NM;nm.us064busfar;
 usausb;OK;US64;Bus;Mus;Muskogee, OK;ok.us064busmus;
 usausb;AR;US64;Bus;Alm;Alma, AR;ar.us064busalm;
 usausb;AR;US64;Bus;Vil;Vilonia, AR;ar.us064busvil;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -482,6 +482,7 @@ usausb;US63;Bus;Moberly, MO;mo.us063busmob
 usausb;US63;Bus;Kirksville, MO;mo.us063buskir
 usausb;US63;Bus;Ottumwa, IA;ia.us063busott
 usausb;US63;Bus;New Hampton, IA;ia.us063busnha
+usausb;US64;Bus;Farmington, NM;nm.us064busfar
 usausb;US64;Bus;Muskogee, OK;ok.us064busmus
 usausb;US64;Bus;Alma, AR;ar.us064busalm
 usausb;US64;Bus;Vilonia, AR;ar.us064busvil


### PR DESCRIPTION
Adds US 64 Business (Farmington), reroutes US 64 in Farmington and US 70 in Lordsburg, and adds NM 547 point to I-40BL (Grants).

Updates entries:

2015-11-20;(USA) New Mexico;US 64 Business (Farmington);nm.us064busfar'Route added
2015-11-20;(USA) New Mexico;US 64;nm.us064;In Farmington, route moved from Main St. and Broadway St. (now US 64 Business), south to Murray Dr.
2015-11-20;(USA) New Mexico;US 70;nm.us070;In Lordsburg, route moved from I-10 between exits 22 and 24, and Main St. (NM 494), north to Motel Dr. (I-10BL)