### PR TITLE
Old forum issues part 3

### DIFF
--- a/hwy_data/KY/usaky/ky.ky0016.wpt
+++ b/hwy_data/KY/usaky/ky.ky0016.wpt
@@ -21,7 +21,8 @@ KY2045 http://www.openstreetmap.org/?lat=38.944758&lon=-84.508681
 KY2047_E http://www.openstreetmap.org/?lat=38.965849&lon=-84.503703
 KY2047_W http://www.openstreetmap.org/?lat=38.970495&lon=-84.503081
 KY1501 http://www.openstreetmap.org/?lat=38.973282&lon=-84.502458
-MillValDr http://www.openstreetmap.org/?lat=39.010814&lon=-84.493403
+KY3716_S http://www.openstreetmap.org/?lat=38.990904&lon=-84.504175
+KY3716_N http://www.openstreetmap.org/?lat=39.018317&lon=-84.510291
 I-275 http://www.openstreetmap.org/?lat=39.022051&lon=-84.511771
 KY3070 http://www.openstreetmap.org/?lat=39.037453&lon=-84.509110
 KY177 http://www.openstreetmap.org/?lat=39.047386&lon=-84.503231

--- a/hwy_data/KY/usaky/ky.ky0680.wpt
+++ b/hwy_data/KY/usaky/ky.ky0680.wpt
@@ -8,9 +8,10 @@ KY122_E http://www.openstreetmap.org/?lat=37.456294&lon=-82.740612
 KY1929 http://www.openstreetmap.org/?lat=37.450707&lon=-82.726493
 LitBraRd http://www.openstreetmap.org/?lat=37.450332&lon=-82.680016
 KY979_S http://www.openstreetmap.org/?lat=37.462085&lon=-82.656498
-KY979_A http://www.openstreetmap.org/?lat=37.493486&lon=-82.654524
-KY979_B +KY979_N http://www.openstreetmap.org/?lat=37.504007&lon=-82.656970
+KY979_A http://www.openstreetmap.org/?lat=37.493818&lon=-82.654969
+KY979_B +KY979_N http://www.openstreetmap.org/?lat=37.504173&lon=-82.656949
 KY979_C http://www.openstreetmap.org/?lat=37.505743&lon=-82.656627
++X164422 http://www.openstreetmap.org/?lat=37.525869&lon=-82.652357
 KY979/1426 http://www.openstreetmap.org/?lat=37.535356&lon=-82.640963
 KY1426_N http://www.openstreetmap.org/?lat=37.536649&lon=-82.638731
 US23/460 http://www.openstreetmap.org/?lat=37.537470&lon=-82.628775

--- a/hwy_data/KY/usaky/ky.ky0979.wpt
+++ b/hwy_data/KY/usaky/ky.ky0979.wpt
@@ -5,10 +5,10 @@ LigCampRd http://www.openstreetmap.org/?lat=37.373943&lon=-82.674522
 KY3380 http://www.openstreetmap.org/?lat=37.413545&lon=-82.647958
 RedMorgRd http://www.openstreetmap.org/?lat=37.427638&lon=-82.643366
 KY680_W http://www.openstreetmap.org/?lat=37.462085&lon=-82.656498
-KY680_A http://www.openstreetmap.org/?lat=37.493486&lon=-82.654524
-KY3379 http://www.openstreetmap.org/?lat=37.493554&lon=-82.653451
+KY680_A http://www.openstreetmap.org/?lat=37.493818&lon=-82.654969
+KY3379 http://www.openstreetmap.org/?lat=37.494329&lon=-82.653827
 +X604084 http://www.openstreetmap.org/?lat=37.502849&lon=-82.651520
-KY680_B +KY680_E http://www.openstreetmap.org/?lat=37.504007&lon=-82.656970
+KY680_B +KY680_E http://www.openstreetmap.org/?lat=37.504173&lon=-82.656949
 KY680_C http://www.openstreetmap.org/?lat=37.505743&lon=-82.656627
 SanBraRd http://www.openstreetmap.org/?lat=37.517725&lon=-82.651649
 +X857288 http://www.openstreetmap.org/?lat=37.524975&lon=-82.651563

--- a/hwy_data/KY/usaus/ky.us060.wpt
+++ b/hwy_data/KY/usaus/ky.us060.wpt
@@ -43,10 +43,12 @@ US45/62 +US45/62_S http://www.openstreetmap.org/?lat=37.068156&lon=-88.627825
 KY994 http://www.openstreetmap.org/?lat=37.069053&lon=-88.612535
 KY284 http://www.openstreetmap.org/?lat=37.057812&lon=-88.582446
 I-24BL/60Bus_E http://www.openstreetmap.org/?lat=37.049235&lon=-88.565302
-US62_E +US62Pad_E http://www.openstreetmap.org/?lat=37.035884&lon=-88.535600
+OldUS60_Rei +US62_E +US62Pad_E http://www.openstreetmap.org/?lat=37.035884&lon=-88.535600
+US62_Rei http://www.openstreetmap.org/?lat=37.028021&lon=-88.532392
+KY6074 http://www.openstreetmap.org/?lat=37.045407&lon=-88.515499
 FerRd http://www.openstreetmap.org/?lat=37.055937&lon=-88.442892
-KY3489_S http://www.openstreetmap.org/?lat=37.065261&lon=-88.434457
-KY3489_N http://www.openstreetmap.org/?lat=37.079212&lon=-88.416487
+KY3489_W http://www.openstreetmap.org/?lat=37.065261&lon=-88.434457
+KY3489_E http://www.openstreetmap.org/?lat=37.079212&lon=-88.416487
 KY937 http://www.openstreetmap.org/?lat=37.085406&lon=-88.411460
 ThoLp http://www.openstreetmap.org/?lat=37.098814&lon=-88.401373
 KY967_W http://www.openstreetmap.org/?lat=37.134641&lon=-88.405617
@@ -140,7 +142,7 @@ KY54 http://www.openstreetmap.org/?lat=37.757810&lon=-87.071344
 KY603 http://www.openstreetmap.org/?lat=37.769553&lon=-87.063925
 +X009A(US60) http://www.openstreetmap.org/?lat=37.781044&lon=-87.048883
 KY144_Thu http://www.openstreetmap.org/?lat=37.797526&lon=-87.049119
-*OldUS60 http://www.openstreetmap.org/?lat=37.815933&lon=-87.041384
+*OldUS60_Owe http://www.openstreetmap.org/?lat=37.815933&lon=-87.041384
 WriLanRd http://www.openstreetmap.org/?lat=37.827955&lon=-87.037436
 +X010(US60) http://www.openstreetmap.org/?lat=37.854614&lon=-87.002991
 US231_N http://www.openstreetmap.org/?lat=37.865372&lon=-87.002487
@@ -170,14 +172,14 @@ KY144_E http://www.openstreetmap.org/?lat=37.840229&lon=-86.574246
 KY992 http://www.openstreetmap.org/?lat=37.776499&lon=-86.478455
 +X014(US60) http://www.openstreetmap.org/?lat=37.764379&lon=-86.472686
 KY259/261 http://www.openstreetmap.org/?lat=37.762238&lon=-86.461503
-OldUS60_W +OldUS60_Har http://www.openstreetmap.org/?lat=37.761039&lon=-86.441071
+OldUS60_Har http://www.openstreetmap.org/?lat=37.761039&lon=-86.441071
 KY1616 http://www.openstreetmap.org/?lat=37.755355&lon=-86.428503
 KY79/259 http://www.openstreetmap.org/?lat=37.751490&lon=-86.409230
 KY1401 http://www.openstreetmap.org/?lat=37.751490&lon=-86.400831
 FreChuRd http://www.openstreetmap.org/?lat=37.778388&lon=-86.374956
 KY86_W http://www.openstreetmap.org/?lat=37.782633&lon=-86.357082
 KY86_E http://www.openstreetmap.org/?lat=37.792422&lon=-86.335158
-OldUS60_E http://www.openstreetmap.org/?lat=37.821692&lon=-86.324049
+OldUS60_Bre http://www.openstreetmap.org/?lat=37.821692&lon=-86.324049
 KY333_E http://www.openstreetmap.org/?lat=37.847807&lon=-86.320010
 KY333_W http://www.openstreetmap.org/?lat=37.851741&lon=-86.316025
 KY79_N http://www.openstreetmap.org/?lat=37.874511&lon=-86.288585
@@ -187,7 +189,7 @@ KY941_N http://www.openstreetmap.org/?lat=37.882698&lon=-86.197190
 KY941_S http://www.openstreetmap.org/?lat=37.882714&lon=-86.196721
 KY1238_W http://www.openstreetmap.org/?lat=37.887522&lon=-86.133984
 KY1238_E http://www.openstreetmap.org/?lat=37.887397&lon=-86.133164
-KY144/313  +KY144_Fla http://www.openstreetmap.org/?lat=37.882375&lon=-86.100239
+KY144/313 +KY144_Fla http://www.openstreetmap.org/?lat=37.882375&lon=-86.100239
 KY2726 http://www.openstreetmap.org/?lat=37.882299&lon=-86.064576
 KY1882 http://www.openstreetmap.org/?lat=37.893551&lon=-86.039837
 PinRd http://www.openstreetmap.org/?lat=37.905060&lon=-86.018974

--- a/hwy_data/KY/usaus/ky.us062.wpt
+++ b/hwy_data/KY/usaus/ky.us062.wpt
@@ -38,8 +38,8 @@ US45/60 +US45/60_N http://www.openstreetmap.org/?lat=37.068156&lon=-88.627825
 KY994 http://www.openstreetmap.org/?lat=37.069053&lon=-88.612535
 KY284 http://www.openstreetmap.org/?lat=37.057812&lon=-88.582446
 I-24BL/60Bus_E http://www.openstreetmap.org/?lat=37.049235&lon=-88.565302
-OldUS60 +US60Pad_E http://www.openstreetmap.org/?lat=37.035884&lon=-88.535600
-US60_Riv http://www.openstreetmap.org/?lat=37.028021&lon=-88.532392
+OldUS60 +US60_Riv +US60Pad_E http://www.openstreetmap.org/?lat=37.035884&lon=-88.535600
+US60_Rei http://www.openstreetmap.org/?lat=37.028021&lon=-88.532392
 KY131 http://www.openstreetmap.org/?lat=37.023452&lon=-88.530423
 KY1887 http://www.openstreetmap.org/?lat=37.017387&lon=-88.526217
 KY787 http://www.openstreetmap.org/?lat=37.011844&lon=-88.519131

--- a/hwy_data/KY/usaus/ky.us062.wpt
+++ b/hwy_data/KY/usaus/ky.us062.wpt
@@ -38,7 +38,8 @@ US45/60 +US45/60_N http://www.openstreetmap.org/?lat=37.068156&lon=-88.627825
 KY994 http://www.openstreetmap.org/?lat=37.069053&lon=-88.612535
 KY284 http://www.openstreetmap.org/?lat=37.057812&lon=-88.582446
 I-24BL/60Bus_E http://www.openstreetmap.org/?lat=37.049235&lon=-88.565302
-US60_Riv +US60Pad_E http://www.openstreetmap.org/?lat=37.035884&lon=-88.535600
+OldUS60 +US60Pad_E http://www.openstreetmap.org/?lat=37.035884&lon=-88.535600
+US60_Riv http://www.openstreetmap.org/?lat=37.028021&lon=-88.532392
 KY131 http://www.openstreetmap.org/?lat=37.023452&lon=-88.530423
 KY1887 http://www.openstreetmap.org/?lat=37.017387&lon=-88.526217
 KY787 http://www.openstreetmap.org/?lat=37.011844&lon=-88.519131


### PR DESCRIPTION
2016-01-06;(USA) Kentucky;US 60;ky.us060;Removed from the old demolished Ledbetter Bridge and KY 6074, and relocated onto the new Ledbetter Bridge about 1/2 mile southeast, between US 62 in Reidland and KY 6074.
2016-01-06;(USA) Kentucky;KY 16;ky.ky0016;Removed from KY 3716 and relocated onto Pride Pkwy between the southern and northern KY 3716 intersections.