### PR TITLE
ME167 truncated & partially redesignated as ME161

### DIFF
--- a/hwy_data/ME/usame/me.me161.wpt
+++ b/hwy_data/ME/usame/me.me161.wpt
@@ -1,3 +1,7 @@
+NB/ME http://www.openstreetmap.org/?lat=46.765281&lon=-67.789390
+AroFalRd http://www.openstreetmap.org/?lat=46.767948&lon=-67.802741
+DorRd http://www.openstreetmap.org/?lat=46.765372&lon=-67.816452
+ForAve http://www.openstreetmap.org/?lat=46.769292&lon=-67.823587
 US1Alt http://www.openstreetmap.org/?lat=46.772820&lon=-67.835555
 GreRidRd http://www.openstreetmap.org/?lat=46.796176&lon=-67.864512
 +x0 http://www.openstreetmap.org/?lat=46.813085&lon=-67.887139

--- a/hwy_data/ME/usame/me.me167.wpt
+++ b/hwy_data/ME/usame/me.me167.wpt
@@ -5,5 +5,5 @@ ME163 http://www.openstreetmap.org/?lat=46.693372&lon=-67.997099
 StaSt http://www.openstreetmap.org/?lat=46.697103&lon=-67.971827
 ME205 http://www.openstreetmap.org/?lat=46.708930&lon=-67.951056
 MapGroRd http://www.openstreetmap.org/?lat=46.710472&lon=-67.947564
-ConRd_W http://www.openstreetmap.org/?lat=46.728991&lon=-67.912293
+ConRd http://www.openstreetmap.org/?lat=46.728991&lon=-67.912293
 US1Alt http://www.openstreetmap.org/?lat=46.752594&lon=-67.869544

--- a/hwy_data/ME/usame/me.me167.wpt
+++ b/hwy_data/ME/usame/me.me167.wpt
@@ -6,10 +6,4 @@ StaSt http://www.openstreetmap.org/?lat=46.697103&lon=-67.971827
 ME205 http://www.openstreetmap.org/?lat=46.708930&lon=-67.951056
 MapGroRd http://www.openstreetmap.org/?lat=46.710472&lon=-67.947564
 ConRd_W http://www.openstreetmap.org/?lat=46.728991&lon=-67.912293
-US1Alt_S http://www.openstreetmap.org/?lat=46.752594&lon=-67.869544
-ConRd_E http://www.openstreetmap.org/?lat=46.760317&lon=-67.858375
-US1Alt_N http://www.openstreetmap.org/?lat=46.772820&lon=-67.835555
-ForAve http://www.openstreetmap.org/?lat=46.769292&lon=-67.823587
-DorRd http://www.openstreetmap.org/?lat=46.765372&lon=-67.816452
-AroFalRd http://www.openstreetmap.org/?lat=46.767948&lon=-67.802741
-ME/NB http://www.openstreetmap.org/?lat=46.765315&lon=-67.789384
+US1Alt http://www.openstreetmap.org/?lat=46.752594&lon=-67.869544

--- a/hwy_data/ME/usausb/me.us001altfor.wpt
+++ b/hwy_data/ME/usausb/me.us001altfor.wpt
@@ -8,7 +8,7 @@ HerRd http://www.openstreetmap.org/?lat=46.606290&lon=-67.865982
 ME10 http://www.openstreetmap.org/?lat=46.643809&lon=-67.866840
 EasLineRd http://www.openstreetmap.org/?lat=46.687481&lon=-67.875606
 MapGroRd http://www.openstreetmap.org/?lat=46.719181&lon=-67.869844
-ME167_W http://www.openstreetmap.org/?lat=46.752594&lon=-67.869544
+ME167 http://www.openstreetmap.org/?lat=46.752594&lon=-67.869544
 ConRd http://www.openstreetmap.org/?lat=46.760317&lon=-67.858375
 ME161 http://www.openstreetmap.org/?lat=46.772820&lon=-67.835555
 NCarRd http://www.openstreetmap.org/?lat=46.774319&lon=-67.831950


### PR DESCRIPTION
2016-05-16;(USA) Maine;ME 161;me.me161;Extended at south end from US 1 Alternate over Main Street and Boundary Line Road (formerly ME 167) to the New Brunswick border.
﻿﻿2016-05-16;(USA) Maine;ME 167;me.me167;Truncated at east end from the New Brunswick border to US 1 Alternate and Fort Fairfield Road. Former segment from the New Brunswick border to US 1 Alternate and ME 161 redesignated as an extension of ME 161.