### PR TITLE
TN: I-69 (Memphis)

### DIFF
--- a/hwy_data/TN/usai/tn.i069.wpt
+++ b/hwy_data/TN/usai/tn.i069.wpt
@@ -1,0 +1,17 @@
+MS/TN +0 http://www.openstreetmap.org/?lat=34.995022&lon=-90.002449
+2 http://www.openstreetmap.org/?lat=35.021066&lon=-90.002543
++X000(I55) http://www.openstreetmap.org/?lat=35.037604&lon=-90.003004
+5A http://www.openstreetmap.org/?lat=35.061372&lon=-90.019596
+5B http://www.openstreetmap.org/?lat=35.063383&lon=-90.023136
+6 http://www.openstreetmap.org/?lat=35.072585&lon=-90.026822
+26(240) http://www.openstreetmap.org/?lat=35.083446&lon=-90.025551
+28(240) http://www.openstreetmap.org/?lat=35.109772&lon=-90.029081
+29(240) http://www.openstreetmap.org/?lat=35.130351&lon=-90.023931
+30(240) http://www.openstreetmap.org/?lat=35.137594&lon=-90.024172
+30A(240) http://www.openstreetmap.org/?lat=35.139590&lon=-90.023593
+31(240) http://www.openstreetmap.org/?lat=35.149591&lon=-90.022010
+32(240) http://www.openstreetmap.org/?lat=35.158065&lon=-90.020471
++X700(I240) http://www.openstreetmap.org/?lat=35.159410&lon=-90.020256
+1E(40) +1F(40) +I-240 http://www.openstreetmap.org/?lat=35.161288&lon=-90.019886
+2(40) http://www.openstreetmap.org/?lat=35.172787&lon=-90.018427
+2A(40) http://www.openstreetmap.org/?lat=35.190592&lon=-90.015020

--- a/hwy_data/TN/usaif/tn.i069futmem.wpt
+++ b/hwy_data/TN/usaif/tn.i069futmem.wpt
@@ -1,18 +1,2 @@
-MS/TN +0 http://www.openstreetmap.org/?lat=34.995022&lon=-90.002449
-2 http://www.openstreetmap.org/?lat=35.021066&lon=-90.002543
-+X000(I55) http://www.openstreetmap.org/?lat=35.037604&lon=-90.003004
-5A http://www.openstreetmap.org/?lat=35.061372&lon=-90.019596
-5B http://www.openstreetmap.org/?lat=35.063383&lon=-90.023136
-6 http://www.openstreetmap.org/?lat=35.072585&lon=-90.026822
-26(240) http://www.openstreetmap.org/?lat=35.083446&lon=-90.025551
-28(240) http://www.openstreetmap.org/?lat=35.109772&lon=-90.029081
-29(240) http://www.openstreetmap.org/?lat=35.130351&lon=-90.023931
-30(240) http://www.openstreetmap.org/?lat=35.137594&lon=-90.024172
-30A(240) http://www.openstreetmap.org/?lat=35.139590&lon=-90.023593
-31(240) http://www.openstreetmap.org/?lat=35.149591&lon=-90.022010
-32(240) http://www.openstreetmap.org/?lat=35.158065&lon=-90.020471
-+X700(I240) http://www.openstreetmap.org/?lat=35.159410&lon=-90.020256
-1E(40) +1F(40) +I-240 http://www.openstreetmap.org/?lat=35.161288&lon=-90.019886
-2(40) http://www.openstreetmap.org/?lat=35.172787&lon=-90.018427
 2A(40) http://www.openstreetmap.org/?lat=35.190592&lon=-90.015020
 US51 http://www.openstreetmap.org/?lat=35.199456&lon=-90.034590

--- a/hwy_data/_systems/usai.csv
+++ b/hwy_data/_systems/usai.csv
@@ -123,6 +123,7 @@ usai;WV;I-68;;;;wv.i068;
 usai;MD;I-68;;;;md.i068;
 usai;TX;I-69;;;Houston, TX;tx.i069;I-69Sug
 usai;MS;I-69;;;;ms.i069;
+usai;TN;I-69;;;;tn.i069;
 usai;KY;I-69;;;;ky.i069;I-69FutMad
 usai;IN;I-69;;Whe;Wheatonville, IN;in.i069whe;
 usai;IN;I-69;;;Fort Wayne, IN;in.i069;

--- a/hwy_data/_systems/usai_con.csv
+++ b/hwy_data/_systems/usai_con.csv
@@ -54,7 +54,7 @@ usai;I-65;;;al.i065,tn.i065,ky.i065,in.i065
 usai;I-66;;;va.i066,dc.i066
 usai;I-68;;;wv.i068,md.i068
 usai;I-69;;Houston, TX;tx.i069
-usai;I-69;;Mississippi;ms.i069
+usai;I-69;;Mississippi - Tennessee;ms.i069,tn.i069
 usai;I-69;;Kentucky;ky.i069
 usai;I-69;;S. Indiana;in.i069whe
 usai;I-69;;C. Indiana - Michigan;in.i069,mi.i069


### PR DESCRIPTION
This change promotes the section between Mississippi and I-40 Exit 2A to a full Interstate.  It has full approval from AASHTO and FHWA, since 2008, yet TDOT still hasn't posted it.  Thus considering it now as a 'hidden' Interstate since it's route is along 3 other fully posted Interstates (I-55, I-240, I-40) & Mississippi posted their segment which was approved at the same time.

See more discussion about this here: http://tm.teresco.org/forum/index.php?topic=309.0

Do not pull in just yet till we're 100% sure we want to go this way.

Either way, here's the entry log for the update page (will need date adjusted to whenever/if we pull in):

2016-06-27;(USA) Tennessee;I-69;tn.i069;Added route.
2016-06-27;(USA) Tennessee;I-69 Future (Memphis);tn.i069futmem;Truncated from southern end at Mississippi state border to I-40 exit 2A. That section is now I-69.
