### PR TITLE
NC changes from mapmikey #2

### DIFF
--- a/hwy_data/NC/usanc/nc.nc042.wpt
+++ b/hwy_data/NC/usanc/nc.nc042.wpt
@@ -18,9 +18,9 @@ TemChuRd http://www.openstreetmap.org/?lat=35.491401&lon=-79.254647
 +x30 http://www.openstreetmap.org/?lat=35.476680&lon=-79.244455
 US1/15 http://www.openstreetmap.org/?lat=35.468604&lon=-79.202939
 OldUS1 http://www.openstreetmap.org/?lat=35.474096&lon=-79.187771
-US421_W http://www.openstreetmap.org/?lat=35.479910&lon=-79.180473
-US421_E http://www.openstreetmap.org/?lat=35.459569&lon=-79.145701
-SanByp http://www.openstreetmap.org/?lat=35.460500&lon=-79.118257
+US421Bus_N +US421_W http://www.openstreetmap.org/?lat=35.479910&lon=-79.180473
+US421Bus_S +US421_E http://www.openstreetmap.org/?lat=35.459569&lon=-79.145701
+US421/87Byp +SanByp http://www.openstreetmap.org/?lat=35.460513&lon=-79.118364
 BroRd http://www.openstreetmap.org/?lat=35.463637&lon=-79.096552
 +x40 http://www.openstreetmap.org/?lat=35.503607&lon=-79.050901
 PopSprRd http://www.openstreetmap.org/?lat=35.535389&lon=-79.039899

--- a/hwy_data/NC/usanc/nc.nc078.wpt
+++ b/hwy_data/NC/usanc/nc.nc078.wpt
@@ -1,3 +1,3 @@
 US1 http://www.openstreetmap.org/?lat=35.437011&lon=-79.218614
 +x1 http://www.openstreetmap.org/?lat=35.436879&lon=-79.191218
-US421 http://www.openstreetmap.org/?lat=35.459569&lon=-79.145701
+US421Bus +US421 http://www.openstreetmap.org/?lat=35.459569&lon=-79.145701

--- a/hwy_data/NC/usanc/nc.nc087.wpt
+++ b/hwy_data/NC/usanc/nc.nc087.wpt
@@ -54,13 +54,13 @@ NC24_N http://www.openstreetmap.org/?lat=35.269681&lon=-79.060160
 NC27 http://www.openstreetmap.org/?lat=35.308795&lon=-79.086703
 GraRd http://www.openstreetmap.org/?lat=35.351578&lon=-79.108735
 SwaStaRd http://www.openstreetmap.org/?lat=35.380931&lon=-79.109212
-SanByp_S http://www.openstreetmap.org/?lat=35.430935&lon=-79.122940
-US421_S http://www.openstreetmap.org/?lat=35.449143&lon=-79.132172
+NC87BypSan +SanByp_S http://www.openstreetmap.org/?lat=35.430935&lon=-79.122940
+US421Bus_S +US421_S http://www.openstreetmap.org/?lat=35.449143&lon=-79.132172
 NC42/78 http://www.openstreetmap.org/?lat=35.459569&lon=-79.145701
 US1Bus/42 http://www.openstreetmap.org/?lat=35.479910&lon=-79.180473
-US421_N http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
+US421Bus_N +US421_N http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
 BurDrv http://www.openstreetmap.org/?lat=35.502867&lon=-79.191052
-SanByp_N http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
+US421/87Byp +SanByp_N http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
 US1_N http://www.openstreetmap.org/?lat=35.523259&lon=-79.183660
 +x90 http://www.openstreetmap.org/?lat=35.616251&lon=-79.192924
 JoeWomRd http://www.openstreetmap.org/?lat=35.655965&lon=-79.175870

--- a/hwy_data/NC/usanc/nc.nc087bypsan
+++ b/hwy_data/NC/usanc/nc.nc087bypsan
@@ -1,0 +1,7 @@
+NC87_S +SanByp_S http://www.openstreetmap.org/?lat=35.430935&lon=-79.122940
+US421(143) http://www.openstreetmap.org/?lat=35.446976&lon=-79.119297
+US421(144) http://www.openstreetmap.org/?lat=35.460513&lon=-79.118364
+US421(145) http://www.openstreetmap.org/?lat=35.483482&lon=-79.133527
++X01 http://www.openstreetmap.org/?lat=35.500656&lon=-79.147602
+US421(148) http://www.openstreetmap.org/?lat=35.507364&lon=-79.168287
+US421(149) http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037

--- a/hwy_data/NC/usanc/nc.nc211.wpt
+++ b/hwy_data/NC/usanc/nc.nc211.wpt
@@ -6,7 +6,7 @@ NC87 http://www.openstreetmap.org/?lat=33.938821&lon=-78.026474
 NC133_N http://www.openstreetmap.org/?lat=33.948193&lon=-78.034977
 NC133_S http://www.openstreetmap.org/?lat=33.952260&lon=-78.047862
 StJamDr http://www.openstreetmap.org/?lat=33.961985&lon=-78.088508
-NC906 *MidRd http://www.openstreetmap.org/?lat=33.972042&lon=-78.130506
+NC906 +MidRd http://www.openstreetmap.org/?lat=33.972042&lon=-78.130506
 SunHarRd http://www.openstreetmap.org/?lat=33.985892&lon=-78.188667
 +x1 http://www.openstreetmap.org/?lat=34.002555&lon=-78.258501
 US17 http://www.openstreetmap.org/?lat=34.017211&lon=-78.273200

--- a/hwy_data/NC/usaus/nc.us001.wpt
+++ b/hwy_data/NC/usaus/nc.us001.wpt
@@ -29,9 +29,9 @@ US15/501Car http://www.openstreetmap.org/?lat=35.404460&lon=-79.231435
 NC78 http://www.openstreetmap.org/?lat=35.437011&lon=-79.218614
 US1Bus/42 http://www.openstreetmap.org/?lat=35.468604&lon=-79.202939
 SprLane http://www.openstreetmap.org/?lat=35.487397&lon=-79.197178
-US421/87 http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
+US421Bus/87 +US421/87 http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
 BurDrv http://www.openstreetmap.org/?lat=35.502867&lon=-79.191052
-SanByp http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
+US421/87Byp +SanByp http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
 US15/501San http://www.openstreetmap.org/?lat=35.523259&lon=-79.183660
 ColRd http://www.openstreetmap.org/?lat=35.561208&lon=-79.153082
 FarRd http://www.openstreetmap.org/?lat=35.587815&lon=-79.121937

--- a/hwy_data/NC/usaus/nc.us015.wpt
+++ b/hwy_data/NC/usaus/nc.us015.wpt
@@ -21,9 +21,9 @@ US1Tra_S http://www.openstreetmap.org/?lat=35.404460&lon=-79.231435
 NC78 http://www.openstreetmap.org/?lat=35.437011&lon=-79.218614
 US1Bus/42 http://www.openstreetmap.org/?lat=35.468604&lon=-79.202939
 SprLane http://www.openstreetmap.org/?lat=35.487397&lon=-79.197178
-US421/87 http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
+US421Bus/87 +US421/87 http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
 BurDrv http://www.openstreetmap.org/?lat=35.502867&lon=-79.191052
-SanByp http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
+US421/87Byp +SanByp http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
 US1San_N http://www.openstreetmap.org/?lat=35.523259&lon=-79.183660
 +x10 http://www.openstreetmap.org/?lat=35.616251&lon=-79.192924
 JoeWomRd http://www.openstreetmap.org/?lat=35.655965&lon=-79.175870

--- a/hwy_data/NC/usaus/nc.us421.wpt
+++ b/hwy_data/NC/usaus/nc.us421.wpt
@@ -46,12 +46,13 @@ US401/210_S +US401_S/210 http://www.openstreetmap.org/?lat=35.398732&lon=-78.816
 LuaDr http://www.openstreetmap.org/?lat=35.418479&lon=-78.879856
 RavRockRd http://www.openstreetmap.org/?lat=35.418120&lon=-78.920519
 SemRd http://www.openstreetmap.org/?lat=35.438228&lon=-79.036208
-SanByp http://www.openstreetmap.org/?lat=35.446792&lon=-79.119077
-NC87 http://www.openstreetmap.org/?lat=35.449143&lon=-79.132172
-NC42/78 http://www.openstreetmap.org/?lat=35.459569&lon=-79.145701
-US1Bus/42 http://www.openstreetmap.org/?lat=35.479910&lon=-79.180473
-US1/15 http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
-CurRd http://www.openstreetmap.org/?lat=35.539527&lon=-79.241037
+143 +SanByp http://www.openstreetmap.org/?lat=35.446792&lon=-79.119077
+144 http://www.openstreetmap.org/?lat=35.460513&lon=-79.118364
+145 http://www.openstreetmap.org/?lat=35.483482&lon=-79.133527
++X01 http://www.openstreetmap.org/?lat=35.500656&lon=-79.147602
+148 http://www.openstreetmap.org/?lat=35.507364&lon=-79.168287
+149 http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
+US421BusSan_N +CurRd http://www.openstreetmap.org/?lat=35.540714&lon=-79.240865
 PlaRd http://www.openstreetmap.org/?lat=35.556418&lon=-79.286029
 +x20 http://www.openstreetmap.org/?lat=35.574493&lon=-79.308978
 PitGolRd http://www.openstreetmap.org/?lat=35.603080&lon=-79.321670

--- a/hwy_data/NC/usaus/nc.us501.wpt
+++ b/hwy_data/NC/usaus/nc.us501.wpt
@@ -29,9 +29,9 @@ US1Tra_S http://www.openstreetmap.org/?lat=35.404460&lon=-79.231435
 NC78 http://www.openstreetmap.org/?lat=35.437011&lon=-79.218614
 US1Bus/42 http://www.openstreetmap.org/?lat=35.468604&lon=-79.202939
 SprLane http://www.openstreetmap.org/?lat=35.487397&lon=-79.197178
-US421/87 http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
+US421Bus/87 +US421/87 http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
 BurDrv http://www.openstreetmap.org/?lat=35.502867&lon=-79.191052
-SanByp http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
+US421/87Byp +SanByp http://www.openstreetmap.org/?lat=35.511190&lon=-79.188037
 US1San_N http://www.openstreetmap.org/?lat=35.523259&lon=-79.183660
 +x10 http://www.openstreetmap.org/?lat=35.616251&lon=-79.192924
 JoeWomRd http://www.openstreetmap.org/?lat=35.655965&lon=-79.175870

--- a/hwy_data/NC/usausb/nc.us001bussan.wpt
+++ b/hwy_data/NC/usausb/nc.us001bussan.wpt
@@ -1,6 +1,6 @@
 US1_S http://www.openstreetmap.org/?lat=35.468604&lon=-79.202939
 OldUS1 http://www.openstreetmap.org/?lat=35.474096&lon=-79.187771
-US421 http://www.openstreetmap.org/?lat=35.479910&lon=-79.180473
+US421Bus +US421 http://www.openstreetmap.org/?lat=35.479910&lon=-79.180473
 ChaAve http://www.openstreetmap.org/?lat=35.481717&lon=-79.177549
 BurDr http://www.openstreetmap.org/?lat=35.501151&lon=-79.179341
 SR1405 http://www.openstreetmap.org/?lat=35.507688&lon=-79.178810

--- a/hwy_data/NC/usausb/nc.us421bussan
+++ b/hwy_data/NC/usausb/nc.us421bussan
@@ -1,0 +1,6 @@
+US421_S http://www.openstreetmap.org/?lat=35.446792&lon=-79.119077
+NC87 http://www.openstreetmap.org/?lat=35.449143&lon=-79.132172
+NC42/78 http://www.openstreetmap.org/?lat=35.459569&lon=-79.145701
+US1Bus/42 http://www.openstreetmap.org/?lat=35.479910&lon=-79.180473
+US1/15 http://www.openstreetmap.org/?lat=35.495251&lon=-79.195182
+US421_N http://www.openstreetmap.org/?lat=35.539527&lon=-79.241037

--- a/hwy_data/_systems/usanc.csv
+++ b/hwy_data/_systems/usanc.csv
@@ -82,6 +82,7 @@ usanc;NC;NC86;;;;nc.nc086;
 usanc;NC;NC86;Trk;Hil;Hillsborough;nc.nc086trkhil;
 usanc;NC;NC87;;;;nc.nc087;
 usanc;NC;NC87;Bus;Eli;Elizabethtown;nc.nc087buseli;
+usanc;NC;NC87;Byp;San;Sanford;nc.nc087bypsan;
 usanc;NC;NC88;;;;nc.nc088;
 usanc;NC;NC89;;;;nc.nc089;
 usanc;NC;NC90;;;;nc.nc090;

--- a/hwy_data/_systems/usanc_con.csv
+++ b/hwy_data/_systems/usanc_con.csv
@@ -82,6 +82,7 @@ usanc;NC86;;;nc.nc086
 usanc;NC86;Trk;Hillsborough;nc.nc086trkhil
 usanc;NC87;;;nc.nc087
 usanc;NC87;Bus;Elizabethtown;nc.nc087buseli
+usanc;NC87;Byp;Sanford;nc.nc087bypsan;
 usanc;NC88;;;nc.nc088
 usanc;NC89;;;nc.nc089
 usanc;NC90;;;nc.nc090

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -1044,6 +1044,7 @@ usausb;AR;US412;Byp;Par;Paragould, AR;ar.us412byppar;
 usausb;TN;US412;Bus;Jac;Jackson, TN;tn.us412busjac;
 usausb;TN;US412;Bus;Col;Columbia, TN;tn.us412buscol;
 usausb;NC;US421;Bus;Wil;Wilkesboro, NC;nc.us421buswil;
+usausb;NC;US421;Bus;San;Sanford, NC;nc.us421bussan;
 usausb;NC;US421;Trk;Wlm;Wilmington, NC;nc.us421trkwlm;
 usausb;NC;US421;Trk;Boo;Boone, NC;nc.us421trkboo;
 usausb;VA;US421;Bus;Gat;Gate City, VA;va.us421busgat;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -1029,6 +1029,7 @@ usausb;US412;Byp;Paragould, AR;ar.us412byppar
 usausb;US412;Bus;Jackson, TN;tn.us412busjac
 usausb;US412;Bus;Columbia, TN;tn.us412buscol
 usausb;US421;Bus;Wilkesboro, NC;nc.us421buswil
+usausb;US421;Bus;Sanford, NC;nc.us421bussan
 usausb;US421;Trk;Wilmington, NC;nc.us421trkwlm
 usausb;US421;Trk;Boone, NC;nc.us421trkboo
 usausb;US421;Bus;Gate City, VA;va.us421busgat


### PR DESCRIPTION
Newsworthy

2016-02-18;(USA) North Carolina;US 421 Bus Sanford;nc.us421bussan;New route
2016-02-18;(USA) North Carolina;US 421;nc.us421;Removed from Boone Trail & Horner Blvd through Sanford (now US421 Bus Sanford) between Exit 143 and US421BusSan_N
2016-02-18;(USA) North Carolina;NC 87 Byp Sanford;nc.nc087bypsan;New route
