### PR TITLE
WV: US-48 (Corridor H) & WV-115 updates

### DIFF
--- a/hwy_data/WV/usaus/wv.us048.wpt
+++ b/hwy_data/WV/usaus/wv.us048.wpt
@@ -1,8 +1,10 @@
-Tuc/Gra http://www.openstreetmap.org/?lat=39.195453&lon=-79.292327
+WV93_Tuc http://www.openstreetmap.org/?lat=39.19451&lon=-79.34913
+CR90/1 http://www.openstreetmap.org/?lat=39.19513&lon=-79.29603
++Tuc/Gra http://www.openstreetmap.org/?lat=39.195453&lon=-79.292327 
 WV93_E http://www.openstreetmap.org/?lat=39.209196&lon=-79.273696
 +X018(US48) http://www.openstreetmap.org/?lat=39.212272&lon=-79.268621
 WV93 http://www.openstreetmap.org/?lat=39.213714&lon=-79.248692
-ToWV42 http://www.openstreetmap.org/?lat=39.216462&lon=-79.213969
+ComDr +ToWV42 http://www.openstreetmap.org/?lat=39.216462&lon=-79.213969
 +X017(US48) http://www.openstreetmap.org/?lat=39.220971&lon=-79.193176
 +X016(US48) http://www.openstreetmap.org/?lat=39.234023&lon=-79.184545
 ToWV93 http://www.openstreetmap.org/?lat=39.219130&lon=-79.147825

--- a/hwy_data/WV/usawv/wv.wv009.wpt
+++ b/hwy_data/WV/usawv/wv.wv009.wpt
@@ -26,15 +26,16 @@ I-81 http://www.openstreetmap.org/?lat=39.496342&lon=-77.959456
 US11_N http://www.openstreetmap.org/?lat=39.475850&lon=-77.957316
 WV45_E http://www.openstreetmap.org/?lat=39.467011&lon=-77.956640
 RacSt http://www.openstreetmap.org/?lat=39.460000&lon=-77.962782
-US11/45 http://www.openstreetmap.org/?lat=39.456224&lon=-77.963955
+US11_S +US11/45 http://www.openstreetmap.org/?lat=39.456224&lon=-77.963955
 WV45_W http://www.openstreetmap.org/?lat=39.442225&lon=-77.969456
-CR9/17 http://www.openstreetmap.org/?lat=39.418707&lon=-77.929609
+WV115_Bak +CR9/17 http://www.openstreetmap.org/?lat=39.418993&lon=-77.928858
 CR9/19 http://www.openstreetmap.org/?lat=39.400023&lon=-77.922657
++X448918 http://www.openstreetmap.org/?lat=39.394750&lon=-77.918322
 +X409489 http://www.openstreetmap.org/?lat=39.391176&lon=-77.893399
 KerPk http://www.openstreetmap.org/?lat=39.381565&lon=-77.894804
-WilRd http://www.openstreetmap.org/?lat=39.362042&lon=-77.866073
+WV115_Bar +WilRd http://www.openstreetmap.org/?lat=39.362042&lon=-77.866073
 +X278150 http://www.openstreetmap.org/?lat=39.353248&lon=-77.855816
-WV115 http://www.openstreetmap.org/?lat=39.332820&lon=-77.856674
+CR9/1 +WV115 http://www.openstreetmap.org/?lat=39.332820&lon=-77.856674
 US340_N http://www.openstreetmap.org/?lat=39.295563&lon=-77.839567
 US340_S http://www.openstreetmap.org/?lat=39.280628&lon=-77.838789
 CatRunRd http://www.openstreetmap.org/?lat=39.274233&lon=-77.820888

--- a/hwy_data/WV/usawv/wv.wv051.wpt
+++ b/hwy_data/WV/usawv/wv.wv051.wpt
@@ -8,5 +8,5 @@ PonTr http://www.openstreetmap.org/?lat=39.326165&lon=-78.003573
 CR1 http://www.openstreetmap.org/?lat=39.310859&lon=-77.979412
 CR6 http://www.openstreetmap.org/?lat=39.303786&lon=-77.924438
 SumPtRd http://www.openstreetmap.org/?lat=39.286217&lon=-77.868176
-WV115 http://www.openstreetmap.org/?lat=39.288841&lon=-77.860107
+WV115 http://www.openstreetmap.org/?lat=39.289074&lon=-77.859914
 US340/9 http://www.openstreetmap.org/?lat=39.295563&lon=-77.839567

--- a/hwy_data/WV/usawv/wv.wv093.wpt
+++ b/hwy_data/WV/usawv/wv.wv093.wpt
@@ -2,14 +2,15 @@ WV32 http://www.openstreetmap.org/?lat=39.134350&lon=-79.476009
 +X000(WV93) http://www.openstreetmap.org/?lat=39.149199&lon=-79.436560
 +X001(WV93) http://www.openstreetmap.org/?lat=39.183703&lon=-79.395146
 AFraRd http://www.openstreetmap.org/?lat=39.185172&lon=-79.368217
-+X002(WV93) http://www.openstreetmap.org/?lat=39.200334&lon=-79.322705
-CR90/1 http://www.openstreetmap.org/?lat=39.195296&lon=-79.295589
-US48_Gra http://www.openstreetmap.org/?lat=39.195453&lon=-79.292327
+*OldWV93_W http://www.openstreetmap.org/?lat=39.194164&lon=-79.352070
+*TempWV93_W http://www.openstreetmap.org/?lat=39.19451&lon=-79.34913
+CR90/1 http://www.openstreetmap.org/?lat=39.19513&lon=-79.29603
++US48_Gra http://www.openstreetmap.org/?lat=39.195453&lon=-79.292327
 US48_E http://www.openstreetmap.org/?lat=39.209196&lon=-79.273696
 +X003(WV93) http://www.openstreetmap.org/?lat=39.208153&lon=-79.253059
 US48 http://www.openstreetmap.org/?lat=39.213714&lon=-79.248692
 CR50/3 http://www.openstreetmap.org/?lat=39.217380&lon=-79.233415
-ToUS48_W http://www.openstreetmap.org/?lat=39.219001&lon=-79.213727
+ComDr +ToUS48_W http://www.openstreetmap.org/?lat=39.219001&lon=-79.213727
 WV42_N http://www.openstreetmap.org/?lat=39.219013&lon=-79.211050
 +X004(WV93) http://www.openstreetmap.org/?lat=39.200068&lon=-79.203100
 +X005(WV93) http://www.openstreetmap.org/?lat=39.198039&lon=-79.174175

--- a/hwy_data/WV/usawv/wv.wv115.wpt
+++ b/hwy_data/WV/usawv/wv.wv115.wpt
@@ -1,5 +1,14 @@
-WV9 http://www.openstreetmap.org/?lat=39.332820&lon=-77.856674
-CR9/1 http://www.openstreetmap.org/?lat=39.332936&lon=-77.859163
-LeePk http://www.openstreetmap.org/?lat=39.312121&lon=-77.863970
-WV51 http://www.openstreetmap.org/?lat=39.288841&lon=-77.860107
 US340 +US340/9 http://www.openstreetmap.org/?lat=39.274005&lon=-77.847496
+WV51 http://www.openstreetmap.org/?lat=39.289074&lon=-77.859914
+LeePk http://www.openstreetmap.org/?lat=39.312067&lon=-77.863723
+CR9/1 +WV9 http://www.openstreetmap.org/?lat=39.332982&lon=-77.859174
++X829502 http://www.openstreetmap.org/?lat=39.353261&lon=-77.856336
+CR8 http://www.openstreetmap.org/?lat=39.361179&lon=-77.867301
+WV9_Bar http://www.openstreetmap.org/?lat=39.362042&lon=-77.866073
+CR16/4 http://www.openstreetmap.org/?lat=39.362664&lon=-77.865247
+CR1/2 http://www.openstreetmap.org/?lat=39.371638&lon=-77.886543
+WV480 http://www.openstreetmap.org/?lat=39.387776&lon=-77.885765
++X592258 http://www.openstreetmap.org/?lat=39.392805&lon=-77.891023
+CR9/19 http://www.openstreetmap.org/?lat=39.402406&lon=-77.911499
+ChaRd_N http://www.openstreetmap.org/?lat=39.422615&lon=-77.925108
+WV9_Bak http://www.openstreetmap.org/?lat=39.418993&lon=-77.928858

--- a/hwy_data/WV/usawv/wv.wv480.wpt
+++ b/hwy_data/WV/usawv/wv.wv480.wpt
@@ -1,4 +1,4 @@
-ChaTownRd http://www.openstreetmap.org/?lat=39.387685&lon=-77.885728
+WV115 +ChaTownRd http://www.openstreetmap.org/?lat=39.387776&lon=-77.885765
 WV45Alt http://www.openstreetmap.org/?lat=39.423265&lon=-77.820454
 WV45/230 http://www.openstreetmap.org/?lat=39.431950&lon=-77.808867
 WV/MD http://www.openstreetmap.org/?lat=39.436127&lon=-77.802665


### PR DESCRIPTION
US-48/WV-93: http://clinched.s2.bizhat.com/viewtopic.php?p=16704&mforum=clinched#16704
WV-115: http://clinched.s2.bizhat.com/viewtopic.php?p=16702&mforum=clinched#16702

Update log info:
2015-11-29;(USA) West Virginia;US 48;wv.us048;Extended west from the County Line of Grant and Tucker (CR90/1) to the now closed temporary alignment of WV 93 (WV93_Tuc) along a newly built 4-lane highway.

2015-11-29;(USA) West Virginia;WV 93;wv.wv093;Relocated route near Bismarck from the now abandoned old road and slightly to the south onto a brand new 4-lane US 48 Corridor H alignment between an intersection with CR 90/1 and the now closed alignment of WV 93 (*OldWV93_W).

2015-11-29;(USA) West Virginia;WV 115;wv.wv115;Extended northward from the intersection with CR 9/1 (Currie Road) along War Admiral Boulevard, Wiltshire Road, Charles Town Road, & Opequon Connector to an interchange with WV 9 in Baker Heights.

2015-11-29;(USA) West Virginia;WV 115;wv.wv115;Route truncated at northern end from the interchange with WV 9 to the intersection with CR 9/1 (Currie Road).