### PR TITLE
MA109 extended E from I-95 to VFW Pkwy

### DIFF
--- a/hwy_data/MA/usama/ma.ma109.wpt
+++ b/hwy_data/MA/usama/ma.ma109.wpt
@@ -5,3 +5,5 @@ MA115 http://www.openstreetmap.org/?lat=42.167549&lon=-71.357210
 MA27 http://www.openstreetmap.org/?lat=42.185580&lon=-71.308908
 PondSt http://www.openstreetmap.org/?lat=42.207265&lon=-71.238077
 I-95 http://www.openstreetmap.org/?lat=42.243896&lon=-71.203551
+ComSt http://www.openstreetmap.org/?lat=42.252032&lon=-71.184341
+VFWPkwy http://www.openstreetmap.org/?lat=42.271510&lon=-71.172663


### PR DESCRIPTION
2016-04-07;(USA) Massachusetts;MA 109;ma.ma109;Extended at east end from I-95 to VFW Pkwy.