### PR TITLE
TX US287BusFtW truncation/relocation

### DIFF
--- a/hwy_data/TX/usaus/tx.us287.wpt
+++ b/hwy_data/TX/usaus/tx.us287.wpt
@@ -139,11 +139,11 @@ US67 http://www.openstreetmap.org/?lat=32.475956&lon=-97.010680
 US287BusMid_N http://www.openstreetmap.org/?lat=32.482151&lon=-97.017866
 FM661 http://www.openstreetmap.org/?lat=32.510354&lon=-97.063737
 TX360 http://www.openstreetmap.org/?lat=32.524017&lon=-97.085951
-US287BusFtW_S http://www.openstreetmap.org/?lat=32.537104&lon=-97.103460
+FM917 http://www.openstreetmap.org/?lat=32.537104&lon=-97.103460
 HerPkwy http://www.openstreetmap.org/?lat=32.554120&lon=-97.111164
 BroSt http://www.openstreetmap.org/?lat=32.568007&lon=-97.117397
 WalCreDr http://www.openstreetmap.org/?lat=32.581598&lon=-97.132165
-FM157 http://www.openstreetmap.org/?lat=32.597451&lon=-97.147339
+US287BusFtW_S http://www.openstreetmap.org/?lat=32.597451&lon=-97.147339
 TurWarRd http://www.openstreetmap.org/?lat=32.614027&lon=-97.161042
 RusCurRd http://www.openstreetmap.org/?lat=32.626405&lon=-97.171251
 EdenRd http://www.openstreetmap.org/?lat=32.633448&lon=-97.176572

--- a/hwy_data/TX/usausb/tx.us287busftw.wpt
+++ b/hwy_data/TX/usausb/tx.us287busftw.wpt
@@ -1,10 +1,5 @@
-US287_S http://www.openstreetmap.org/?lat=32.537104&lon=-97.103460
-FM157_S http://www.openstreetmap.org/?lat=32.535750&lon=-97.106271
-FM917 http://www.openstreetmap.org/?lat=32.549416&lon=-97.129207
-IndBlvd http://www.openstreetmap.org/?lat=32.556266&lon=-97.140561
-BroSt http://www.openstreetmap.org/?lat=32.563498&lon=-97.142041
-PleRidDr http://www.openstreetmap.org/?lat=32.573597&lon=-97.144144
-FM157_N http://www.openstreetmap.org/?lat=32.579166&lon=-97.149396
+US287_S http://www.openstreetmap.org/?lat=32.597451&lon=-97.147339
+FM157_S http://www.openstreetmap.org/?lat=32.579166&lon=-97.149396
 FM1187 http://www.openstreetmap.org/?lat=32.590731&lon=-97.162212
 TurWarRd http://www.openstreetmap.org/?lat=32.608510&lon=-97.181035
 SubRd http://www.openstreetmap.org/?lat=32.645850&lon=-97.220507


### PR DESCRIPTION
2016-05-26;(USA) Texas;US 287 Business (Fort Worth);tx.us287busftw;South end removed from Main Street south of Mouser Way to US 287, and relocated onto FM 157 north of Mouser Way to US 287.