### PR TITLE
ON: ON-401 final extension

### DIFF
--- a/hwy_data/ON/cannf/on.ecrowexpy.wpt
+++ b/hwy_data/ON/cannf/on.ecrowexpy.wpt
@@ -1,5 +1,6 @@
 OjiPkwy http://www.openstreetmap.org/?lat=42.274165&lon=-83.078667
 MatRd http://www.openstreetmap.org/?lat=42.275157&lon=-83.071736
+ON401 http://www.openstreetmap.org/?lat=42.273213&lon=-83.065556
 ON3 http://www.openstreetmap.org/?lat=42.270886&lon=-83.047639
 DomBlvd http://www.openstreetmap.org/?lat=42.274086&lon=-83.029454
 DouAve http://www.openstreetmap.org/?lat=42.276150&lon=-83.015989

--- a/hwy_data/ON/canonf/on.on401.wpt
+++ b/hwy_data/ON/canonf/on.on401.wpt
@@ -1,3 +1,5 @@
+1 http://www.openstreetmap.org/?lat=42.272728&lon=-83.079944
+2 http://www.openstreetmap.org/?lat=42.273213&lon=-83.065556
 5 http://www.openstreetmap.org/?lat=42.264479&lon=-83.044217
 6A http://www.openstreetmap.org/?lat=42.256237&lon=-83.038847
 6 http://www.openstreetmap.org/?lat=42.251052&lon=-83.035929


### PR DESCRIPTION
Final extension till the new International Bridge is built for ON-401 has been opened on Nov. 21st, 2015.

Update log info:
2015-11-29;(Canada) Ontario;ON401;on.on401;Extended westward from the former ending interchange with ON 3 (Exit 5) along a newly built freeway to an interchange with Ojibway Parkway (Exit 1).