### PR TITLE
Some WV fixes

### DIFF
--- a/hwy_data/WV/usaus/wv.us035.wpt
+++ b/hwy_data/WV/usaus/wv.us035.wpt
@@ -12,10 +12,10 @@ CR9 http://www.openstreetmap.org/?lat=38.616623&lon=-81.990682
 +X002(US35) http://www.openstreetmap.org/?lat=38.682612&lon=-81.964531
 CraCrkRd http://www.openstreetmap.org/?lat=38.716708&lon=-81.968811
 +X003(US35) http://www.openstreetmap.org/?lat=38.737503&lon=-81.975818
-WV817_N http://www.openstreetmap.org/?lat=38.766733&lon=-82.007006
+WV817_N http://www.openstreetmap.org/?lat=38.766545&lon=-82.007167
 +X004(US35) http://www.openstreetmap.org/?lat=38.770564&lon=-82.050190
 +X005(US35) http://www.openstreetmap.org/?lat=38.789295&lon=-82.091904
-WV817_Hen http://www.openstreetmap.org/?lat=38.812777&lon=-82.109435
-OldUS35 http://www.openstreetmap.org/?lat=38.818217&lon=-82.117116
+WV817_HenS +WV817_Hen http://www.openstreetmap.org/?lat=38.812777&lon=-82.109435
+WV817_HenN +OldUS35 http://www.openstreetmap.org/?lat=38.818217&lon=-82.117116
 WV2 http://www.openstreetmap.org/?lat=38.831162&lon=-82.142664
 WV/OH http://www.openstreetmap.org/?lat=38.835604&lon=-82.148992

--- a/hwy_data/WV/usaus/wv.us052.wpt
+++ b/hwy_data/WV/usaus/wv.us052.wpt
@@ -13,7 +13,7 @@ WV65_S http://www.openstreetmap.org/?lat=37.661781&lon=-82.157854
 +X746780 http://www.openstreetmap.org/?lat=37.667312&lon=-82.130141
 OldFieRd http://www.openstreetmap.org/?lat=37.670302&lon=-82.114048
 +X014(US52) http://www.openstreetmap.org/?lat=37.656551&lon=-82.093288
-WV44 http://www.openstreetmap.org/?lat=37.649709&lon=-81.999394
+WV44 http://www.openstreetmap.org/?lat=37.650032&lon=-81.999904
 CR52/02 http://www.openstreetmap.org/?lat=37.635940&lon=-81.907285
 +X015(US52) http://www.openstreetmap.org/?lat=37.610942&lon=-81.876533
 WV80_N http://www.openstreetmap.org/?lat=37.614214&lon=-81.866727

--- a/hwy_data/WV/usawv/wv.wv044.wpt
+++ b/hwy_data/WV/usawv/wv.wv044.wpt
@@ -1,4 +1,7 @@
-US52 http://www.openstreetmap.org/?lat=37.649680&lon=-81.999464
+BeeCreRd http://www.openstreetmap.org/?lat=37.629880&lon=-81.996417
+KingCoalHwy http://www.openstreetmap.org/?lat=37.630658&lon=-81.997259
++X666827 http://www.openstreetmap.org/?lat=37.646876&lon=-82.004056
+US52 http://www.openstreetmap.org/?lat=37.650032&lon=-81.999904
 +X397788 http://www.openstreetmap.org/?lat=37.664391&lon=-81.996503
 +X794232 http://www.openstreetmap.org/?lat=37.670947&lon=-82.008433
 ConBraRd http://www.openstreetmap.org/?lat=37.711054&lon=-81.987619

--- a/hwy_data/WV/usawv/wv.wv065.wpt
+++ b/hwy_data/WV/usawv/wv.wv065.wpt
@@ -1,7 +1,7 @@
 WV49 http://www.openstreetmap.org/?lat=37.621948&lon=-82.162886
 MayRd http://www.openstreetmap.org/?lat=37.632281&lon=-82.148509
 +X492555 http://www.openstreetmap.org/?lat=37.658378&lon=-82.135634
-KingCoalHwy http://www.openstreetmap.org/?lat=37.657664&lon=-82.142951
+KingCoalHwy http://www.openstreetmap.org/?lat=37.656832&lon=-82.143852
 US52_S http://www.openstreetmap.org/?lat=37.661781&lon=-82.157854
 +X012(US52) http://www.openstreetmap.org/?lat=37.678114&lon=-82.178367
 US52_N http://www.openstreetmap.org/?lat=37.702937&lon=-82.185438

--- a/hwy_data/WV/usawv/wv.wv817.wpt
+++ b/hwy_data/WV/usawv/wv.wv817.wpt
@@ -14,6 +14,7 @@ CR9 http://www.openstreetmap.org/?lat=38.616623&lon=-81.990682
 +X002(US35) http://www.openstreetmap.org/?lat=38.682612&lon=-81.964531
 CraCrkRd http://www.openstreetmap.org/?lat=38.716708&lon=-81.968811
 +X003(US35) http://www.openstreetmap.org/?lat=38.737503&lon=-81.975818
-US35_N http://www.openstreetmap.org/?lat=38.766733&lon=-82.007006
+US35_N http://www.openstreetmap.org/?lat=38.766545&lon=-82.007167
 CR27 http://www.openstreetmap.org/?lat=38.788747&lon=-82.058387
-US35 http://www.openstreetmap.org/?lat=38.812777&lon=-82.109435
+US35_HenS +US35 http://www.openstreetmap.org/?lat=38.812777&lon=-82.109435
+US35_HenN http://www.openstreetmap.org/?lat=38.818217&lon=-82.117116


### PR DESCRIPTION
Extension of WV-44 down to just South of the King Coal Highway till WV gets their act together and only has one posted route for US-52 in that area.  Also a small extension of WV-817 along US-35.

2016-01-30;(USA) West Virginia;WV 44;wv.wv044;Extended southward from it's former southern end at US 52 down to just south of the intersection with the King Coal Highway at Beech Creek Road.
2016-01-30;(USA) West Virginia;WV 817;wv.wv817;Extended westward along US 35 near Henderson from the old western end at US 35 (US35_HenS) to an intersection with Old US 35 (US35_HenN).