### PR TITLE
SC: US-521 Connector removal in Sumter, SC.

### DIFF
--- a/hwy_data/SC/usausb/sc.us521consum.wpt
+++ b/hwy_data/SC/usausb/sc.us521consum.wpt
@@ -1,6 +1,0 @@
-US15 http://www.openstreetmap.org/?lat=33.880976&lon=-80.351087
-SGuiPkwy http://www.openstreetmap.org/?lat=33.885457&lon=-80.350028
-BraSt http://www.openstreetmap.org/?lat=33.912094&lon=-80.354255
-SC763 http://www.openstreetmap.org/?lat=33.919960&lon=-80.359766
-GuiDr http://www.openstreetmap.org/?lat=33.935081&lon=-80.370722
-US521 +US301 http://www.openstreetmap.org/?lat=33.945202&lon=-80.372460

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -1098,7 +1098,6 @@ usausb;VA;US501;Trk;Sou;South Boston, VA;va.us501trksou;
 usausb;SC;US521;Bus;And;Andrews, SC;sc.us521busand;
 usausb;SC;US521;Bus;Ker;Kershaw, SC;sc.us521busker;
 usausb;SC;US521;Bus;Lan;Lancaster, SC;sc.us521buslan;
-usausb;SC;US521;Con;Sum;Sumter, SC;sc.us521consum;
 usausb;SC;US521;Trk;Cam;Camden, SC;sc.us521trkcam;
 usausb;VA;US522;Bus;Was;Washington, VA;va.us522buswas;
 usausb;SC;US601;Bus;Ker;Kershaw, SC;sc.us601busker;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -1083,7 +1083,6 @@ usausb;US501;Trk;South Boston, VA;va.us501trksou
 usausb;US521;Bus;Andrews, SC;sc.us521busand
 usausb;US521;Bus;Kershaw, SC;sc.us521busker
 usausb;US521;Bus;Lancaster, SC;sc.us521buslan
-usausb;US521;Con;Sumter, SC;sc.us521consum
 usausb;US521;Trk;Camden, SC;sc.us521trkcam
 usausb;US522;Bus;Washington, VA;va.us522buswas
 usausb;US601;Bus;Kershaw, SC;sc.us601busker


### PR DESCRIPTION
This route should have been deleted at the same time when I rerouted US-521 in Sumter, SC along the 'connector's' former route.  This pull request fixes that problem.

2016-01-01;(USA) South Carolina;US 521 Connector (Sumter);;Route deleted