### PR TITLE
White Plains NY cleanup

### DIFF
--- a/hwy_data/NY/usai/ny.i287.wpt
+++ b/hwy_data/NY/usai/ny.i287.wpt
@@ -16,9 +16,10 @@ NJ/NY +0 http://www.openstreetmap.org/?lat=41.112796&lon=-74.162645
 3 http://www.openstreetmap.org/?lat=41.054599&lon=-73.810015
 4 http://www.openstreetmap.org/?lat=41.047119&lon=-73.803868
 5 http://www.openstreetmap.org/?lat=41.043182&lon=-73.787652
-6 http://www.openstreetmap.org/?lat=41.045044&lon=-73.765425
-7 http://www.openstreetmap.org/?lat=41.032806&lon=-73.753046
-8 http://www.openstreetmap.org/?lat=41.030540&lon=-73.746323
+6 http://www.openstreetmap.org/?lat=41.045812&lon=-73.769503
+7 http://www.openstreetmap.org/?lat=41.041722&lon=-73.762674
+8W http://www.openstreetmap.org/?lat=41.034010&lon=-73.753881
+8E http://www.openstreetmap.org/?lat=41.031031&lon=-73.749783
 9A http://www.openstreetmap.org/?lat=41.025360&lon=-73.730977
 9 http://www.openstreetmap.org/?lat=41.014070&lon=-73.717146
 10 http://www.openstreetmap.org/?lat=41.008240&lon=-73.697558

--- a/hwy_data/NY/usany/ny.ny127.wpt
+++ b/hwy_data/NY/usany/ny.ny127.wpt
@@ -3,4 +3,4 @@ HalAve http://www.openstreetmap.org/?lat=40.968849&lon=-73.712811
 NorSt http://www.openstreetmap.org/?lat=40.987097&lon=-73.709764
 ParkDrS http://www.openstreetmap.org/?lat=40.991859&lon=-73.712318
 HutRivPkwy http://www.openstreetmap.org/?lat=40.999795&lon=-73.726051
-I-287 http://www.openstreetmap.org/?lat=41.031379&lon=-73.750802
+I-287 http://www.openstreetmap.org/?lat=41.031031&lon=-73.749783


### PR DESCRIPTION
2016-01-02;(USA) New York;I-287;ny.i287;Moved Exit 7 from Bloomingdale Rd (now labeled 8W) to Central Westchester Parkway.