### PR TITLE
NY: various state route changes /  NY North Country Adjustments

### DIFF
--- a/hwy_data/NY/usany/ny.ny012.wpt
+++ b/hwy_data/NY/usany/ny.ny012.wpt
@@ -62,7 +62,7 @@ NY28_N http://www.openstreetmap.org/?lat=43.418702&lon=-75.225749
 NY12D_S http://www.openstreetmap.org/?lat=43.480390&lon=-75.325785
 ESchSt http://www.openstreetmap.org/?lat=43.484719&lon=-75.331278
 LeyRd http://www.openstreetmap.org/?lat=43.536043&lon=-75.324712
-EMainSt http://www.openstreetmap.org/?lat=43.582754&lon=-75.344882
+MainSt_Por http://www.openstreetmap.org/?lat=43.582754&lon=-75.344882
 NY12D_N http://www.openstreetmap.org/?lat=43.617406&lon=-75.370288
 CheSt http://www.openstreetmap.org/?lat=43.633684&lon=-75.378442
 BurCroRd http://www.openstreetmap.org/?lat=43.679015&lon=-75.382133
@@ -82,7 +82,7 @@ NY126 http://www.openstreetmap.org/?lat=43.965515&lon=-75.874929
 NY3_E http://www.openstreetmap.org/?lat=43.967384&lon=-75.881506
 NY3_W +NY283 http://www.openstreetmap.org/?lat=43.974391&lon=-75.908194
 US11_N http://www.openstreetmap.org/?lat=43.981386&lon=-75.913800
-NY12E_S http://www.openstreetmap.org/?lat=43.983740&lon=-75.917212
+MainSt_Wat http://www.openstreetmap.org/?lat=43.983740&lon=-75.917212
 I-81(47) http://www.openstreetmap.org/?lat=44.001027&lon=-75.919690
 NY342 http://www.openstreetmap.org/?lat=44.029538&lon=-75.935419
 ParRd http://www.openstreetmap.org/?lat=44.061224&lon=-75.953250
@@ -90,7 +90,7 @@ NY180_S http://www.openstreetmap.org/?lat=44.097078&lon=-75.998054
 StLawRd http://www.openstreetmap.org/?lat=44.151174&lon=-76.078091
 BaldRockRd http://www.openstreetmap.org/?lat=44.186420&lon=-76.081738
 ClaSt http://www.openstreetmap.org/?lat=44.216724&lon=-76.069894
-NY12E_N  +NY12E http://www.openstreetmap.org/?lat=44.236160&lon=-76.084099
+NY12E http://www.openstreetmap.org/?lat=44.236160&lon=-76.084099
 +X12 http://www.openstreetmap.org/?lat=44.258294&lon=-76.012301
 NY180_N http://www.openstreetmap.org/?lat=44.272800&lon=-76.000285
 I-81(50) http://www.openstreetmap.org/?lat=44.293200&lon=-75.972390

--- a/hwy_data/NY/usany/ny.ny012e.wpt
+++ b/hwy_data/NY/usany/ny.ny012e.wpt
@@ -1,6 +1,5 @@
-NY12_S http://www.openstreetmap.org/?lat=43.983740&lon=-75.917212
-TealRd http://www.openstreetmap.org/?lat=43.998001&lon=-75.933080
-BriSt http://www.openstreetmap.org/?lat=44.001798&lon=-75.981188
+NY12F http://www.openstreetmap.org/?lat=43.999483&lon=-75.982003
+MainSt_E +BriSt +NY12_S http://www.openstreetmap.org/?lat=44.001798&lon=-75.981188
 +X02 http://www.openstreetmap.org/?lat=44.003033&lon=-76.004019
 NY180 http://www.openstreetmap.org/?lat=44.029112&lon=-76.047406
 EvaSt http://www.openstreetmap.org/?lat=44.068964&lon=-76.136713
@@ -9,4 +8,4 @@ MillSt http://www.openstreetmap.org/?lat=44.081327&lon=-76.196022
 PoiSt http://www.openstreetmap.org/?lat=44.127921&lon=-76.336184
 MilBayRd http://www.openstreetmap.org/?lat=44.171431&lon=-76.240611
 StLawRd http://www.openstreetmap.org/?lat=44.193621&lon=-76.204133
-NY12_N http://www.openstreetmap.org/?lat=44.236160&lon=-76.084099
+NY12 +NY12_N http://www.openstreetmap.org/?lat=44.236160&lon=-76.084099

--- a/hwy_data/NY/usany/ny.ny012f.wpt
+++ b/hwy_data/NY/usany/ny.ny012f.wpt
@@ -1,5 +1,5 @@
 NY180 http://www.openstreetmap.org/?lat=44.001397&lon=-76.045132
 WatIntAir http://www.openstreetmap.org/?lat=43.996909&lon=-76.023116
-BriSt http://www.openstreetmap.org/?lat=43.999483&lon=-75.982003
+NY12E  +BriSt http://www.openstreetmap.org/?lat=43.999483&lon=-75.982003
 I-81 http://www.openstreetmap.org/?lat=43.988770&lon=-75.944195
 US11/12 +US11 http://www.openstreetmap.org/?lat=43.978727&lon=-75.915238

--- a/hwy_data/NY/usany/ny.ny022.wpt
+++ b/hwy_data/NY/usany/ny.ny022.wpt
@@ -191,10 +191,7 @@ I-87(38) http://www.openstreetmap.org/?lat=44.714263&lon=-73.464031
 NY374 http://www.openstreetmap.org/?lat=44.717282&lon=-73.470619
 AshRd http://www.openstreetmap.org/?lat=44.758010&lon=-73.472486
 DurRd http://www.openstreetmap.org/?lat=44.766732&lon=-73.491658
-NY456 http://www.openstreetmap.org/?lat=44.775331&lon=-73.491604
+SpelRd http://www.openstreetmap.org/?lat=44.775331&lon=-73.491604
 +X33 http://www.openstreetmap.org/?lat=44.853120&lon=-73.516774
 NY191 http://www.openstreetmap.org/?lat=44.895867&lon=-73.549433
-US11_N http://www.openstreetmap.org/?lat=44.960365&lon=-73.581533
-US11_S http://www.openstreetmap.org/?lat=44.960334&lon=-73.587284
-+X34 http://www.openstreetmap.org/?lat=44.996429&lon=-73.588314
-NY/QC http://www.openstreetmap.org/?lat=45.004516&lon=-73.603055
+US11 +US11_N http://www.openstreetmap.org/?lat=44.960365&lon=-73.581533

--- a/hwy_data/NY/usany/ny.ny314.wpt
+++ b/hwy_data/NY/usany/ny.ny314.wpt
@@ -1,5 +1,2 @@
 I-87 http://www.openstreetmap.org/?lat=44.729133&lon=-73.440127
 US9 http://www.openstreetmap.org/?lat=44.725333&lon=-73.436651
-CumHeadRd http://www.openstreetmap.org/?lat=44.724046&lon=-73.417232
-+X01 http://www.openstreetmap.org/?lat=44.716978&lon=-73.396740
-Ferry http://www.openstreetmap.org/?lat=44.699247&lon=-73.379788

--- a/hwy_data/NY/usany/ny.ny314.wpt
+++ b/hwy_data/NY/usany/ny.ny314.wpt
@@ -1,2 +1,2 @@
 I-87 http://www.openstreetmap.org/?lat=44.729133&lon=-73.440127
-US9 http://www.openstreetmap.org/?lat=44.725333&lon=-73.436651
+US9 +Ferry http://www.openstreetmap.org/?lat=44.725333&lon=-73.436651

--- a/hwy_data/NY/usany/ny.ny374.wpt
+++ b/hwy_data/NY/usany/ny.ny374.wpt
@@ -1,5 +1,4 @@
-CAN/USA http://www.openstreetmap.org/?lat=44.993667&lon=-74.085789
-US11 http://www.openstreetmap.org/?lat=44.926496&lon=-74.079652
+US11 +CAN/USA http://www.openstreetmap.org/?lat=44.926496&lon=-74.079652
 ChaHolRd http://www.openstreetmap.org/?lat=44.875416&lon=-74.054418
 NY190_W http://www.openstreetmap.org/?lat=44.857926&lon=-74.033518
 BunHillRd http://www.openstreetmap.org/?lat=44.841132&lon=-74.035363

--- a/hwy_data/NY/usany/ny.ny456.wpt
+++ b/hwy_data/NY/usany/ny.ny456.wpt
@@ -1,3 +1,0 @@
-NY22 http://www.openstreetmap.org/?lat=44.775331&lon=-73.491604
-I-87 http://www.openstreetmap.org/?lat=44.780941&lon=-73.437488
-US9 http://www.openstreetmap.org/?lat=44.782779&lon=-73.426609

--- a/hwy_data/NY/usaus/ny.us009.wpt
+++ b/hwy_data/NY/usaus/ny.us009.wpt
@@ -178,7 +178,7 @@ NY3 http://www.openstreetmap.org/?lat=44.699532&lon=-73.453045
 RilAve http://www.openstreetmap.org/?lat=44.707274&lon=-73.453131
 NY314 http://www.openstreetmap.org/?lat=44.725333&lon=-73.436651
 +X47 http://www.openstreetmap.org/?lat=44.757426&lon=-73.418841
-NY456 http://www.openstreetmap.org/?lat=44.782779&lon=-73.426609
+SpeRd http://www.openstreetmap.org/?lat=44.782779&lon=-73.426609
 +X48 http://www.openstreetmap.org/?lat=44.825129&lon=-73.433475
 SheLn http://www.openstreetmap.org/?lat=44.866237&lon=-73.420472
 NY191 http://www.openstreetmap.org/?lat=44.894674&lon=-73.436866

--- a/hwy_data/NY/usaus/ny.us011.wpt
+++ b/hwy_data/NY/usaus/ny.us011.wpt
@@ -141,8 +141,8 @@ AldBenRd http://www.openstreetmap.org/?lat=44.922845&lon=-73.705902
 +X22 http://www.openstreetmap.org/?lat=44.924669&lon=-73.685217
 +X23 http://www.openstreetmap.org/?lat=44.944858&lon=-73.663630
 +X24 http://www.openstreetmap.org/?lat=44.963870&lon=-73.624878
-NY22_N http://www.openstreetmap.org/?lat=44.960334&lon=-73.587284
-NY22_S http://www.openstreetmap.org/?lat=44.960365&lon=-73.581533
+HemRd http://www.openstreetmap.org/?lat=44.960334&lon=-73.587284
+NY22 http://www.openstreetmap.org/?lat=44.960365&lon=-73.581533
 DepSt http://www.openstreetmap.org/?lat=44.966117&lon=-73.577027
 I-87 http://www.openstreetmap.org/?lat=44.980980&lon=-73.457379
 US9 http://www.openstreetmap.org/?lat=44.978308&lon=-73.446651

--- a/hwy_data/_systems/usany.csv
+++ b/hwy_data/_systems/usany.csv
@@ -7,7 +7,7 @@ usany;NY;NY5;Trk;Sch;Schenectady;ny.ny005trksch;
 usany;NY;NY5A;;;;ny.ny005a;
 usany;NY;NY5B;;;;ny.ny005b;
 usany;NY;NY5S;;;;ny.ny005s;
-usany;NY;NY6N;;;;ny.ny006n;
+usany;NY;NY6N;;;;ny.ny006n;n
 usany;NY;NY7;;;;ny.ny007;
 usany;NY;NY7A;;;;ny.ny007a;
 usany;NY;NY7B;;;;ny.ny007b;
@@ -475,7 +475,6 @@ usany;NY;NY444;;;;ny.ny444;
 usany;NY;NY446;;;;ny.ny446;
 usany;NY;NY448;;;;ny.ny448;
 usany;NY;NY454;;;;ny.ny454;
-usany;NY;NY456;;;;ny.ny456;
 usany;NY;NY458;;;;ny.ny458;
 usany;NY;NY470;;;;ny.ny470;
 usany;NY;NY474;;;;ny.ny474;

--- a/hwy_data/_systems/usany_con.csv
+++ b/hwy_data/_systems/usany_con.csv
@@ -469,7 +469,6 @@ usany;NY444;;;ny.ny444
 usany;NY446;;;ny.ny446
 usany;NY448;;;ny.ny448
 usany;NY454;;;ny.ny454
-usany;NY456;;;ny.ny456
 usany;NY458;;;ny.ny458
 usany;NY470;;;ny.ny470
 usany;NY474;;;ny.ny474


### PR DESCRIPTION
Addresses #526 & http://tm.teresco.org/forum/index.php?topic=186

--

2016-05-03;(USA) New York;NY 12E;ny.ny012e;Removed from Main St between Bridge St and NY 12, and relocated onto Bridge St between Main St and NY 12F.
2016-05-03;(USA) New York;NY 22;ny.ny022;Truncated at north end from Canadian border to US 11.
2016-05-03;(USA) New York;NY 314;ny.ny314;Truncated at east end from Cumberland Head - Grand Isle Ferry to US9.
2016-05-03;(USA) New York;NY 374;ny.ny374;Truncated at west end from Canadian border to US 11.
2016-05-03;(USA) New York;NY 456;;Route deleted.