### PR TITLE
NS255: relocation & new bridge

### DIFF
--- a/hwy_data/NS/cannsc/ns.ns255.wpt
+++ b/hwy_data/NS/cannsc/ns.ns255.wpt
@@ -4,7 +4,8 @@ BirGroRd http://www.openstreetmap.org/?lat=46.172371&lon=-59.966898
 SandLakeRd http://www.openstreetmap.org/?lat=46.160312&lon=-59.942126
 DonHwy http://www.openstreetmap.org/?lat=46.174364&lon=-59.915748
 LongBeaRd http://www.openstreetmap.org/?lat=46.138801&lon=-59.871273
-+X256640 http://www.openstreetmap.org/?lat=46.101901&lon=-59.908496
+*OldNS255_N http://www.openstreetmap.org/?lat=46.107851&lon=-59.907482
+*OldNS255_S http://www.openstreetmap.org/?lat=46.104921&lon=-59.908576
 SouHeadRd http://www.openstreetmap.org/?lat=46.083721&lon=-59.898290
 +X680549 http://www.openstreetmap.org/?lat=46.065602&lon=-59.899086
 +X761631 http://www.openstreetmap.org/?lat=46.046087&lon=-59.960176

--- a/hwy_data/NS/cannss/ns.martrl.wpt
+++ b/hwy_data/NS/cannss/ns.martrl.wpt
@@ -7,7 +7,8 @@ NS255_PCa http://www.openstreetmap.org/?lat=46.174364&lon=-59.915748
 SouSt_Don http://www.openstreetmap.org/?lat=46.181634&lon=-59.874789
 SchPondRd http://www.openstreetmap.org/?lat=46.177923&lon=-59.847503
 NS255_PMo http://www.openstreetmap.org/?lat=46.138801&lon=-59.871273
-+X256640 http://www.openstreetmap.org/?lat=46.101901&lon=-59.908496
+*OldNS255_N http://www.openstreetmap.org/?lat=46.107851&lon=-59.907482
+*OldNS255_S http://www.openstreetmap.org/?lat=46.104921&lon=-59.908576
 SouHeadRd http://www.openstreetmap.org/?lat=46.083721&lon=-59.898290
 +X680549 http://www.openstreetmap.org/?lat=46.065602&lon=-59.899086
 +X761631 http://www.openstreetmap.org/?lat=46.046087&lon=-59.960176


### PR DESCRIPTION
2016-02-27;(Canada) Nova Scotia;NS 255;ns.ns255;Removed from a closed roadway and demolished bridge, and relocated onto a new parallel roadway and bridge to the east between points labeled *OldNS255_N and *OldNS255_S.

--

Better off merging #453 first, as that contains changes to updates.csv.