### PR TITLE
OK US283 / OK6 / OK44

### DIFF
--- a/hwy_data/OK/usaok/ok.ok006.wpt
+++ b/hwy_data/OK/usaok/ok.ok006.wpt
@@ -7,22 +7,22 @@ E1750 http://www.openstreetmap.org/?lat=34.479294&lon=-99.634345
 OK34 http://www.openstreetmap.org/?lat=34.512033&lon=-99.561453
 GSt http://www.openstreetmap.org/?lat=34.548620&lon=-99.422643
 US62_W http://www.openstreetmap.org/?lat=34.637796&lon=-99.421396
-US283_A http://www.openstreetmap.org/?lat=34.637869&lon=-99.333916
+US62/283 +US283_A http://www.openstreetmap.org/?lat=34.637869&lon=-99.333916
 E1600 http://www.openstreetmap.org/?lat=34.695870&lon=-99.334313
 E1580 http://www.openstreetmap.org/?lat=34.725169&lon=-99.334801
 OK19 http://www.openstreetmap.org/?lat=34.783549&lon=-99.335396
-US283_B http://www.openstreetmap.org/?lat=34.813187&lon=-99.334881
-US283_C http://www.openstreetmap.org/?lat=34.856443&lon=-99.378376
+OldUS283 +US283_B http://www.openstreetmap.org/?lat=34.813187&lon=-99.334881
+US283_N http://www.openstreetmap.org/?lat=34.856443&lon=-99.378376
 E1470 http://www.openstreetmap.org/?lat=34.885539&lon=-99.378633
 OK9 http://www.openstreetmap.org/?lat=34.957975&lon=-99.378119
 MouAve http://www.openstreetmap.org/?lat=34.965283&lon=-99.378226
 RoseSt http://www.openstreetmap.org/?lat=34.966331&lon=-99.373891
-E1340_W http://www.openstreetmap.org/?lat=35.073083&lon=-99.374213
-E1340_E http://www.openstreetmap.org/?lat=35.073400&lon=-99.363871
-OK55_E http://www.openstreemap.org/?lat=35.16033&lon=-99.35992
-+X001 http://www.openstreetmap.org/?lat=35.18128&lon=-99.36068
-E1250 http://www.openstreetmap.org/?lat=35.20437&lon=-99.39273
-OK55_W http://www.openstreetmap.org/?lat=35.21889&lon=-99.40036
+N2020 http://www.openstreetmap.org/?lat=35.034951&lon=-99.376338
+*OldOK6 http://www.openstreetmap.org/?lat=35.076993&lon=-99.360030
+OK55_E http://www.openstreetmap.org/?lat=35.160330&lon=-99.359920
++X001 http://www.openstreetmap.org/?lat=35.181280&lon=-99.360680
+E1250 http://www.openstreetmap.org/?lat=35.204370&lon=-99.392730
+OK55_W http://www.openstreetmap.org/?lat=35.218890&lon=-99.400360
 OK152_E http://www.openstreetmap.org/?lat=35.291410&lon=-99.399748
 I-40 http://www.openstreetmap.org/?lat=35.389155&lon=-99.401979
 OK34_E http://www.openstreetmap.org/?lat=35.411683&lon=-99.405026
@@ -31,7 +31,7 @@ PioRd http://www.openstreetmap.org/?lat=35.411753&lon=-99.435024
 OK34_W http://www.openstreetmap.org/?lat=35.407660&lon=-99.471931
 BK29 http://www.openstreetmap.org/?lat=35.407326&lon=-99.505405
 BK25 http://www.openstreetmap.org/?lat=35.407196&lon=-99.575872
-US283_D http://www.openstreetmap.org/?lat=35.407188&lon=-99.655781
+US283 +US283_D http://www.openstreetmap.org/?lat=35.407188&lon=-99.655781
 BK15 http://www.openstreetmap.org/?lat=35.407466&lon=-99.752812
 BK13 http://www.openstreetmap.org/?lat=35.422200&lon=-99.787874
 OK152_W http://www.openstreetmap.org/?lat=35.422070&lon=-99.843664

--- a/hwy_data/OK/usaok/ok.ok044.wpt
+++ b/hwy_data/OK/usaok/ok.ok044.wpt
@@ -1,4 +1,4 @@
-US283 http://www.openstreetmap.org/?lat=34.856267&lon=-99.329581
+OldUS283 +US283 http://www.openstreetmap.org/?lat=34.856267&lon=-99.329581
 OK44A http://www.openstreetmap.org/?lat=34.869630&lon=-99.305592
 E1470 http://www.openstreetmap.org/?lat=34.885297&lon=-99.278812
 ShoRd http://www.openstreetmap.org/?lat=34.928868&lon=-99.262934

--- a/hwy_data/OK/usaus/ok.us283.wpt
+++ b/hwy_data/OK/usaus/ok.us283.wpt
@@ -5,9 +5,8 @@ US62 http://www.openstreetmap.org/?lat=34.637869&lon=-99.333916
 E1600 http://www.openstreetmap.org/?lat=34.695870&lon=-99.334313
 E1580 http://www.openstreetmap.org/?lat=34.725169&lon=-99.334801
 OK19 http://www.openstreetmap.org/?lat=34.783549&lon=-99.335396
-OK6_A http://www.openstreetmap.org/?lat=34.813187&lon=-99.334881
-OK44 http://www.openstreetmap.org/?lat=34.856267&lon=-99.329581
-OK6_B http://www.openstreetmap.org/?lat=34.856443&lon=-99.378376
+OldUS283 +OK6_A http://www.openstreetmap.org/?lat=34.813187&lon=-99.334881
+OK6_N +OK6_B http://www.openstreetmap.org/?lat=34.856443&lon=-99.378376
 N1970 http://www.openstreetmap.org/?lat=34.856526&lon=-99.467125
 OK34_S http://www.openstreetmap.org/?lat=34.872236&lon=-99.502788
 OK9_W http://www.openstreetmap.org/?lat=34.902660&lon=-99.502423
@@ -22,7 +21,7 @@ I-40 http://www.openstreetmap.org/?lat=35.262756&lon=-99.643250
 OK152 http://www.openstreetmap.org/?lat=35.291274&lon=-99.639945
 I-40BL_E http://www.openstreetmap.org/?lat=35.307561&lon=-99.640074
 E1130 http://www.openstreetmap.org/?lat=35.378289&lon=-99.637756
-OK6_C http://www.openstreetmap.org/?lat=35.407188&lon=-99.655781
+OK6 +OK6_C http://www.openstreetmap.org/?lat=35.407188&lon=-99.655781
 E1040 http://www.openstreetmap.org/?lat=35.508699&lon=-99.664192
 OK47_W http://www.openstreetmap.org/?lat=35.613942&lon=-99.671917
 E0940 http://www.openstreetmap.org/?lat=35.653491&lon=-99.668312


### PR DESCRIPTION
addresses #271:

2016-01-04;(USA) Oklahoma;US 283;ok.us283;Removed from a two-lane north-south roadway and E 1490 between a point (labeled OldUS283) near the Jackson/Greer county line and the OK 6 north split, and relocated onto a divided four-lane diagonal directly between these two points.
2016-01-04;(USA) Oklahoma;OK 6;ok.ok006;Removed from N 2020 Rd, E 1340 Rd and a closed two-lane roadway and relocated onto a divided four-lane diagonal between N 2020 Rd and the closed intersection with Old OK 6.