### PR TITLE
DC Interstates updates

### DIFF
--- a/hwy_data/DC/usadc/dc.dc295.wpt
+++ b/hwy_data/DC/usadc/dc.dc295.wpt
@@ -1,7 +1,7 @@
-I-295/695 +I-295 http://www.openstreetmap.org/?lat=38.869050&lon=-76.988111
+I-295/695 +I-295 http://www.openstreetmap.org/?lat=38.869618&lon=-76.987634
 PenAve http://www.openstreetmap.org/?lat=38.875198&lon=-76.974592
-CapSt http://www.openstreetmap.org/?lat=38.889764&lon=-76.958477
+ECapSt +CapSt http://www.openstreetmap.org/?lat=38.889764&lon=-76.958477
 BenRd http://www.openstreetmap.org/?lat=38.895575&lon=-76.952040
-NanHelBAve http://www.openstreetmap.org/?lat=38.902397&lon=-76.943741
+NHBurAve http://www.openstreetmap.org/?lat=38.902397&lon=-76.943741
 NashSt http://www.openstreetmap.org/?lat=38.907536&lon=-76.938238
 DC/MD http://www.openstreetmap.org/?lat=38.912265&lon=-76.934123

--- a/hwy_data/DC/usai/dc.i295.wpt
+++ b/hwy_data/DC/usai/dc.i295.wpt
@@ -1,7 +1,5 @@
 MD/DC +0 http://www.openstreetmap.org/?lat=38.804592&lon=-77.022362
-1 http://www.openstreetmap.org/?lat=38.822323&lon=-77.016306
-1A http://www.openstreetmap.org/?lat=38.828241&lon=-77.016263
-2 http://www.openstreetmap.org/?lat=38.838504&lon=-77.008624
-2A http://www.openstreetmap.org/?lat=38.844989&lon=-77.007079
-3 http://www.openstreetmap.org/?lat=38.863036&lon=-76.999011
-4 +DC295 http://www.openstreetmap.org/?lat=38.869050&lon=-76.988111
+1 +1A http://www.openstreetmap.org/?lat=38.825901&lon=-77.016692
+2 http://www.openstreetmap.org/?lat=38.845073&lon=-77.007374
+3 http://www.openstreetmap.org/?lat=38.863011&lon=-76.999360
+5 +4 +DC295 +I-695 http://www.openstreetmap.org/?lat=38.869618&lon=-76.987634

--- a/hwy_data/DC/usai/dc.i395.wpt
+++ b/hwy_data/DC/usai/dc.i395.wpt
@@ -1,11 +1,11 @@
 VA/DC +0 http://www.openstreetmap.org/?lat=38.873929&lon=-77.043343
 1 +US1 http://www.openstreetmap.org/?lat=38.879249&lon=-77.036197
-2 http://www.openstreetmap.org/?lat=38.879107&lon=-77.033601
-3 +12thSt http://www.openstreetmap.org/?lat=38.882314&lon=-77.027882
+2 http://www.openstreetmap.org/?lat=38.880068&lon=-77.031402
+3 +12thSt http://www.openstreetmap.org/?lat=38.882239&lon=-77.027850
 4 +9thSt http://www.openstreetmap.org/?lat=38.882402&lon=-77.024009
-5 +6thSt http://www.openstreetmap.org/?lat=38.882515&lon=-77.019176
-7 +I-295 http://www.openstreetmap.org/?lat=38.882815&lon=-77.012540
-8 +DStSW http://www.openstreetmap.org/?lat=38.885496&lon=-77.012690
-9 +DStNW http://www.openstreetmap.org/?lat=38.894757&lon=-77.014182
-10 +MassAve http://www.openstreetmap.org/?lat=38.897813&lon=-77.014187
+5 http://www.openstreetmap.org/?lat=38.882482&lon=-77.021901
+7 +I-295 http://www.openstreetmap.org/?lat=38.882386&lon=-77.012470
+8 +DStSW http://www.openstreetmap.org/?lat=38.885003&lon=-77.012502
+9 http://www.openstreetmap.org/?lat=38.894799&lon=-77.014144
+10 http://www.openstreetmap.org/?lat=38.899466&lon=-77.014166
 US50 +999 http://www.openstreetmap.org/?lat=38.904910&lon=-77.016081

--- a/hwy_data/DC/usai/dc.i695.wpt
+++ b/hwy_data/DC/usai/dc.i695.wpt
@@ -1,6 +1,6 @@
-I-395 +0 http://www.openstreetmap.org/?lat=38.882448&lon=-77.013130
-CapStSE http://www.openstreetmap.org/?lat=38.881650&lon=-77.009059
-6thSt http://www.openstreetmap.org/?lat=38.879508&lon=-76.998324
-SEFwy +I-295 http://www.openstreetmap.org/?lat=38.877771&lon=-76.991029
-MStSE http://www.openstreetmap.org/?lat=38.874639&lon=-76.991061
-I-295/295 +I/DC295 http://www.openstreetmap.org/?lat=38.869050&lon=-76.988111
+I-395 +0 http://www.openstreetmap.org/?lat=38.882386&lon=-77.012470
+1A +CapStSE http://www.openstreetmap.org/?lat=38.881617&lon=-77.009102
+1B +6thSt http://www.openstreetmap.org/?lat=38.879604&lon=-76.998742
+1C +I-295 +SEFwy http://www.openstreetmap.org/?lat=38.877892&lon=-76.991539
+2 http://www.openstreetmap.org/?lat=38.876468&lon=-76.990632
+2A +I/DC295 +I-295/295 +999 http://www.openstreetmap.org/?lat=38.869618&lon=-76.987634


### PR DESCRIPTION
Updates to DC I-295, I-395, and I-695, plus conforming changes to DC295. Main changes are to replace named waypoints on I-695 with new exit numbers, and adjusting point locations as needed on that and other freeways.

Edits discussed at (excessive) length at the old CHM forum, at http://clinched.s2.bizhat.com/viewtopic.php?t=2254&mforum=clinched

No items needed for our Updates list, all affected labels in use kept as alternate labels.