### PR TITLE
PA Fixes

### DIFF
--- a/hwy_data/PA/usai/pa.i076.wpt
+++ b/hwy_data/PA/usai/pa.i076.wpt
@@ -104,6 +104,7 @@ OH/PA +0 http://www.openstreetmap.org/?lat=40.911518&lon=-80.519700
 326 http://www.openstreetmap.org/?lat=40.091698&lon=-75.409180
 327 http://www.openstreetmap.org/?lat=40.086555&lon=-75.400897
 328 https://www.openstreetmap.org/?lat=40.083350&lon=-75.394396
+329 http://www.openstreetmap.org/?lat=40.075059&lon=-75.352918
 330 http://www.openstreetmap.org/?lat=40.068515&lon=-75.341502
 331 https://www.openstreetmap.org/?lat=40.064739&lon=-75.321364
 332 http://www.openstreetmap.org/?lat=40.066372&lon=-75.313135

--- a/hwy_data/PA/usapa/pa.pa272.wpt
+++ b/hwy_data/PA/usapa/pa.pa272.wpt
@@ -22,6 +22,6 @@ US222_Ore http://www.openstreetmap.org/?lat=40.104834&lon=-76.254923
 PA722 https://www.openstreetmap.org/?lat=40.114719&lon=-76.243937
 PA772 https://www.openstreetmap.org/?lat=40.131039&lon=-76.217051
 US322 https://www.openstreetmap.org/?lat=40.185731&lon=-76.187568
-SpuRd http://www.openstreetmap.org/?lat=40.222490&lon=-76.096759
+ColHowBlvd +SpuRd http://www.openstreetmap.org/?lat=40.222490&lon=-76.096759
 PA897 https://www.openstreetmap.org/?lat=40.233120&lon=-76.078327
 US222/568 https://www.openstreetmap.org/?lat=40.249059&lon=-76.036828

--- a/hwy_data/PA/usapa/pa.pa902.wpt
+++ b/hwy_data/PA/usapa/pa.pa902.wpt
@@ -1,7 +1,8 @@
 US209 https://www.openstreetmap.org/?lat=40.832028&lon=-75.882440
-NorSt http://www.openstreetmap.org/?lat=40.829032&lon=-75.872054
-CheSt_S http://www.openstreetmap.org/?lat=40.823516&lon=-75.870810
-LauRd http://www.openstreetmap.org/?lat=40.825083&lon=-75.850157
+CheSt http://www.openstreetmap.org/?lat=40.829032&lon=-75.872054
+LehSt http://www.openstreetmap.org/?lat=40.829041&lon=-75.868996
+AmiSt http://www.openstreetmap.org/?lat=40.824125&lon=-75.867510
+WhiBearDr +LauRd http://www.openstreetmap.org/?lat=40.825083&lon=-75.850157
 MillRd_S http://www.openstreetmap.org/?lat=40.797559&lon=-75.809956
 MahSt_E http://www.openstreetmap.org/?lat=40.831468&lon=-75.721700
 PA443 http://www.openstreetmap.org/?lat=40.821661&lon=-75.720413

--- a/hwy_data/PA/usaus/pa.us202.wpt
+++ b/hwy_data/PA/usaus/pa.us202.wpt
@@ -20,9 +20,13 @@ PA252_E https://www.openstreetmap.org/?lat=40.071766&lon=-75.437204
 SweRd http://www.openstreetmap.org/?lat=40.076561&lon=-75.415006
 US422 http://www.openstreetmap.org/?lat=40.079779&lon=-75.406938
 I-76 https://www.openstreetmap.org/?lat=40.083350&lon=-75.394396
-MonAve +PA363 http://www.openstreetmap.org/?lat=40.085098&lon=-75.388827
+GulRd +PA363 +MonAve http://www.openstreetmap.org/?lat=40.085098&lon=-75.388827
+HenRd http://www.openstreetmap.org/?lat=40.094673&lon=-75.362869
 DekPk_S +DekPk http://www.openstreetmap.org/?lat=40.098629&lon=-75.354581
 PA23 http://www.openstreetmap.org/?lat=40.105978&lon=-75.348959
+MainSt http://www.openstreetmap.org/?lat=40.114987&lon=-75.345633
+JohHwy http://www.openstreetmap.org/?lat=40.131945&lon=-75.328585
+GerPk http://www.openstreetmap.org/?lat=40.141771&lon=-75.312535
 PA73 https://www.openstreetmap.org/?lat=40.167101&lon=-75.290251
 SumPk http://www.openstreetmap.org/?lat=40.202002&lon=-75.255446
 DekPk_N http://www.openstreetmap.org/?lat=40.216406&lon=-75.247679


### PR DESCRIPTION
See the following threads:
http://tm.teresco.org/forum/index.php?topic=358.0
http://tm.teresco.org/forum/index.php?topic=356.0
http://tm.teresco.org/forum/index.php?topic=353.0

Only newsworthy entry is the correction of the routing of PA-902 in Summit Hill.

2016-07-25;(USA) Pennsylvania;PA 902;pa.pa902;Removed from North/South Chestnut Street and East Amidon Street in Summit Hill, and rerouted along East North Street & North/South Pine Street between the intersections of PA 902 (East North Street)/North Chestnut Street and PA 902 (East Amidon Street)/South Pine Street.