### PR TITLE
CA US 101 construction-related update

### DIFF
--- a/hwy_data/CA/usaca/ca.ca152.wpt
+++ b/hwy_data/CA/usaca/ca.ca152.wpt
@@ -11,8 +11,8 @@ PoleLineRd http://www.openstreetmap.org/?lat=36.996032&lon=-121.717079
 +x27 http://www.openstreetmap.org/?lat=36.989523&lon=-121.696812
 BlaCanRd http://www.openstreetmap.org/?lat=37.003923&lon=-121.680965
 WatRd http://www.openstreetmap.org/?lat=37.013475&lon=-121.650281
-US101Bus_W http://www.openstreetmap.org/?lat=37.014628&lon=-121.572395
-US101Bus_E http://www.openstreetmap.org/?lat=37.019396&lon=-121.574793
+US101Bus_S http://www.openstreetmap.org/?lat=37.014628&lon=-121.572395
+US101Bus_N http://www.openstreetmap.org/?lat=37.019396&lon=-121.574793
 357(101) http://www.openstreetmap.org/?lat=37.022385&lon=-121.566650
 356(101) http://www.openstreetmap.org/?lat=37.002990&lon=-121.556468
 FraLakeRd http://www.openstreetmap.org/?lat=36.999217&lon=-121.525103
@@ -31,11 +31,11 @@ DinPtRd http://www.openstreetmap.org/?lat=37.066470&lon=-121.219191
 +x57 http://www.openstreetmap.org/?lat=37.104802&lon=-121.130276
 +x58 http://www.openstreetmap.org/?lat=37.086147&lon=-121.110320
 +x61 http://www.openstreetmap.org/?lat=37.056904&lon=-121.041012
-CA33_W http://www.openstreetmap.org/?lat=37.056864&lon=-121.016335
+CA33_N http://www.openstreetmap.org/?lat=37.056864&lon=-121.016335
 I-5 http://www.openstreetmap.org/?lat=37.056680&lon=-120.969826
 CA165 http://www.openstreetmap.org/?lat=37.056913&lon=-120.835393
 BriRd http://www.openstreetmap.org/?lat=37.054406&lon=-120.707967
-CA33_E http://www.openstreetmap.org/?lat=37.050514&lon=-120.635590
+CA33_S http://www.openstreetmap.org/?lat=37.050514&lon=-120.635590
 +x64 http://www.openstreetmap.org/?lat=37.053000&lon=-120.557227
 CA59 http://www.openstreetmap.org/?lat=37.083238&lon=-120.492649
 Rd9 http://www.openstreetmap.org/?lat=37.083366&lon=-120.382712

--- a/hwy_data/CA/usaus/ca.us101.wpt
+++ b/hwy_data/CA/usaus/ca.us101.wpt
@@ -368,9 +368,8 @@ DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 462B http://www.openstreetmap.org/?lat=38.105032&lon=-122.562237
 463 http://www.openstreetmap.org/?lat=38.117690&lon=-122.565108
 OloSPRd http://www.openstreetmap.org/?lat=38.150348&lon=-122.566513
-SanAntRd_N http://www.openstreetmap.org/?lat=38.188023&lon=-122.601006
-GamRd http://www.openstreetmap.org/?lat=38.205210&lon=-122.598292
-472A http://www.openstreetmap.org/?lat=38.223954&lon=-122.612180
+*SanAntRd_N http://www.openstreetmap.org/?lat=38.188023&lon=-122.601006
+472A http://www.openstreetmap.org/?lat=38.220768&lon=-122.607524
 472B +CA116_E http://www.openstreetmap.org/?lat=38.233263&lon=-122.617946
 474 http://www.openstreetmap.org/?lat=38.246834&lon=-122.627694
 476 http://www.openstreetmap.org/?lat=38.272069&lon=-122.669950


### PR DESCRIPTION
Minor updates to CA US 101 due to freeway conversion of segment at Marin-Sonoma county line. 472A (not in use) relocated to new interchange, SanAntRd_N (in use) marked as closed intersection, and GamRd (not in use) removed.

Tweak to in-dev CA 152 comes along for the ride.