### PR TITLE
TN: US-64 overhaul P1

### DIFF
--- a/hwy_data/TN/usaus/tn.us064.wpt
+++ b/hwy_data/TN/usaus/tn.us064.wpt
@@ -1,11 +1,11 @@
 AR/TN http://www.openstreetmap.org/?lat=35.128262&lon=-90.076736
-I-55(12C) http://www.openstreetmap.org/?lat=35.125099&lon=-90.072500&zoom=15
-I-55(12A) http://www.openstreetmap.org/?lat=35.124761&lon=-90.067055&zoom=15
+I-55(12C) http://www.openstreetmap.org/?lat=35.125099&lon=-90.072500
+I-55(12A) http://www.openstreetmap.org/?lat=35.124761&lon=-90.067055
 US61_S http://www.openstreetmap.org/?lat=35.124586&lon=-90.054910
 US78 http://www.openstreetmap.org/?lat=35.137870&lon=-90.053741
 UniAve_W http://www.openstreetmap.org/?lat=35.142713&lon=-90.051697
 US51_N http://www.openstreetmap.org/?lat=35.141038&lon=-90.045447
-I-240(30) http://www.openstreetmap.org/?lat=35.137594&lon=-90.024172&zoom=15
+I-240(30) http://www.openstreetmap.org/?lat=35.137594&lon=-90.024172
 US51_S http://www.openstreetmap.org/?lat=35.137239&lon=-90.020599
 US72_E http://www.openstreetmap.org/?lat=35.133554&lon=-89.983714
 TNs57 +TNs57_E http://www.openstreetmap.org/?lat=35.140485&lon=-89.982909
@@ -14,27 +14,35 @@ NorPkwy +TNs1/57_W http://www.openstreetmap.org/?lat=35.151021&lon=-89.981246
 HigSt +NHigSt http://www.openstreetmap.org/?lat=35.149477&lon=-89.944510
 GraSt +NGraSt http://www.openstreetmap.org/?lat=35.149135&lon=-89.928020
 PerRd http://www.openstreetmap.org/?lat=35.148705&lon=-89.907818
-I-40(12A) http://www.openstreetmap.org/?lat=35.153806&lon=-89.887809&zoom=15
+I-40(12A) http://www.openstreetmap.org/?lat=35.153806&lon=-89.887809
 SycViewRd http://www.openstreetmap.org/?lat=35.172010&lon=-89.868432
 RalLagRd http://www.openstreetmap.org/?lat=35.180798&lon=-89.859527
 US70/79_E http://www.openstreetmap.org/?lat=35.205400&lon=-89.834486
 AppRd http://www.openstreetmap.org/?lat=35.204707&lon=-89.814713
 TNs177 http://www.openstreetmap.org/?lat=35.204488&lon=-89.792032
-I-40(18) http://www.openstreetmap.org/?lat=35.204330&lon=-89.772356&zoom=15
+I-40(18) http://www.openstreetmap.org/?lat=35.204330&lon=-89.772356
 CanRd http://www.openstreetmap.org/?lat=35.205663&lon=-89.732766
 TN385 http://www.openstreetmap.org/?lat=35.210059&lon=-89.654344
 TNs205 http://www.openstreetmap.org/?lat=35.210064&lon=-89.650626
-TNs196_N http://www.openstreetmap.org/?lat=35.224850&lon=-89.586575
-TNs196_S http://www.openstreetmap.org/?lat=35.225297&lon=-89.583378
+TNs196 http://www.openstreetmap.org/?lat=35.224850&lon=-89.586575
+OldSR196 http://www.openstreetmap.org/?lat=35.225297&lon=-89.583378
 TNs194 http://www.openstreetmap.org/?lat=35.228899&lon=-89.515110
+WarRd http://www.openstreetmap.org/?lat=35.233360&lon=-89.442959
 TN76 http://www.openstreetmap.org/?lat=35.243586&lon=-89.349908
-TNs15_E http://www.openstreetmap.org/?lat=35.318084&lon=-89.163666
-TNs179 http://www.openstreetmap.org/?lat=35.318785&lon=-89.152465
-TNs15_W http://www.openstreetmap.org/?lat=35.319923&lon=-89.134097
-TN100_E http://www.openstreetmap.org/?lat=35.319310&lon=-89.131007
-TN18_S http://www.openstreetmap.org/?lat=35.256483&lon=-88.999890
++X000(US64) http://www.openstreetmap.org/?lat=35.247275&lon=-89.302100
+LacRd http://www.openstreetmap.org/?lat=35.281050&lon=-89.251288
+US64BusWhi_W http://www.openstreetmap.org/?lat=35.318084&lon=-89.163666
+TNs179 http://www.openstreetmap.org/?lat=35.318789&lon=-89.152427
+US64BusWhi_E http://www.openstreetmap.org/?lat=35.319901&lon=-89.134097
+TN100 +TN100_E http://www.openstreetmap.org/?lat=35.319292&lon=-89.130996
+OldHwy64_W http://www.openstreetmap.org/?lat=35.304418&lon=-89.121845
+VilRd http://www.openstreetmap.org/?lat=35.287561&lon=-89.037291
+OldHwy64_E http://www.openstreetmap.org/?lat=35.278164&lon=-89.024953
+TN18_S http://www.openstreetmap.org/?lat=35.256487&lon=-89.000088
 TN18/125 +TN18/125_N http://www.openstreetmap.org/?lat=35.256159&lon=-88.987831
-TNs225 http://www.openstreetmap.org/?lat=35.213885&lon=-88.747795
+MitSt http://www.openstreetmap.org/?lat=35.224684&lon=-88.837278
+MainSt http://www.openstreetmap.org/?lat=35.223369&lon=-88.826716
+TNs225 http://www.openstreetmap.org/?lat=35.213526&lon=-88.747838
 US45/64Bus_N +US45_N http://www.openstreetmap.org/?lat=35.182670&lon=-88.614510
 NewBelRd http://www.openstreetmap.org/?lat=35.169669&lon=-88.613266
 +X001(US45) http://www.openstreetmap.org/?lat=35.156683&lon=-88.610079
@@ -75,7 +83,7 @@ TN11 http://www.openstreetmap.org/?lat=35.170923&lon=-87.054945
 TNs166_S http://www.openstreetmap.org/?lat=35.170274&lon=-87.051491
 US31 http://www.openstreetmap.org/?lat=35.170055&lon=-87.015646
 EColSt http://www.openstreetmap.org/?lat=35.176544&lon=-86.986967
-I-65(14) http://www.openstreetmap.org/?lat=35.193521&lon=-86.870849&zoom=15
+I-65(14) http://www.openstreetmap.org/?lat=35.193521&lon=-86.870849
 McBRd_W http://www.openstreetmap.org/?lat=35.190250&lon=-86.859713
 McBRd_E http://www.openstreetmap.org/?lat=35.191706&lon=-86.802013
 TNs244 http://www.openstreetmap.org/?lat=35.205908&lon=-86.723928
@@ -95,17 +103,17 @@ US64BusWin_W http://www.openstreetmap.org/?lat=35.166555&lon=-86.131815
 TN16 http://www.openstreetmap.org/?lat=35.167362&lon=-86.127126
 US41A/64BusWin_E http://www.openstreetmap.org/?lat=35.170423&lon=-86.070274
 TN50_W http://www.openstreetmap.org/?lat=35.228032&lon=-86.047711
-I-24(127) http://www.openstreetmap.org/?lat=35.300153&lon=-85.903087&zoom=15
-+X005(I24) http://www.openstreetmap.org/?lat=35.258801&lon=-85.874285&zoom=15
-+X006(I24) http://www.openstreetmap.org/?lat=35.239122&lon=-85.876259&zoom=15
-I-24(134) http://www.openstreetmap.org/?lat=35.240270&lon=-85.847780&zoom=15
-I-24(135) http://www.openstreetmap.org/?lat=35.231038&lon=-85.826933&zoom=15
-+X007(I24) http://www.openstreetmap.org/?lat=35.221713&lon=-85.811677&zoom=15
-+X008(I24) http://www.openstreetmap.org/?lat=35.173633&lon=-85.796099&zoom=15
-I-24(143) http://www.openstreetmap.org/?lat=35.146034&lon=-85.775059&zoom=15
-+X009(I24) http://www.openstreetmap.org/?lat=35.100310&lon=-85.737691&zoom=15
-+X010(I24) http://www.openstreetmap.org/?lat=35.072243&lon=-85.734783&zoom=15
-I-24(152) http://www.openstreetmap.org/?lat=35.040125&lon=-85.690543&zoom=15
+I-24(127) http://www.openstreetmap.org/?lat=35.300153&lon=-85.903087
++X005(I24) http://www.openstreetmap.org/?lat=35.258801&lon=-85.874285
++X006(I24) http://www.openstreetmap.org/?lat=35.239122&lon=-85.876259
+I-24(134) http://www.openstreetmap.org/?lat=35.240270&lon=-85.847780
+I-24(135) http://www.openstreetmap.org/?lat=35.231038&lon=-85.826933
++X007(I24) http://www.openstreetmap.org/?lat=35.221713&lon=-85.811677
++X008(I24) http://www.openstreetmap.org/?lat=35.173633&lon=-85.796099
+I-24(143) http://www.openstreetmap.org/?lat=35.146034&lon=-85.775059
++X009(I24) http://www.openstreetmap.org/?lat=35.100310&lon=-85.737691
++X010(I24) http://www.openstreetmap.org/?lat=35.072243&lon=-85.734783
+I-24(152) http://www.openstreetmap.org/?lat=35.040125&lon=-85.690543
 TNs2Kim_W http://www.openstreetmap.org/?lat=35.042848&lon=-85.687394
 US41_N http://www.openstreetmap.org/?lat=35.074034&lon=-85.625725
 TN28 http://www.openstreetmap.org/?lat=35.072199&lon=-85.614545

--- a/hwy_data/TN/usausb/tn.us064buswhi.wpt
+++ b/hwy_data/TN/usausb/tn.us064buswhi.wpt
@@ -1,0 +1,5 @@
+US64_W http://www.openstreetmap.org/?lat=35.318084&lon=-89.163666
+TNs179_E http://www.openstreetmap.org/?lat=35.325678&lon=-89.151810
+TNs179_W http://www.openstreetmap.org/?lat=35.326164&lon=-89.150882
+BassAve http://www.openstreetmap.org/?lat=35.326068&lon=-89.143324
+US64_E http://www.openstreetmap.org/?lat=35.319901&lon=-89.134097

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -498,6 +498,7 @@ usausb;AR;US64;Bus;Par;Parkin, AR;ar.us064buspar;
 usausb;AR;US64;Bus;Ear;Earle, AR;ar.us064busear;
 usausb;AR;US64;Bus;Cra;Crawfordsville, AR;ar.us064buscra;
 usausb;AR;US64;Spr;Wyn;Wynne, AR;ar.us064sprwyn;
+usausb;TN;US64;Bus;Whiteville, TN;tn.us064buswhi;
 usausb;TN;US64;Bus;Sel;Selmer, TN;tn.us064bussel;
 usausb;TN;US64;Bus;Way;Waynesboro, TN;tn.us064busway;
 usausb;TN;US64;Bus;Fay;Fayetteville, TN;tn.us064busfay;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -490,6 +490,7 @@ usausb;US64;Bus;Parkin, AR;ar.us064buspar
 usausb;US64;Bus;Earle, AR;ar.us064busear
 usausb;US64;Bus;Crawfordsville, AR;ar.us064buscra
 usausb;US64;Spr;Wynne, AR;ar.us064sprwyn
+usausb;US64;Bus;Whiteville, TN;tn.us064buswhi
 usausb;US64;Bus;Selmer, TN;tn.us064bussel
 usausb;US64;Bus;Waynesboro, TN;tn.us064busway
 usausb;US64;Bus;Fayetteville, TN;tn.us064busfay


### PR DESCRIPTION
This is just part 1.  I decided not to wait till I had finished the route (might take a few days) since I noticed there are _several_ realignments for it that I've missed, & that sticking them all in one update entry log would be completely overkill (I think there's 4+ more than the one mentioned below) and confusing to the end user.  Plus I discovered a missing posted Business route for US-64, and wanted to get it online quickly as well.

Even better news? Eliminates 2 datacheck errors automatically. :)

Update log info:
2016-02-14;(USA) Tennessee;US 64;tn.us064;Removed from old two-lane through Hornsby (now Mitchell Street & Main Street), and moved onto a new 4-lane alignment to the south between the intersections with Mitchell Street (MitSt) & Main Street (MainSt).
2016-02-14;(USA) Tennessee;US 64 Business (Whiteville);tn.us064buswhi;Route added