### PR TITLE
GA: US-19/19Bus updates around Dahlonega

### DIFF
--- a/hwy_data/GA/usaus/ga.us019.wpt
+++ b/hwy_data/GA/usaus/ga.us019.wpt
@@ -160,8 +160,8 @@ GA136 http://www.openstreetmap.org/?lat=34.398730&lon=-84.011968
 GA60_S http://www.openstreetmap.org/?lat=34.468672&lon=-83.967508
 +X017(US19) http://www.openstreetmap.org/?lat=34.478012&lon=-83.979557
 +X018(US19) http://www.openstreetmap.org/?lat=34.503285&lon=-83.968045
-US19BusDah_S http://www.openstreetmap.org/?lat=34.526933&lon=-83.979353
-GA9/52_S http://www.openstreetmap.org/?lat=34.537133&lon=-83.975978
+GA9/52 http://www.openstreetmap.org/?lat=34.526933&lon=-83.979353
+US19BusDah_S +GA9/52_S http://www.openstreetmap.org/?lat=34.537133&lon=-83.975978
 GA52_E http://www.openstreetmap.org/?lat=34.540830&lon=-83.974326
 US19BusDah_N http://www.openstreetmap.org/?lat=34.570890&lon=-83.968050
 +X019(US19) http://www.openstreetmap.org/?lat=34.609387&lon=-83.970780

--- a/hwy_data/GA/usausb/ga.us019busdah.wpt
+++ b/hwy_data/GA/usausb/ga.us019busdah.wpt
@@ -1,5 +1,5 @@
 US19_S http://www.openstreetmap.org/?lat=34.537133&lon=-83.975978
-MainSt_W http://www.openstreetmap.org/?lat=34.533695&lon=-83.983274
+MainSt_W +GA9/52_N http://www.openstreetmap.org/?lat=34.533695&lon=-83.983274
 OakGroRd http://www.openstreetmap.org/?lat=34.550495&lon=-83.995441
 AndDr http://www.openstreetmap.org/?lat=34.562092&lon=-83.995494
 +X000(US19B) http://www.openstreetmap.org/?lat=34.568709&lon=-83.982228

--- a/hwy_data/GA/usausb/ga.us019busdah.wpt
+++ b/hwy_data/GA/usausb/ga.us019busdah.wpt
@@ -1,6 +1,5 @@
-US19_S http://www.openstreetmap.org/?lat=34.526933&lon=-83.979353
-GA9/52_S http://www.openstreetmap.org/?lat=34.532389&lon=-83.985216
-GA9/52_N http://www.openstreetmap.org/?lat=34.533695&lon=-83.983274
+US19_S http://www.openstreetmap.org/?lat=34.537133&lon=-83.975978
+MainSt_W http://www.openstreetmap.org/?lat=34.533695&lon=-83.983274
 OakGroRd http://www.openstreetmap.org/?lat=34.550495&lon=-83.995441
 AndDr http://www.openstreetmap.org/?lat=34.562092&lon=-83.995494
 +X000(US19B) http://www.openstreetmap.org/?lat=34.568709&lon=-83.982228


### PR DESCRIPTION
See: http://tm.teresco.org/forum/index.php?topic=216.0

Entries for update log:

2016-06-27;(USA) Georgia;US 19 Business (Dahlonega);ga.us019busdah;Removed from South Chestatee Street and East Main Street between the intersections of South Chestatee Street/US 19/GA 9/GA 52/GA 60 and North Grove Street/East Main Street. Then rerouted along East Main Street between the intersections of North Grove Street/East Main Street and East Main Street/US 19/GA 9/GA 52/GA 60.

2016-06-27;(USA) Georgia;US 19;ga.us019;Moved label 'US19BusDah_S' from intersection with South Chestatee Street (now 'GA9/52') to the north to the intersection with East Main Street (formerly 'GA9/52_S') in Dahlonega.
