### PR TITLE
Deub patch

### DIFF
--- a/hwy_data/DEU/deub/deu.b001.wpt
+++ b/hwy_data/DEU/deub/deu.b001.wpt
@@ -1,4 +1,4 @@
-﻿A39 http://www.openstreetmap.org/?lat=52.255431&lon=10.657425
+A39 http://www.openstreetmap.org/?lat=52.255431&lon=10.657425
 L631 http://www.openstreetmap.org/?lat=52.247431&lon=10.662789
 K637 http://www.openstreetmap.org/?lat=52.247313&lon=10.702014
 K3 http://www.openstreetmap.org/?lat=52.257126&lon=10.757246

--- a/hwy_data/DEU/deub/deu.b001a.wpt
+++ b/hwy_data/DEU/deub/deu.b001a.wpt
@@ -1,4 +1,4 @@
-﻿B1_W http://www.openstreetmap.org/?lat=50.770122&lon=6.072435
+B1_W http://www.openstreetmap.org/?lat=50.770122&lon=6.072435
 L232 http://www.openstreetmap.org/?lat=50.781873&lon=6.077929
 B57 http://www.openstreetmap.org/?lat=50.782008&lon=6.088443
 B1_E http://www.openstreetmap.org/?lat=50.778291&lon=6.094537

--- a/hwy_data/DEU/deub/deu.b001aac.wpt
+++ b/hwy_data/DEU/deub/deu.b001aac.wpt
@@ -1,4 +1,4 @@
-﻿NLD/DEU http://www.openstreetmap.org/?lat=50.771099&lon=6.025143
+NLD/DEU http://www.openstreetmap.org/?lat=50.771099&lon=6.025143
 L260 http://www.openstreetmap.org/?lat=50.769417&lon=6.046171
 L212 http://www.openstreetmap.org/?lat=50.769037&lon=6.057758
 B1A_W http://www.openstreetmap.org/?lat=50.770122&lon=6.072435

--- a/hwy_data/DEU/deub/deu.b001dor.wpt
+++ b/hwy_data/DEU/deub/deu.b001dor.wpt
@@ -1,4 +1,4 @@
-﻿A40 http://www.openstreetmap.org/?lat=51.497576&lon=7.448688
+A40 http://www.openstreetmap.org/?lat=51.497576&lon=7.448688
 B54 http://www.openstreetmap.org/?lat=51.498805&lon=7.468300
 L672 http://www.openstreetmap.org/?lat=51.500695&lon=7.482591
 SemStr http://www.openstreetmap.org/?lat=51.503594&lon=7.497246

--- a/hwy_data/DEU/deub/deu.b001dus.wpt
+++ b/hwy_data/DEU/deub/deu.b001dus.wpt
@@ -1,4 +1,4 @@
-﻿A57Ast http://www.openstreetmap.org/?lat=51.198386&lon=6.718612
+A57Ast http://www.openstreetmap.org/?lat=51.198386&lon=6.718612
 AdeWeg http://www.openstreetmap.org/?lat=51.198601&lon=6.742591
 B326 http://www.openstreetmap.org/?lat=51.200975&lon=6.755412
 PloStr http://www.openstreetmap.org/?lat=51.209404&lon=6.758029

--- a/hwy_data/DEU/deub/deu.b001ess.wpt
+++ b/hwy_data/DEU/deub/deu.b001ess.wpt
@@ -1,4 +1,4 @@
-﻿A52 http://www.openstreetmap.org/?lat=51.354705&lon=6.863773
+A52 http://www.openstreetmap.org/?lat=51.354705&lon=6.863773
 K19 http://www.openstreetmap.org/?lat=51.359696&lon=6.863236
 K4 http://www.openstreetmap.org/?lat=51.378558&lon=6.862679
 K10 http://www.openstreetmap.org/?lat=51.388414&lon=6.866369

--- a/hwy_data/DEU/deub/deu.b001ham.wpt
+++ b/hwy_data/DEU/deub/deu.b001ham.wpt
@@ -1,4 +1,4 @@
-﻿B55_S http://www.openstreetmap.org/?lat=51.607783&lon=8.310471
+B55_S http://www.openstreetmap.org/?lat=51.607783&lon=8.310471
 B55_N http://www.openstreetmap.org/?lat=51.611834&lon=8.336477
 L735 http://www.openstreetmap.org/?lat=51.612607&lon=8.342357
 L536 http://www.openstreetmap.org/?lat=51.622599&lon=8.398705

--- a/hwy_data/DEU/deub/deu.b001unn.wpt
+++ b/hwy_data/DEU/deub/deu.b001unn.wpt
@@ -1,4 +1,4 @@
-﻿L821 http://www.openstreetmap.org/?lat=51.523805&lon=7.647729
+L821 http://www.openstreetmap.org/?lat=51.523805&lon=7.647729
 A1 http://www.openstreetmap.org/?lat=51.526628&lon=7.659144
 L678 http://www.openstreetmap.org/?lat=51.528851&lon=7.671418
 K28 http://www.openstreetmap.org/?lat=51.527890&lon=7.682619

--- a/hwy_data/DEU/deub/deu.b002.wpt
+++ b/hwy_data/DEU/deub/deu.b002.wpt
@@ -1,4 +1,4 @@
-﻿A9_BayN http://www.openstreetmap.org/?lat=49.959421&lon=11.605940
+A9_BayN http://www.openstreetmap.org/?lat=49.959421&lon=11.605940
 B22/B85 http://www.openstreetmap.org/?lat=49.946056&lon=11.580963
 A9_BayS http://www.openstreetmap.org/?lat=49.928254&lon=11.602464
 B22_E http://www.openstreetmap.org/?lat=49.920269&lon=11.605747

--- a/hwy_data/DEU/deub/deu.b002hof.wpt
+++ b/hwy_data/DEU/deub/deu.b002hof.wpt
@@ -1,4 +1,4 @@
-﻿B90 http://www.openstreetmap.org/?lat=50.442174&lon=11.860600
+B90 http://www.openstreetmap.org/?lat=50.442174&lon=11.860600
 L1093 http://www.openstreetmap.org/?lat=50.439359&lon=11.861844
 Doba http://www.openstreetmap.org/?lat=50.425239&lon=11.853690
 K310/K554 http://www.openstreetmap.org/?lat=50.413331&lon=11.861200

--- a/hwy_data/DEU/deub/deu.b002lei.wpt
+++ b/hwy_data/DEU/deub/deu.b002lei.wpt
@@ -1,4 +1,4 @@
-﻿A10_Bar http://www.openstreetmap.org/?lat=52.613980&lon=13.558631
+A10_Bar http://www.openstreetmap.org/?lat=52.613980&lon=13.558631
 L200 http://www.openstreetmap.org/?lat=52.612846&lon=13.536186
 BlaPflWeg http://www.openstreetmap.org/?lat=52.582974&lon=13.483229
 DarStr http://www.openstreetmap.org/?lat=52.567247&lon=13.474603

--- a/hwy_data/DEU/deub/deu.b002r.wpt
+++ b/hwy_data/DEU/deub/deu.b002r.wpt
@@ -1,4 +1,4 @@
-﻿A95_E http://www.openstreetmap.org/?lat=48.110920&lon=11.518371
+A95_E http://www.openstreetmap.org/?lat=48.110920&lon=11.518371
 PasStr http://www.openstreetmap.org/?lat=48.110569&lon=11.534100
 B11 http://www.openstreetmap.org/?lat=48.110698&lon=11.539593
 SchStr http://www.openstreetmap.org/?lat=48.112274&lon=11.553540

--- a/hwy_data/DEU/deub/deu.b002sch.wpt
+++ b/hwy_data/DEU/deub/deu.b002sch.wpt
@@ -1,4 +1,4 @@
-﻿POL/DEU http://www.openstreetmap.org/?lat=53.306673&lon=14.409084
+POL/DEU http://www.openstreetmap.org/?lat=53.306673&lon=14.409084
 B113 http://www.openstreetmap.org/?lat=53.265316&lon=14.400759
 WieStr http://www.openstreetmap.org/?lat=53.211019&lon=14.393656
 L27 http://www.openstreetmap.org/?lat=53.212162&lon=14.369817

--- a/hwy_data/DEU/deub/deu.b002wei.wpt
+++ b/hwy_data/DEU/deub/deu.b002wei.wpt
@@ -1,4 +1,4 @@
-﻿A952 http://www.openstreetmap.org/?lat=48.001025&lon=11.363243
+A952 http://www.openstreetmap.org/?lat=48.001025&lon=11.363243
 St2063_W http://www.openstreetmap.org/?lat=48.002069&lon=11.349092
 St2063_E http://www.openstreetmap.org/?lat=48.000562&lon=11.342762
 St2070 http://www.openstreetmap.org/?lat=47.996606&lon=11.338170

--- a/hwy_data/DEU/deub/deu.b003.wpt
+++ b/hwy_data/DEU/deub/deu.b003.wpt
@@ -1,4 +1,4 @@
-﻿L235_N http://www.openstreetmap.org/?lat=53.477218&lon=9.786243
+L235_N http://www.openstreetmap.org/?lat=53.477218&lon=9.786243
 +X01 http://www.openstreetmap.org/?lat=53.471522&lon=9.770730
 B73_E http://www.openstreetmap.org/?lat=53.455042&lon=9.772725
 B73_W http://www.openstreetmap.org/?lat=53.450225&lon=9.751353

--- a/hwy_data/DEU/deub/deu.b003fra.wpt
+++ b/hwy_data/DEU/deub/deu.b003fra.wpt
@@ -1,4 +1,4 @@
-﻿A485 http://www.openstreetmap.org/?lat=50.492525&lon=8.653901
+A485 http://www.openstreetmap.org/?lat=50.492525&lon=8.653901
 K256_N http://www.openstreetmap.org/?lat=50.478046&lon=8.655553
 L3129 http://www.openstreetmap.org/?lat=50.464798&lon=8.641348
 K256_S http://www.openstreetmap.org/?lat=50.454580&lon=8.650961

--- a/hwy_data/DEU/deub/deu.b003kar.wpt
+++ b/hwy_data/DEU/deub/deu.b003kar.wpt
@@ -1,4 +1,4 @@
-﻿A661 http://www.openstreetmap.org/?lat=49.962996&lon=8.674822
+A661 http://www.openstreetmap.org/?lat=49.962996&lon=8.674822
 K167 http://www.openstreetmap.org/?lat=49.948541&lon=8.669887
 K165 http://www.openstreetmap.org/?lat=49.931666&lon=8.659372
 K166 http://www.openstreetmap.org/?lat=49.923350&lon=8.655381

--- a/hwy_data/DEU/deub/deu.b003mar.wpt
+++ b/hwy_data/DEU/deub/deu.b003mar.wpt
@@ -1,4 +1,4 @@
-﻿A49 http://www.openstreetmap.org/?lat=51.067028&lon=9.236712
+A49 http://www.openstreetmap.org/?lat=51.067028&lon=9.236712
 K74 http://www.openstreetmap.org/?lat=51.063973&lon=9.199719
 B485 http://www.openstreetmap.org/?lat=51.050392&lon=9.180772
 K61/K65 http://www.openstreetmap.org/?lat=51.038345&lon=9.167876

--- a/hwy_data/DEU/deub/deu.b003n.wpt
+++ b/hwy_data/DEU/deub/deu.b003n.wpt
@@ -1,2 +1,2 @@
-﻿K9608 http://www.openstreetmap.org/?lat=48.734908&lon=8.146577
+K9608 http://www.openstreetmap.org/?lat=48.734908&lon=8.146577
 B3 http://www.openstreetmap.org/?lat=48.724604&lon=8.142049

--- a/hwy_data/DEU/deub/deu.b004.wpt
+++ b/hwy_data/DEU/deub/deu.b004.wpt
@@ -1,4 +1,4 @@
-﻿A395 http://www.openstreetmap.org/?lat=51.937479&lon=10.583439
+A395 http://www.openstreetmap.org/?lat=51.937479&lon=10.583439
 K34 http://www.openstreetmap.org/?lat=51.931195&lon=10.564899
 K46 http://www.openstreetmap.org/?lat=51.915473&lon=10.554342
 B6_W http://www.openstreetmap.org/?lat=51.908537&lon=10.554085

--- a/hwy_data/DEU/deub/deu.b004cob.wpt
+++ b/hwy_data/DEU/deub/deu.b004cob.wpt
@@ -1,4 +1,4 @@
-﻿B89 http://www.openstreetmap.org/?lat=50.326943&lon=11.165500
+B89 http://www.openstreetmap.org/?lat=50.326943&lon=11.165500
 L2662 http://www.openstreetmap.org/?lat=50.320751&lon=11.159406
 St2708 http://www.openstreetmap.org/?lat=50.313078&lon=11.128635
 CobStr http://www.openstreetmap.org/?lat=50.312914&lon=11.091986

--- a/hwy_data/DEU/deub/deu.b004ham.wpt
+++ b/hwy_data/DEU/deub/deu.b004ham.wpt
@@ -1,4 +1,4 @@
-﻿B206 http://www.openstreetmap.org/?lat=53.914551&lon=9.901471
+B206 http://www.openstreetmap.org/?lat=53.914551&lon=9.901471
 Ble http://www.openstreetmap.org/?lat=53.916093&lon=9.884970
 K76 http://www.openstreetmap.org/?lat=53.901228&lon=9.883211
 L320 http://www.openstreetmap.org/?lat=53.867282&lon=9.888639

--- a/hwy_data/DEU/deub/deu.b004nur.wpt
+++ b/hwy_data/DEU/deub/deu.b004nur.wpt
@@ -1,4 +1,4 @@
-﻿A73 http://www.openstreetmap.org/?lat=49.582125&lon=10.988302
+A73 http://www.openstreetmap.org/?lat=49.582125&lon=10.988302
 St2242 http://www.openstreetmap.org/?lat=49.581106&lon=10.992572
 GebStr http://www.openstreetmap.org/?lat=49.576070&lon=11.015865
 SudSpa http://www.openstreetmap.org/?lat=49.568924&lon=11.028085

--- a/hwy_data/DEU/deub/deu.b004r.wpt
+++ b/hwy_data/DEU/deub/deu.b004r.wpt
@@ -1,4 +1,4 @@
-﻿B4_N http://www.openstreetmap.org/?lat=49.469379&lon=11.068028
+B4_N http://www.openstreetmap.org/?lat=49.469379&lon=11.068028
 RolStr http://www.openstreetmap.org/?lat=49.469505&lon=11.081471
 NordRing http://www.openstreetmap.org/?lat=49.470258&lon=11.094797
 B2_N http://www.openstreetmap.org/?lat=49.466974&lon=11.097876

--- a/hwy_data/DEU/deub/deu.b004uel.wpt
+++ b/hwy_data/DEU/deub/deu.b004uel.wpt
@@ -1,4 +1,4 @@
-﻿A39 http://www.openstreetmap.org/?lat=53.277750&lon=10.400920
+A39 http://www.openstreetmap.org/?lat=53.277750&lon=10.400920
 B209_E http://www.openstreetmap.org/?lat=53.268293&lon=10.428944
 K53 http://www.openstreetmap.org/?lat=53.260849&lon=10.442376
 BleLan http://www.openstreetmap.org/?lat=53.250798&lon=10.445509

--- a/hwy_data/DEU/deub/deu.b005.wpt
+++ b/hwy_data/DEU/deub/deu.b005.wpt
@@ -1,4 +1,4 @@
-﻿A7 http://www.openstreetmap.org/?lat=53.595784&lon=9.923272
+A7 http://www.openstreetmap.org/?lat=53.595784&lon=9.923272
 SpoRing http://www.openstreetmap.org/?lat=53.592263&lon=9.928679
 B4 http://www.openstreetmap.org/?lat=53.572518&lon=9.942455
 FruAll http://www.openstreetmap.org/?lat=53.570390&lon=9.956059

--- a/hwy_data/DEU/deub/deu.b005hus.wpt
+++ b/hwy_data/DEU/deub/deu.b005hus.wpt
@@ -1,4 +1,4 @@
-﻿DNK/DEU http://www.openstreetmap.org/?lat=54.903856&lon=8.910255
+DNK/DEU http://www.openstreetmap.org/?lat=54.903856&lon=8.910255
 L192 http://www.openstreetmap.org/?lat=54.886519&lon=8.908496
 L1 http://www.openstreetmap.org/?lat=54.872273&lon=8.907895
 L2/L301 http://www.openstreetmap.org/?lat=54.869396&lon=8.906093

--- a/hwy_data/DEU/deub/deu.b006.wpt
+++ b/hwy_data/DEU/deub/deu.b006.wpt
@@ -1,4 +1,4 @@
-﻿A27 http://www.openstreetmap.org/?lat=53.116677&lon=8.811893
+A27 http://www.openstreetmap.org/?lat=53.116677&lon=8.811893
 HocRing http://www.openstreetmap.org/?lat=53.112060&lon=8.810016
 IngStr http://www.openstreetmap.org/?lat=53.105007&lon=8.802119
 UtbRing http://www.openstreetmap.org/?lat=53.102495&lon=8.799952

--- a/hwy_data/DEU/deub/deu.b006bre.wpt
+++ b/hwy_data/DEU/deub/deu.b006bre.wpt
@@ -1,3 +1,3 @@
-﻿B71 http://www.openstreetmap.org/?lat=53.487331&lon=8.603067
+B71 http://www.openstreetmap.org/?lat=53.487331&lon=8.603067
 L121 http://www.openstreetmap.org/?lat=53.485313&lon=8.602939
 A27 http://www.openstreetmap.org/?lat=53.464688&lon=8.601308

--- a/hwy_data/DEU/deub/deu.b006lei.wpt
+++ b/hwy_data/DEU/deub/deu.b006lei.wpt
@@ -1,4 +1,4 @@
-﻿B100 http://www.openstreetmap.org/?lat=51.498458&lon=11.980333
+B100 http://www.openstreetmap.org/?lat=51.498458&lon=11.980333
 RossPla http://www.openstreetmap.org/?lat=51.491725&lon=11.981546
 BerStr http://www.openstreetmap.org/?lat=51.489854&lon=11.983337
 B80 http://www.openstreetmap.org/?lat=51.478443&lon=11.983509

--- a/hwy_data/DEU/deub/deu.b006lob.wpt
+++ b/hwy_data/DEU/deub/deu.b006lob.wpt
@@ -1,4 +1,4 @@
-﻿B156 http://www.openstreetmap.org/?lat=51.179693&lon=14.447858
+B156 http://www.openstreetmap.org/?lat=51.179693&lon=14.447858
 S111_Bau http://www.openstreetmap.org/?lat=51.175967&lon=14.462074
 S110 http://www.openstreetmap.org/?lat=51.148502&lon=14.569910
 B178 http://www.openstreetmap.org/?lat=51.110851&lon=14.648724

--- a/hwy_data/DEU/deub/deu.b006n.wpt
+++ b/hwy_data/DEU/deub/deu.b006n.wpt
@@ -1,3 +1,3 @@
-﻿B6 http://www.openstreetmap.org/?lat=53.048321&lon=8.819264
+B6 http://www.openstreetmap.org/?lat=53.048321&lon=8.819264
 HabBruStr http://www.openstreetmap.org/?lat=53.040632&lon=8.841290
 A1 http://www.openstreetmap.org/?lat=53.029149&lon=8.858843

--- a/hwy_data/DEU/deub/deu.b007.wpt
+++ b/hwy_data/DEU/deub/deu.b007.wpt
@@ -1,4 +1,4 @@
-﻿A46 http://www.openstreetmap.org/?lat=51.356286&lon=8.368042
+A46 http://www.openstreetmap.org/?lat=51.356286&lon=8.368042
 L776_S http://www.openstreetmap.org/?lat=51.361264&lon=8.399391
 L776_KirW http://www.openstreetmap.org/?lat=51.368967&lon=8.418338
 L776_KirE http://www.openstreetmap.org/?lat=51.368874&lon=8.427415

--- a/hwy_data/DEU/deub/deu.b007alt.wpt
+++ b/hwy_data/DEU/deub/deu.b007alt.wpt
@@ -1,4 +1,4 @@
-﻿L1362 http://www.openstreetmap.org/?lat=50.865968&lon=12.178924
+L1362 http://www.openstreetmap.org/?lat=50.865968&lon=12.178924
 L1081_N http://www.openstreetmap.org/?lat=50.864519&lon=12.180727
 L1081_S http://www.openstreetmap.org/?lat=50.869055&lon=12.220445
 A4 http://www.openstreetmap.org/?lat=50.871560&lon=12.227697

--- a/hwy_data/DEU/deub/deu.b007dus.wpt
+++ b/hwy_data/DEU/deub/deu.b007dus.wpt
@@ -1,4 +1,4 @@
-﻿A52 http://www.openstreetmap.org/?lat=51.234898&lon=6.703227
+A52 http://www.openstreetmap.org/?lat=51.234898&lon=6.703227
 L392_Hee http://www.openstreetmap.org/?lat=51.233574&lon=6.718225
 RheAll http://www.openstreetmap.org/?lat=51.234125&lon=6.730778
 L30 http://www.openstreetmap.org/?lat=51.240819&lon=6.743712

--- a/hwy_data/DEU/deub/deu.b007got.wpt
+++ b/hwy_data/DEU/deub/deu.b007got.wpt
@@ -1,4 +1,4 @@
-﻿B247 http://www.openstreetmap.org/?lat=50.942556&lon=10.719781
+B247 http://www.openstreetmap.org/?lat=50.942556&lon=10.719781
 L2147N http://www.openstreetmap.org/?lat=50.944395&lon=10.754156
 L1044 http://www.openstreetmap.org/?lat=50.947640&lon=10.882215
 A71 http://www.openstreetmap.org/?lat=50.955642&lon=10.941181

--- a/hwy_data/DEU/deub/deu.b007hag.wpt
+++ b/hwy_data/DEU/deub/deu.b007hag.wpt
@@ -1,4 +1,4 @@
-﻿B54 http://www.openstreetmap.org/?lat=51.359321&lon=7.478256
+B54 http://www.openstreetmap.org/?lat=51.359321&lon=7.478256
 L704 http://www.openstreetmap.org/?lat=51.361117&lon=7.506366
 K1 http://www.openstreetmap.org/?lat=51.364258&lon=7.543048
 L693 http://www.openstreetmap.org/?lat=51.357968&lon=7.553068

--- a/hwy_data/DEU/deub/deu.b007men.wpt
+++ b/hwy_data/DEU/deub/deu.b007men.wpt
@@ -1,4 +1,4 @@
-﻿A46_W http://www.openstreetmap.org/?lat=51.385823&lon=7.732401
+A46_W http://www.openstreetmap.org/?lat=51.385823&lon=7.732401
 L683 http://www.openstreetmap.org/?lat=51.394265&lon=7.760468
 OeseStr http://www.openstreetmap.org/?lat=51.404968&lon=7.791683
 B515_S http://www.openstreetmap.org/?lat=51.427946&lon=7.801913

--- a/hwy_data/DEU/deub/deu.b007wei.wpt
+++ b/hwy_data/DEU/deub/deu.b007wei.wpt
@@ -1,4 +1,4 @@
-﻿A71 http://www.openstreetmap.org/?lat=51.037859&lon=11.063232
+A71 http://www.openstreetmap.org/?lat=51.037859&lon=11.063232
 K52 http://www.openstreetmap.org/?lat=51.012864&lon=11.060615
 L1055 http://www.openstreetmap.org/?lat=50.997174&lon=11.074305
 L1052 http://www.openstreetmap.org/?lat=50.977561&lon=11.092200

--- a/hwy_data/DEU/deub/deu.b008.wpt
+++ b/hwy_data/DEU/deub/deu.b008.wpt
@@ -1,4 +1,4 @@
-﻿A560 http://www.openstreetmap.org/?lat=50.767581&lon=7.311273
+A560 http://www.openstreetmap.org/?lat=50.767581&lon=7.311273
 L268_N http://www.openstreetmap.org/?lat=50.731036&lon=7.368500
 L171 http://www.openstreetmap.org/?lat=50.722153&lon=7.377920
 L274 http://www.openstreetmap.org/?lat=50.707901&lon=7.437615

--- a/hwy_data/DEU/deub/deu.b008asc.wpt
+++ b/hwy_data/DEU/deub/deu.b008asc.wpt
@@ -1,4 +1,4 @@
-﻿A45 http://www.openstreetmap.org/?lat=50.021624&lon=9.048325
+A45 http://www.openstreetmap.org/?lat=50.021624&lon=9.048325
 A3 http://www.openstreetmap.org/?lat=49.991429&lon=9.074106
 IndStr http://www.openstreetmap.org/?lat=49.989422&lon=9.079278
 LinStr http://www.openstreetmap.org/?lat=49.980398&lon=9.112000

--- a/hwy_data/DEU/deub/deu.b008din.wpt
+++ b/hwy_data/DEU/deub/deu.b008din.wpt
@@ -1,4 +1,4 @@
-﻿B473 http://www.openstreetmap.org/?lat=51.683080&lon=6.597311
+B473 http://www.openstreetmap.org/?lat=51.683080&lon=6.597311
 K7 http://www.openstreetmap.org/?lat=51.669308&lon=6.609478
 HerRing http://www.openstreetmap.org/?lat=51.660391&lon=6.608775
 B58 http://www.openstreetmap.org/?lat=51.649941&lon=6.615357

--- a/hwy_data/DEU/deub/deu.b008dus.wpt
+++ b/hwy_data/DEU/deub/deu.b008dus.wpt
@@ -1,4 +1,4 @@
-﻿B288 http://www.openstreetmap.org/?lat=51.352313&lon=6.744103
+B288 http://www.openstreetmap.org/?lat=51.352313&lon=6.744103
 B8N_Fro http://www.openstreetmap.org/?lat=51.338481&lon=6.752021
 BocStr http://www.openstreetmap.org/?lat=51.318678&lon=6.743524
 L422 http://www.openstreetmap.org/?lat=51.305453&lon=6.742172

--- a/hwy_data/DEU/deub/deu.b008emm.wpt
+++ b/hwy_data/DEU/deub/deu.b008emm.wpt
@@ -1,4 +1,4 @@
-﻿NLD/DEU http://www.openstreetmap.org/?lat=51.900468&lon=6.133665
+NLD/DEU http://www.openstreetmap.org/?lat=51.900468&lon=6.133665
 L472_S http://www.openstreetmap.org/?lat=51.874173&lon=6.156399
 L472_N http://www.openstreetmap.org/?lat=51.871927&lon=6.159317
 +X01 http://www.openstreetmap.org/?lat=51.862182&lon=6.170969

--- a/hwy_data/DEU/deub/deu.b008fra.wpt
+++ b/hwy_data/DEU/deub/deu.b008fra.wpt
@@ -1,4 +1,4 @@
-﻿A66_Miq http://www.openstreetmap.org/?lat=50.131893&lon=8.656862
+A66_Miq http://www.openstreetmap.org/?lat=50.131893&lon=8.656862
 K810 http://www.openstreetmap.org/?lat=50.131680&lon=8.672183
 L3003 http://www.openstreetmap.org/?lat=50.131611&lon=8.684049
 B3_N http://www.openstreetmap.org/?lat=50.128997&lon=8.693104

--- a/hwy_data/DEU/deub/deu.b008kol.wpt
+++ b/hwy_data/DEU/deub/deu.b008kol.wpt
@@ -1,4 +1,4 @@
-﻿A3 http://www.openstreetmap.org/?lat=51.055956&lon=6.991682
+A3 http://www.openstreetmap.org/?lat=51.055956&lon=6.991682
 L288 http://www.openstreetmap.org/?lat=51.055099&lon=7.000651
 NeuHof http://www.openstreetmap.org/?lat=51.041222&lon=6.991054
 OlofPalStr http://www.openstreetmap.org/?lat=51.039451&lon=6.989000

--- a/hwy_data/DEU/deub/deu.b008mar.wpt
+++ b/hwy_data/DEU/deub/deu.b008mar.wpt
@@ -1,4 +1,4 @@
-﻿A3 http://www.openstreetmap.org/?lat=49.818015&lon=9.558384
+A3 http://www.openstreetmap.org/?lat=49.818015&lon=9.558384
 MSP31 http://www.openstreetmap.org/?lat=49.824390&lon=9.558578
 EicFur http://www.openstreetmap.org/?lat=49.835602&lon=9.570680
 St2315 http://www.openstreetmap.org/?lat=49.851045&lon=9.590056

--- a/hwy_data/DEU/deub/deu.b008n.wpt
+++ b/hwy_data/DEU/deub/deu.b008n.wpt
@@ -1,4 +1,4 @@
-﻿A59 http://www.openstreetmap.org/?lat=51.353365&lon=6.758352
+A59 http://www.openstreetmap.org/?lat=51.353365&lon=6.758352
 B8_Fro http://www.openstreetmap.org/?lat=51.338481&lon=6.752021
 +X01 http://www.openstreetmap.org/?lat=51.327018&lon=6.751699
 L139 http://www.openstreetmap.org/?lat=51.318624&lon=6.764445

--- a/hwy_data/DEU/deub/deu.b008neu.wpt
+++ b/hwy_data/DEU/deub/deu.b008neu.wpt
@@ -1,4 +1,4 @@
-﻿A73 http://www.openstreetmap.org/?lat=49.363867&lon=11.197300
+A73 http://www.openstreetmap.org/?lat=49.363867&lon=11.197300
 St2239 http://www.openstreetmap.org/?lat=49.366082&lon=11.205711
 RegStr_Feu http://www.openstreetmap.org/?lat=49.367452&lon=11.228113
 St2401 http://www.openstreetmap.org/?lat=49.356859&lon=11.257854

--- a/hwy_data/DEU/deub/deu.b008str.wpt
+++ b/hwy_data/DEU/deub/deu.b008str.wpt
@@ -1,4 +1,4 @@
-﻿A3 http://www.openstreetmap.org/?lat=48.991975&lon=12.240272
+A3 http://www.openstreetmap.org/?lat=48.991975&lon=12.240272
 St2329 http://www.openstreetmap.org/?lat=48.967710&lon=12.326317
 St2146 http://www.openstreetmap.org/?lat=48.957792&lon=12.354212
 St2146_S http://www.openstreetmap.org/?lat=48.958468&lon=12.370949

--- a/hwy_data/DEU/deub/deu.b008wur.wpt
+++ b/hwy_data/DEU/deub/deu.b008wur.wpt
@@ -1,4 +1,4 @@
-﻿B27_S http://www.openstreetmap.org/?lat=49.791516&lon=9.864607
+B27_S http://www.openstreetmap.org/?lat=49.791516&lon=9.864607
 FasStr http://www.openstreetmap.org/?lat=49.786986&lon=9.877095
 LeiStr http://www.openstreetmap.org/?lat=49.786979&lon=9.897405
 St2300 http://www.openstreetmap.org/?lat=49.794397&lon=9.916449

--- a/hwy_data/DEU/deub/deu.b009.wpt
+++ b/hwy_data/DEU/deub/deu.b009.wpt
@@ -1,4 +1,4 @@
-﻿L431_Lau http://www.openstreetmap.org/?lat=49.973871&lon=8.312638
+L431_Lau http://www.openstreetmap.org/?lat=49.973871&lon=8.312638
 A60 http://www.openstreetmap.org/?lat=49.970649&lon=8.312230
 K13 http://www.openstreetmap.org/?lat=49.967040&lon=8.319440
 +X01 http://www.openstreetmap.org/?lat=49.949287&lon=8.338323

--- a/hwy_data/DEU/deub/deu.b009dor.wpt
+++ b/hwy_data/DEU/deub/deu.b009dor.wpt
@@ -1,4 +1,4 @@
-﻿A57 http://www.openstreetmap.org/?lat=51.169112&lon=6.734834
+A57 http://www.openstreetmap.org/?lat=51.169112&lon=6.734834
 L137 http://www.openstreetmap.org/?lat=51.170034&lon=6.756592
 A46 http://www.openstreetmap.org/?lat=51.163589&lon=6.768308
 L280 http://www.openstreetmap.org/?lat=51.096785&lon=6.841908

--- a/hwy_data/DEU/deub/deu.b009gel.wpt
+++ b/hwy_data/DEU/deub/deu.b009gel.wpt
@@ -1,4 +1,4 @@
-﻿NLD/DEU http://www.openstreetmap.org/?lat=51.816415&lon=5.957251
+NLD/DEU http://www.openstreetmap.org/?lat=51.816415&lon=5.957251
 K31 http://www.openstreetmap.org/?lat=51.809729&lon=5.968130
 B504_Sch http://www.openstreetmap.org/?lat=51.800548&lon=6.023726
 B504_Kra http://www.openstreetmap.org/?lat=51.784197&lon=6.027031

--- a/hwy_data/DEU/deub/deu.b009kob.wpt
+++ b/hwy_data/DEU/deub/deu.b009kob.wpt
@@ -1,4 +1,4 @@
-﻿B56 http://www.openstreetmap.org/?lat=50.737433&lon=7.103734
+B56 http://www.openstreetmap.org/?lat=50.737433&lon=7.103734
 ReuStr http://www.openstreetmap.org/?lat=50.719015&lon=7.117596
 A562 http://www.openstreetmap.org/?lat=50.705774&lon=7.132273
 L158 http://www.openstreetmap.org/?lat=50.690523&lon=7.149246

--- a/hwy_data/DEU/deub/deu.b019pop.wpt
+++ b/hwy_data/DEU/deub/deu.b019pop.wpt
@@ -1,4 +1,4 @@
-﻿B286_W http://www.openstreetmap.org/?lat=50.137608&lon=10.150208
+B286_W http://www.openstreetmap.org/?lat=50.137608&lon=10.150208
 SW18 http://www.openstreetmap.org/?lat=50.117056&lon=10.144157
 B286_E http://www.openstreetmap.org/?lat=50.094265&lon=10.147676
 A71 http://www.openstreetmap.org/?lat=50.060101&lon=10.150337

--- a/hwy_data/DEU/deub/deu.b027wur.wpt
+++ b/hwy_data/DEU/deub/deu.b027wur.wpt
@@ -1,4 +1,4 @@
-﻿B287 http://www.openstreetmap.org/?lat=50.112653&lon=9.880915
+B287 http://www.openstreetmap.org/?lat=50.112653&lon=9.880915
 UntStr http://www.openstreetmap.org/?lat=50.114043&lon=9.863427
 St2434 http://www.openstreetmap.org/?lat=50.089378&lon=9.812958
 St2303 http://www.openstreetmap.org/?lat=50.045579&lon=9.775407

--- a/hwy_data/DEU/deub/deu.b286.wpt
+++ b/hwy_data/DEU/deub/deu.b286.wpt
@@ -1,4 +1,4 @@
-﻿B19 http://www.openstreetmap.org/?lat=50.094265&lon=10.147676
+B19 http://www.openstreetmap.org/?lat=50.094265&lon=10.147676
 A71 http://www.openstreetmap.org/?lat=50.092407&lon=10.158319
 Mai http://www.openstreetmap.org/?lat=50.090989&lon=10.185871
 St2280 http://www.openstreetmap.org/?lat=50.052234&lon=10.230675

--- a/hwy_data/DEU/deub/deu.b286kis.wpt
+++ b/hwy_data/DEU/deub/deu.b286kis.wpt
@@ -1,4 +1,4 @@
-﻿A7_Vol http://www.openstreetmap.org/?lat=50.336087&lon=9.772747
+A7_Vol http://www.openstreetmap.org/?lat=50.336087&lon=9.772747
 KG25 http://www.openstreetmap.org/?lat=50.326505&lon=9.770021
 St2289_W http://www.openstreetmap.org/?lat=50.312969&lon=9.795771
 EbeStr http://www.openstreetmap.org/?lat=50.319799&lon=9.818199

--- a/hwy_data/DEU/deub/deu.b303sch.wpt
+++ b/hwy_data/DEU/deub/deu.b303sch.wpt
@@ -1,4 +1,4 @@
-﻿A7 http://www.openstreetmap.org/?lat=50.065307&lon=10.045967
+A7 http://www.openstreetmap.org/?lat=50.065307&lon=10.045967
 SW2 http://www.openstreetmap.org/?lat=50.059563&lon=10.069313
 St2290 http://www.openstreetmap.org/?lat=50.062704&lon=10.129566
 A71 http://www.openstreetmap.org/?lat=50.060101&lon=10.150337

--- a/hwy_data/DEU/deub/deu.b468.wpt
+++ b/hwy_data/DEU/deub/deu.b468.wpt
@@ -1,2 +1,2 @@
-﻿B8 http://www.openstreetmap.org/?lat=49.774946&lon=9.777832
+B8 http://www.openstreetmap.org/?lat=49.774946&lon=9.777832
 A3 http://www.openstreetmap.org/?lat=49.767420&lon=9.774785


### PR DESCRIPTION
Removes the '﻿' character that was randomly added to the beginning of each file by Github and only showed up when you edited the files on the in-browser editor.