### PR TITLE
Ohio & Kentucky

### DIFF
--- a/hwy_data/KY/usaky3/ky.ky1020.wpt
+++ b/hwy_data/KY/usaky3/ky.ky1020.wpt
@@ -6,10 +6,12 @@ KY2055 http://www.openstreetmap.org/?lat=38.096842&lon=-85.738163
 KY841 http://www.openstreetmap.org/?lat=38.117576&lon=-85.748039
 KY1065 http://www.openstreetmap.org/?lat=38.126961&lon=-85.748978
 KY907 http://www.openstreetmap.org/?lat=38.152580&lon=-85.765543
-I-264 http://www.openstreetmap.org/?lat=38.189962&lon=-85.764813
+SouDr_N http://www.openstreetmap.org/?lat=38.176659&lon=-85.764721
+SouPkwy_S http://www.openstreetmap.org/?lat=38.181811&lon=-85.768434
+I-264 http://www.openstreetmap.org/?lat=38.189899&lon=-85.766686
 US60Alt_W http://www.openstreetmap.org/?lat=38.210146&lon=-85.762980
 US60Alt_E http://www.openstreetmap.org/?lat=38.213748&lon=-85.762315
-MagAve http://www.openstreetmap.org/?lat=38.228944&lon=-85.759706
-OakSt http://www.openstreetmap.org/?lat=38.234877&lon=-85.758634
+MagAve http://www.openstreetmap.org/?lat=38.228860&lon=-85.758810
+OakSt http://www.openstreetmap.org/?lat=38.234776&lon=-85.757840
 US150 http://www.openstreetmap.org/?lat=38.245899&lon=-85.755887
 US31E/31W http://www.openstreetmap.org/?lat=38.255584&lon=-85.753441

--- a/hwy_data/OH/usaoh/oh.oh093.wpt
+++ b/hwy_data/OH/usaoh/oh.oh093.wpt
@@ -30,7 +30,7 @@ OH139 http://www.openstreetmap.org/?lat=39.051927&lon=-82.636848
 BriSt http://www.openstreetmap.org/?lat=39.054460&lon=-82.640238
 US35Bus_S http://www.openstreetmap.org/?lat=39.055334&lon=-82.639203
 OH788_S http://www.openstreetmap.org/?lat=39.056701&lon=-82.638168
-ChiSt http://www.openstreetmap.org/?lat=39.059304&lon=-82.638651
+US35Bus_N +ChiSt http://www.openstreetmap.org/?lat=39.059245&lon=-82.638733
 US35 http://www.openstreetmap.org/?lat=39.072545&lon=-82.628571
 +x70 http://www.openstreetmap.org/?lat=39.095609&lon=-82.612526
 MainSt_Coa http://www.openstreetmap.org/?lat=39.113688&lon=-82.611319

--- a/hwy_data/OH/usaus/oh.us035.wpt
+++ b/hwy_data/OH/usaus/oh.us035.wpt
@@ -12,9 +12,9 @@ OH279 http://www.openstreetmap.org/?lat=38.895768&lon=-82.438252
 +x20 http://www.openstreetmap.org/?lat=38.949979&lon=-82.479746
 OH327 http://www.openstreetmap.org/?lat=38.993122&lon=-82.540970
 OH32 http://www.openstreetmap.org/?lat=39.045519&lon=-82.612939
-US35BusJac http://www.openstreetmap.org/?lat=39.052943&lon=-82.618271
-US35Bus/93 http://www.openstreetmap.org/?lat=39.072545&lon=-82.628571
-ChiPk http://www.openstreetmap.org/?lat=39.095139&lon=-82.659105
+US35BusJac_S http://www.openstreetmap.org/?lat=39.052943&lon=-82.618271
+OH93 http://www.openstreetmap.org/?lat=39.072545&lon=-82.628571
+US35BusJac_N http://www.openstreetmap.org/?lat=39.095139&lon=-82.659105
 SourRunRd http://www.openstreetmap.org/?lat=39.129929&lon=-82.702568
 SavRd http://www.openstreetmap.org/?lat=39.142033&lon=-82.724556
 +x30 http://www.openstreetmap.org/?lat=39.182882&lon=-82.753052

--- a/hwy_data/OH/usausb/oh.us035busjac.wpt
+++ b/hwy_data/OH/usausb/oh.us035busjac.wpt
@@ -2,5 +2,5 @@ US35_S http://www.openstreetmap.org/?lat=39.052943&lon=-82.618271
 WatSt http://www.openstreetmap.org/?lat=39.052793&lon=-82.635866
 OH93_S http://www.openstreetmap.org/?lat=39.055334&lon=-82.639203
 OH788_S http://www.openstreetmap.org/?lat=39.056701&lon=-82.638168
-ChiSt http://www.openstreetmap.org/?lat=39.059304&lon=-82.638651
-US35_N http://www.openstreetmap.org/?lat=39.072545&lon=-82.628571
+OH93_N http://www.openstreetmap.org/?lat=39.059245&lon=-82.638733
+US35_N http://www.openstreetmap.org/?lat=39.095139&lon=-82.659105

--- a/hwy_data/OH/usausb/oh.us035busjac.wpt
+++ b/hwy_data/OH/usausb/oh.us035busjac.wpt
@@ -1,6 +1,6 @@
 US35_S http://www.openstreetmap.org/?lat=39.052943&lon=-82.618271
 WatSt http://www.openstreetmap.org/?lat=39.052793&lon=-82.635866
 OH93_S http://www.openstreetmap.org/?lat=39.055334&lon=-82.639203
-OH788_S http://www.openstreetmap.org/?lat=39.056701&lon=-82.638168
+OH788 http://www.openstreetmap.org/?lat=39.056701&lon=-82.638168
 OH93_N http://www.openstreetmap.org/?lat=39.059245&lon=-82.638733
 US35_N http://www.openstreetmap.org/?lat=39.095139&lon=-82.659105


### PR DESCRIPTION
Newsworthy:

2016-02-01;(USA) Ohio;US 35 Business (Jackson);oh.us035busjac;Removed from Morton St between Chillicothe St and US-35, and relocated onto Chillicothe St and Chillicothe Pike between Morton St and US 35