### PR TITLE
CA US 50 error fix

### DIFF
--- a/hwy_data/CA/usaus/ca.us050.wpt
+++ b/hwy_data/CA/usaus/ca.us050.wpt
@@ -50,7 +50,7 @@ IceHouRd http://www.openstreetmap.org/?lat=38.769301&lon=-120.447498
 +x29 http://www.openstreetmap.org/?lat=38.764181&lon=-120.323982
 SilForRd http://www.openstreetmap.org/?lat=38.774424&lon=-120.294188
 WriLakeRd http://www.openstreetmap.org/?lat=38.785180&lon=-120.213882
-StrCreRd http://www.openstreetmap.org/?lat=38.791088&lon=-120.152401
+StrCrkRd http://www.openstreetmap.org/?lat=38.791088&lon=-120.152401
 +X349417 http://www.openstreetmap.org/?lat=38.806762&lon=-120.138577
 PyrCrkRd http://www.openstreetmap.org/?lat=38.811343&lon=-120.120633
 SliFordRd http://www.openstreetmap.org/?lat=38.805642&lon=-120.123031
@@ -60,11 +60,11 @@ EchoDr http://www.openstreetmap.org/?lat=38.812957&lon=-120.031299
 OldMyeRd http://www.openstreetmap.org/?lat=38.825834&lon=-120.029272
 +x37 http://www.openstreetmap.org/?lat=38.841675&lon=-120.042629
 US50Alt/89 http://www.openstreetmap.org/?lat=38.851038&lon=-120.022319
-PioTr http://www.openstreetmap.org/?lat=38.859527&lon=-120.012159
+PioTr_W http://www.openstreetmap.org/?lat=38.859527&lon=-120.012159
 SawRd http://www.openstreetmap.org/?lat=38.875685&lon=-120.005384
 AirRd http://www.openstreetmap.org/?lat=38.895066&lon=-119.999929
 CA89_N +CA89 http://www.openstreetmap.org/?lat=38.913454&lon=-120.004569
 AlTahBlvd http://www.openstreetmap.org/?lat=38.934360&lon=-119.977752
 LakAve http://www.openstreetmap.org/?lat=38.944149&lon=-119.976287
-PioTr http://www.openstreetmap.org/?lat=38.953828&lon=-119.946241
+PioTr_E http://www.openstreetmap.org/?lat=38.953828&lon=-119.946241
 CA/NV http://www.openstreetmap.org/?lat=38.959150&lon=-119.942057


### PR DESCRIPTION
Renames two waypoints, not in use, with duplicate labels.

Remaining new Datacheck error in just-updated CA US route files (sharp angle in US050AltPol) is false positive, to be crossed off later.