### PR TITLE
Windham NH

### DIFF
--- a/hwy_data/NH/usai/nh.i093.wpt
+++ b/hwy_data/NH/usai/nh.i093.wpt
@@ -1,8 +1,8 @@
 MA/NH +0 http://www.openstreetmap.org/?lat=42.743324&lon=-71.209648
 1 http://www.openstreetmap.org/?lat=42.761255&lon=-71.233764
 2 http://www.openstreetmap.org/?lat=42.777385&lon=-71.244793
-+x2a http://www.openstreetmap.org/?lat=42.788274&lon=-71.267989
-3 http://www.openstreetmap.org/?lat=42.808594&lon=-71.270070
+*OldI-93 http://www.openstreetmap.org/?lat=42.785865&lon=-71.264878
+3 http://www.openstreetmap.org/?lat=42.809149&lon=-71.272135
 4 http://www.openstreetmap.org/?lat=42.869988&lon=-71.340837
 5 http://www.openstreetmap.org/?lat=42.916458&lon=-71.371479
 +x5b http://www.openstreetmap.org/?lat=42.941390&lon=-71.386671
@@ -20,7 +20,7 @@ MA/NH +0 http://www.openstreetmap.org/?lat=42.743324&lon=-71.209648
 12 http://www.openstreetmap.org/?lat=43.179676&lon=-71.531081
 13 http://www.openstreetmap.org/?lat=43.193382&lon=-71.526146
 14 http://www.openstreetmap.org/?lat=43.208742&lon=-71.533012
-15 http://www.openstreetmap.org/?lat=43.216521&lon=-71.533796&zoom=15
+15 http://www.openstreetmap.org/?lat=43.216521&lon=-71.533796
 16 http://www.openstreetmap.org/?lat=43.236796&lon=-71.538962
 17 http://www.openstreetmap.org/?lat=43.291756&lon=-71.572913
 +x17a http://www.openstreetmap.org/?lat=43.319398&lon=-71.590090
@@ -49,7 +49,7 @@ MA/NH +0 http://www.openstreetmap.org/?lat=42.743324&lon=-71.209648
 32 http://www.openstreetmap.org/?lat=44.033678&lon=-71.679568
 33 http://www.openstreetmap.org/?lat=44.062025&lon=-71.687379
 34 http://www.openstreetmap.org/?lat=44.091500&lon=-71.684976
-34A http://www.openstreetmap.org/?lat=44.105890&lon=-71.683484&zoom=15
+34A http://www.openstreetmap.org/?lat=44.105890&lon=-71.683484
 +x34d http://www.openstreetmap.org/?lat=44.164330&lon=-71.676312
 34B http://www.openstreetmap.org/?lat=44.170015&lon=-71.683694
 34C http://www.openstreetmap.org/?lat=44.179218&lon=-71.691841

--- a/hwy_data/NH/usanh/nh.nh016.wpt
+++ b/hwy_data/NH/usanh/nh.nh016.wpt
@@ -1,10 +1,10 @@
 US1Byp http://www.openstreetmap.org/?lat=43.073057&lon=-70.780663
 RocAve http://www.openstreetmap.org/?lat=43.075244&lon=-70.783775
-I-95 http://www.openstreetmap.org/?lat=43.079515&lon=-70.789225
+I-95 http://www.openstreetmap.org/?lat=43.078974&lon=-70.789128
 BraDr http://www.openstreetmap.org/?lat=43.084828&lon=-70.795362
 1 http://www.openstreetmap.org/?lat=43.090657&lon=-70.802357
-2 http://www.openstreetmap.org/?lat=43.100389&lon=-70.810758
-3 http://www.openstreetmap.org/?lat=43.106278&lon=-70.813751
+*2 http://www.openstreetmap.org/?lat=43.100411&lon=-70.811048
+3 http://www.openstreetmap.org/?lat=43.104496&lon=-70.813397
 4 http://www.openstreetmap.org/?lat=43.113234&lon=-70.819663
 5 http://www.openstreetmap.org/?lat=43.123054&lon=-70.831110
 6 http://www.openstreetmap.org/?lat=43.130900&lon=-70.838900

--- a/hwy_data/NH/usanh/nh.nh111.wpt
+++ b/hwy_data/NH/usanh/nh.nh111.wpt
@@ -17,9 +17,9 @@ SulRd http://www.openstreetmap.org/?lat=42.791179&lon=-71.368636
 NH128 http://www.openstreetmap.org/?lat=42.802576&lon=-71.351883
 LowRd_S http://www.openstreetmap.org/?lat=42.801010&lon=-71.304217
 LowRd_N http://www.openstreetmap.org/?lat=42.804469&lon=-71.299703
-I-93 http://www.openstreetmap.org/?lat=42.808594&lon=-71.270070
+EntDr http://www.openstreetmap.org/?lat=42.806967&lon=-71.287125
+I-93 http://www.openstreetmap.org/?lat=42.809149&lon=-71.272135
 NH111A_Win http://www.openstreetmap.org/?lat=42.806634&lon=-71.262158
-RanRd http://www.openstreetmap.org/?lat=42.809711&lon=-71.255323
 NH28 http://www.openstreetmap.org/?lat=42.812285&lon=-71.248843
 ZacCroRd http://www.openstreetmap.org/?lat=42.835731&lon=-71.231242
 IslPondRd http://www.openstreetmap.org/?lat=42.852060&lon=-71.216673

--- a/hwy_data/NH/usaus/nh.us004.wpt
+++ b/hwy_data/NH/usaus/nh.us004.wpt
@@ -41,13 +41,13 @@ US3_S http://www.openstreetmap.org/?lat=43.304663&lon=-71.608855
 EastSt http://www.openstreetmap.org/?lat=43.291350&lon=-71.595229
 I-93(17) http://www.openstreetmap.org/?lat=43.291756&lon=-71.572913
 I-93(16) http://www.openstreetmap.org/?lat=43.236796&lon=-71.538962
-I-93(15) http://www.openstreetmap.org/?lat=43.216521&lon=-71.533796&zoom=15
-I-393(1) http://www.openstreetmap.org/?lat=43.219048&lon=-71.524912&zoom=15
-I-393(2) http://www.openstreetmap.org/?lat=43.224080&lon=-71.507398&zoom=15
+I-93(15) http://www.openstreetmap.org/?lat=43.216521&lon=-71.533796
+I-393(1) http://www.openstreetmap.org/?lat=43.219048&lon=-71.524912
+I-393(2) http://www.openstreetmap.org/?lat=43.224080&lon=-71.507398
 +x393(2a) http://www.openstreetmap.org/?lat=43.235205&lon=-71.478102
 I-393(3) http://www.openstreetmap.org/?lat=43.234948&lon=-71.470313
 +x393(3a) http://www.openstreetmap.org/?lat=43.235319&lon=-71.462556
-I-393/9 I-393_E http://www.openstreetmap.org/?lat=43.241324&lon=-71.457159&zoom=15
+I-393/9 +I-393_E http://www.openstreetmap.org/?lat=43.241324&lon=-71.457159
 KingRd http://www.openstreetmap.org/?lat=43.248090&lon=-71.415671
 MainSt_Chi http://www.openstreetmap.org/?lat=43.243903&lon=-71.404427
 NH28 http://www.openstreetmap.org/?lat=43.227913&lon=-71.360579
@@ -70,10 +70,10 @@ NH108 http://www.openstreetmap.org/?lat=43.138495&lon=-70.911126
 NH16_N http://www.openstreetmap.org/?lat=43.130900&lon=-70.838900
 HilDr http://www.openstreetmap.org/?lat=43.123054&lon=-70.831110
 RivRd http://www.openstreetmap.org/?lat=43.113234&lon=-70.819663
-WooAve http://www.openstreetmap.org/?lat=43.106278&lon=-70.813751
-FoxRunRd http://www.openstreetmap.org/?lat=43.100389&lon=-70.810758
+WooAve http://www.openstreetmap.org/?lat=43.104496&lon=-70.813397
+*FoxRunRd http://www.openstreetmap.org/?lat=43.100411&lon=-70.811048
 PeaBlvd http://www.openstreetmap.org/?lat=43.090657&lon=-70.802357
 BraDr http://www.openstreetmap.org/?lat=43.084828&lon=-70.795362
-I-95 http://www.openstreetmap.org/?lat=43.079515&lon=-70.789225
+I-95 http://www.openstreetmap.org/?lat=43.078974&lon=-70.789128
 RocAve http://www.openstreetmap.org/?lat=43.075244&lon=-70.783775
 US1Byp http://www.openstreetmap.org/?lat=43.073057&lon=-70.780663


### PR DESCRIPTION
2016-03-17;(USA) New Hampshire;I-93;nh.i093;Northbound roadway relocated approximately 0.2 mi westward immediately parallel to southbound roadway, between a point south of Exit 3 (labeled *OldI-93) and Exit 3. Southbound roadway unaffected.
2016-03-17;(USA) New Hampshire;NH 111;nh.nh111;Removed from Enterprise Drive and relocated onto Indian Rock Road between Enterprise Drive and I-93.