### PR TITLE
GA/FL Updates

### DIFF
--- a/hwy_data/FL/usafl/fl.fl009bjac.wpt
+++ b/hwy_data/FL/usafl/fl.fl009bjac.wpt
@@ -1,3 +1,5 @@
+I-95 http://www.openstreetmap.org/?lat=30.114617&lon=-81.514156
+DurRd http://www.openstreetmap.org/?lat=30.130848&lon=-81.510240
 US1 http://www.openstreetmap.org/?lat=30.134805&lon=-81.509318
 +4 http://www.openstreetmap.org/?lat=30.165675&lon=-81.511163
 I-295 http://www.openstreetmap.org/?lat=30.180469&lon=-81.513609

--- a/hwy_data/FL/usai/fl.i010.wpt
+++ b/hwy_data/FL/usai/fl.i010.wpt
@@ -89,7 +89,8 @@ GadCoRA http://www.openstreetmap.org/?lat=30.630222&lon=-84.892634
 343 http://www.openstreetmap.org/?lat=30.288951&lon=-81.982896
 350 http://www.openstreetmap.org/?lat=30.306642&lon=-81.878325
 351 http://www.openstreetmap.org/?lat=30.309141&lon=-81.848560
-355 http://www.openstreetmap.org/?lat=30.315062&lon=-81.779295
+355 http://www.openstreetmap.org/?lat=30.314830&lon=-81.792741
+*355A http://www.openstreetmap.org/?lat=30.315062&lon=-81.779295
 356 http://www.openstreetmap.org/?lat=30.315219&lon=-81.769821
 357 http://www.openstreetmap.org/?lat=30.315506&lon=-81.751952
 358 http://www.openstreetmap.org/?lat=30.317296&lon=-81.730717

--- a/hwy_data/FL/usai/fl.i095.wpt
+++ b/hwy_data/FL/usai/fl.i095.wpt
@@ -139,7 +139,7 @@ US1 +0 http://www.openstreetmap.org/?lat=25.749548&lon=-80.211313
 +X020(I95) http://www.openstreetmap.org/?lat=30.044718&lon=-81.496600
 329 http://www.openstreetmap.org/?lat=30.065076&lon=-81.498165
 +X021(I95) http://www.openstreetmap.org/?lat=30.094541&lon=-81.498190
-+333 http://www.openstreetmap.org/?lat=30.114617&lon=-81.514156
+333 http://www.openstreetmap.org/?lat=30.114617&lon=-81.514156
 335 http://www.openstreetmap.org/?lat=30.141416&lon=-81.540624
 337 http://www.openstreetmap.org/?lat=30.166494&lon=-81.555080
 339 http://www.openstreetmap.org/?lat=30.184773&lon=-81.558131

--- a/hwy_data/FL/usaif/fl.i795futjac.wpt
+++ b/hwy_data/FL/usaif/fl.i795futjac.wpt
@@ -1,3 +1,5 @@
+I-95 http://www.openstreetmap.org/?lat=30.114617&lon=-81.514156
+DurRd http://www.openstreetmap.org/?lat=30.130848&lon=-81.510240
 US1 http://www.openstreetmap.org/?lat=30.134805&lon=-81.509318
 +4 http://www.openstreetmap.org/?lat=30.165675&lon=-81.511163
 I-295 http://www.openstreetmap.org/?lat=30.180469&lon=-81.513609

--- a/hwy_data/FL/usaus/fl.us090.wpt
+++ b/hwy_data/FL/usaus/fl.us090.wpt
@@ -149,6 +149,7 @@ US301_S http://www.openstreetmap.org/?lat=30.302756&lon=-81.983416
 US301_N http://www.openstreetmap.org/?lat=30.302849&lon=-81.972473
 +FutFL23 http://www.openstreetmap.org/?lat=30.311100&lon=-81.878636
 ChaRd +CR115C http://www.openstreetmap.org/?lat=30.314256&lon=-81.848539
+DevSt http://www.openstreetmap.org/?lat=30.320179&lon=-81.793682
 CahRd http://www.openstreetmap.org/?lat=30.322630&lon=-81.783696
 FL103 http://www.openstreetmap.org/?lat=30.324390&lon=-81.751990
 FL111 http://www.openstreetmap.org/?lat=30.327592&lon=-81.730854

--- a/hwy_data/GA/usai/ga.i085.wpt
+++ b/hwy_data/GA/usai/ga.i085.wpt
@@ -53,7 +53,8 @@ AL/GA +0 http://www.openstreetmap.org/?lat=32.854389&lon=-85.178764
 +X009(I85) http://www.openstreetmap.org/?lat=33.799562&lon=-84.391603
 86 http://www.openstreetmap.org/?lat=33.806453&lon=-84.381078
 +X010(I85) http://www.openstreetmap.org/?lat=33.813527&lon=-84.366642
-87 http://www.openstreetmap.org/?lat=33.821736&lon=-84.359701
+87A http://www.openstreetmap.org/?lat=33.820667&lon=-84.360548
+87 http://www.openstreetmap.org/?lat=33.822440&lon=-84.358746
 86A http://www.openstreetmap.org/?lat=33.822904&lon=-84.357319
 88 http://www.openstreetmap.org/?lat=33.823876&lon=-84.352008
 89 http://www.openstreetmap.org/?lat=33.832155&lon=-84.335529

--- a/hwy_data/GA/usansf/ga.ga400.wpt
+++ b/hwy_data/GA/usansf/ga.ga400.wpt
@@ -1,9 +1,10 @@
-I-85 http://www.openstreetmap.org/?lat=33.821736&lon=-84.359701
-1 http://www.openstreetmap.org/?lat=33.825150&lon=-84.359754
+1A +I-85 http://www.openstreetmap.org/?lat=33.822440&lon=-84.358746
+1B http://www.openstreetmap.org/?lat=33.825150&lon=-84.359754
 +X000(GA400) http://www.openstreetmap.org/?lat=33.840425&lon=-84.359969
 2 http://www.openstreetmap.org/?lat=33.851920&lon=-84.369807
 3 http://www.openstreetmap.org/?lat=33.903076&lon=-84.359432
 4 http://www.openstreetmap.org/?lat=33.911664&lon=-84.357088
+4C http://www.openstreetmap.org/?lat=33.918996&lon=-84.357850
 5 http://www.openstreetmap.org/?lat=33.933435&lon=-84.357845
 5C http://www.openstreetmap.org/?lat=33.946297&lon=-84.358027
 +X001(GA400) http://www.openstreetmap.org/?lat=33.957457&lon=-84.355892

--- a/hwy_data/GA/usaus/ga.us019.wpt
+++ b/hwy_data/GA/usaus/ga.us019.wpt
@@ -134,6 +134,7 @@ GleDrNE http://www.openstreetmap.org/?lat=33.902083&lon=-84.378819
 I-285(25) http://www.openstreetmap.org/?lat=33.912238&lon=-84.379045
 I-285(26) http://www.openstreetmap.org/?lat=33.910226&lon=-84.361750
 I-285(27) http://www.openstreetmap.org/?lat=33.911664&lon=-84.357088
+GA400(4C) http://www.openstreetmap.org/?lat=33.918996&lon=-84.357850
 GA400(5) http://www.openstreetmap.org/?lat=33.933435&lon=-84.357845
 GA400(5C) http://www.openstreetmap.org/?lat=33.946297&lon=-84.358027
 +X001(GA400) http://www.openstreetmap.org/?lat=33.957457&lon=-84.355892


### PR DESCRIPTION
See following posts:
http://tm.teresco.org/forum/index.php?topic=215.msg1425#msg1425
http://tm.teresco.org/forum/index.php?topic=27.0
http://tm.teresco.org/forum/index.php?topic=122.0

Update entries that are needed:
2016-06-16;(USA) Florida;I-10;fl.i010;Relocated exit 355 0.8 miles to the west to a new interchange with Hammond Boulvard, and relabeled former interchange (now closed) at Greeland Avenue as *355A.
2016-06-16;(USA) Florida;I-795 Future (Jacksonville);fl.i795futjac;Extended at south end from the interchange US 1 down to a new interchange with I-95.
