### PR TITLE
Williston ND changes

### DIFF
--- a/hwy_data/ND/usand/nd.nd1804.wpt
+++ b/hwy_data/ND/usand/nd.nd1804.wpt
@@ -93,12 +93,12 @@ ND23BTrk_N http://www.openstreetmap.org/?lat=47.997134&lon=-102.497345
 +X016 http://www.openstreetmap.org/?lat=48.152745&lon=-103.297405
 124thAve http://www.openstreetmap.org/?lat=48.154463&lon=-103.367100
 129thAve http://www.openstreetmap.org/?lat=48.154463&lon=-103.474731
-20thAve http://www.openstreetmap.org/?lat=48.147062&lon=-103.593607
-US2Bus_E http://www.openstreetmap.org/?lat=48.146553&lon=-103.621888
-2ndSt http://www.openstreetmap.org/?lat=48.145523&lon=-103.621695
+US85Byp +20thAve http://www.openstreetmap.org/?lat=48.147062&lon=-103.593607
+7thAve http://www.openstreetmap.org/?lat=48.147033&lon=-103.610966
+US2/85Bus_E http://www.openstreetmap.org/?lat=48.144524&lon=-103.621459
 2ndAve http://www.openstreetmap.org/?lat=48.145211&lon=-103.625756
-US2Bus_W http://www.openstreetmap.org/?lat=48.145830&lon=-103.658345
-US85_S http://www.openstreetmap.org/?lat=48.140210&lon=-103.723512
+US2/85Bus_W  +US2Bus_W http://www.openstreetmap.org/?lat=48.145830&lon=-103.658345
+US85 +US85_S http://www.openstreetmap.org/?lat=48.140210&lon=-103.723512
 US2_W http://www.openstreetmap.org/?lat=48.140067&lon=-103.776877
 48thSt http://www.openstreetmap.org/?lat=48.111214&lon=-103.776855
 144thAve http://www.openstreetmap.org/?lat=48.081806&lon=-103.798742

--- a/hwy_data/ND/usaus/nd.us002.wpt
+++ b/hwy_data/ND/usaus/nd.us002.wpt
@@ -4,9 +4,9 @@ MT/ND http://www.openstreetmap.org/?lat=48.137454&lon=-104.045087
 145thAve http://www.openstreetmap.org/?lat=48.140318&lon=-103.819942
 ND1804 http://www.openstreetmap.org/?lat=48.140067&lon=-103.776877
 US85_S http://www.openstreetmap.org/?lat=48.140210&lon=-103.723512
-US2BusWil_W http://www.openstreetmap.org/?lat=48.145830&lon=-103.658345
+US2BusWil/1804 +US2BusWil_W http://www.openstreetmap.org/?lat=48.145830&lon=-103.658345
 US2BusWil_E http://www.openstreetmap.org/?lat=48.168733&lon=-103.625901
-US2Byp_E http://www.openstreetmap.org/?lat=48.244697&lon=-103.625654
+US85/85Byp +US2Byp_E http://www.openstreetmap.org/?lat=48.244697&lon=-103.625654
 US85_N http://www.openstreetmap.org/?lat=48.340430&lon=-103.623675
 129thAve http://www.openstreetmap.org/?lat=48.342530&lon=-103.474678
 123rdAve http://www.openstreetmap.org/?lat=48.342602&lon=-103.345084

--- a/hwy_data/ND/usaus/nd.us085.wpt
+++ b/hwy_data/ND/usaus/nd.us085.wpt
@@ -53,9 +53,12 @@ CR16 http://www.openstreetmap.org/?lat=47.978633&lon=-103.659750
 CR4 http://www.openstreetmap.org/?lat=48.057925&lon=-103.661166
 RivLn http://www.openstreetmap.org/?lat=48.117492&lon=-103.723351
 US2_W http://www.openstreetmap.org/?lat=48.140210&lon=-103.723512
-US85BusWil_S +US2Bus_W http://www.openstreetmap.org/?lat=48.145830&lon=-103.658345
-US85BusWil_N +US2Bus_E http://www.openstreetmap.org/?lat=48.168733&lon=-103.625901
-US85Byp http://www.openstreetmap.org/?lat=48.244697&lon=-103.625654
+52ndSt http://www.openstreetmap.org/?lat=48.168661&lon=-103.733693
++X141600 http://www.openstreetmap.org/?lat=48.185782&lon=-103.753772
+56thSt_W http://www.openstreetmap.org/?lat=48.225527&lon=-103.748247
+56thSt_E http://www.openstreetmap.org/?lat=48.227181&lon=-103.734267
+140thAve http://www.openstreetmap.org/?lat=48.241410&lon=-103.712273
+US2/85Byp +US85Byp http://www.openstreetmap.org/?lat=48.244697&lon=-103.625654
 US2_E http://www.openstreetmap.org/?lat=48.340430&lon=-103.623675
 69thSt http://www.openstreetmap.org/?lat=48.416385&lon=-103.624672
 CR12 http://www.openstreetmap.org/?lat=48.503348&lon=-103.624308
@@ -67,4 +70,4 @@ ND50 http://www.openstreetmap.org/?lat=48.569444&lon=-103.624270
 ND5_E http://www.openstreetmap.org/?lat=48.908962&lon=-103.616878
 MainSt_For http://www.openstreetmap.org/?lat=48.909269&lon=-103.776528
 ND5_W http://www.openstreetmap.org/?lat=48.909279&lon=-103.794043
-ND/Can http://www.openstreetmap.org/?lat=48.999521&lon=-103.809557
+USA/Can +ND/Can http://www.openstreetmap.org/?lat=48.999521&lon=-103.809557

--- a/hwy_data/ND/usausb/nd.us002buswil.wpt
+++ b/hwy_data/ND/usausb/nd.us002buswil.wpt
@@ -1,7 +1,8 @@
 US2_W http://www.openstreetmap.org/?lat=48.145830&lon=-103.658345
 2ndAve http://www.openstreetmap.org/?lat=48.145211&lon=-103.625756
+ND1804_E http://www.openstreetmap.org/?lat=48.144524&lon=-103.621459
 2ndSt http://www.openstreetmap.org/?lat=48.145523&lon=-103.621695
-ND1804 http://www.openstreetmap.org/?lat=48.146553&lon=-103.621888
+Bro +ND1804 http://www.openstreetmap.org/?lat=48.146553&lon=-103.621888
 11thSt_E http://www.openstreetmap.org/?lat=48.154212&lon=-103.623165
 11thSt_W http://www.openstreetmap.org/?lat=48.154191&lon=-103.625804
 US2_E http://www.openstreetmap.org/?lat=48.168733&lon=-103.625901

--- a/hwy_data/ND/usausb/nd.us002bypwil.wpt
+++ b/hwy_data/ND/usausb/nd.us002bypwil.wpt
@@ -1,7 +1,0 @@
-US2_W http://www.openstreetmap.org/?lat=48.140210&lon=-103.723512
-52ndSt http://www.openstreetmap.org/?lat=48.168661&lon=-103.733693
-+X141600 http://www.openstreetmap.org/?lat=48.185782&lon=-103.753772
-56thSt_W http://www.openstreetmap.org/?lat=48.225527&lon=-103.748247
-56thSt_E http://www.openstreetmap.org/?lat=48.227181&lon=-103.734267
-140thAve http://www.openstreetmap.org/?lat=48.241410&lon=-103.712273
-US2_E http://www.openstreetmap.org/?lat=48.244697&lon=-103.625654

--- a/hwy_data/ND/usausb/nd.us085buswil.wpt
+++ b/hwy_data/ND/usausb/nd.us085buswil.wpt
@@ -1,7 +1,8 @@
-US85_S http://www.openstreetmap.org/?lat=48.145830&lon=-103.658345
+US2_W http://www.openstreetmap.org/?lat=48.145830&lon=-103.658345
 2ndAve http://www.openstreetmap.org/?lat=48.145211&lon=-103.625756
+ND1804_E http://www.openstreetmap.org/?lat=48.144524&lon=-103.621459
 2ndSt http://www.openstreetmap.org/?lat=48.145523&lon=-103.621695
-ND1804 http://www.openstreetmap.org/?lat=48.146553&lon=-103.621888
+Bro +ND1804 http://www.openstreetmap.org/?lat=48.146553&lon=-103.621888
 11thSt_E http://www.openstreetmap.org/?lat=48.154212&lon=-103.623165
 11thSt_W http://www.openstreetmap.org/?lat=48.154191&lon=-103.625804
-US85_N http://www.openstreetmap.org/?lat=48.168733&lon=-103.625901
+US2_E http://www.openstreetmap.org/?lat=48.168733&lon=-103.625901

--- a/hwy_data/ND/usausb/nd.us085bypwil.wpt
+++ b/hwy_data/ND/usausb/nd.us085bypwil.wpt
@@ -1,7 +1,8 @@
-US85_S http://www.openstreetmap.org/?lat=48.140210&lon=-103.723512
-52ndSt http://www.openstreetmap.org/?lat=48.168661&lon=-103.733693
-+X141600 http://www.openstreetmap.org/?lat=48.185782&lon=-103.753772
-56thSt_W http://www.openstreetmap.org/?lat=48.225527&lon=-103.748247
-56thSt_E http://www.openstreetmap.org/?lat=48.227181&lon=-103.734267
-140thAve http://www.openstreetmap.org/?lat=48.241410&lon=-103.712273
-US85_N http://www.openstreetmap.org/?lat=48.244697&lon=-103.625654
+ND1804 http://www.openstreetmap.org/?lat=48.147062&lon=-103.593607
+20thAve http://www.openstreetmap.org/?lat=48.153382&lon=-103.593494
++X959903 http://www.openstreetmap.org/?lat=48.154971&lon=-103.583146
+53rdSt http://www.openstreetmap.org/?lat=48.183221&lon=-103.582765
+55thSt http://www.openstreetmap.org/?lat=48.212213&lon=-103.582878
+57thSt http://www.openstreetmap.org/?lat=48.241181&lon=-103.583012
+135thAve http://www.openstreetmap.org/?lat=48.242432&lon=-103.604046
+US2/85 http://www.openstreetmap.org/?lat=48.244697&lon=-103.625654

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -37,7 +37,6 @@ usausb;WA;US2;Bus;Cas;Cashmere, WA;wa.us002buscas;
 usausb;ND;US2;Bus;Wil;Williston, ND;nd.us002buswil;
 usausb;ND;US2;Bus;Min;Minot, ND;nd.us002busmin;
 usausb;ND;US2;Bus;GrF;Grand Forks, ND;nd.us002busgrf;
-usausb;ND;US2;Byp;Wil;Williston, ND;nd.us002bypwil;
 usausb;MN;US2;Bus;EGr;East Grand Forks, MN;mn.us002busegr;
 usausb;WI;US2;Trk;Sup;Superior, WI;wi.us002trksup;
 usausb;WI;US2;Alt;Ash;Ashland, WI;wi.us002altash;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -35,7 +35,6 @@ usausb;US2;Bus;Cashmere, WA;wa.us002buscas
 usausb;US2;Bus;Williston, ND;nd.us002buswil
 usausb;US2;Bus;Minot, ND;nd.us002busmin
 usausb;US2;Bus;Grand Forks, ND;nd.us002busgrf,mn.us002busegr
-usausb;US2;Byp;Williston, ND;nd.us002bypwil
 usausb;US2;Trk;Superior, WI;wi.us002trksup
 usausb;US2;Alt;Ashland, WI;wi.us002altash
 usausb;US2;Bus;Ironwood, MI;mi.us002busiro


### PR DESCRIPTION
Several reroutes in Williston ND area, including US 85 onto western bypass (absorbing former US 2 Byp and US 85 Byp), new US 85 eastern bypass (replacing former US 85 Byp), and lesser reroutes of Bus US2/85 and ND 1804 in downtown Williston. Previously discussed on the TM and AARoads forums.

Updates items:

2016-07-28;(USA) North Dakota;US 85;nd.us085;Relocated from US 2 to new western Williston bypass, between southern US 2 junction and new US 85 Bypass

2016-07-28;(USA) North Dakota;US 2 Bypass (Williston);(NONE): Route deleted (absorbed into US 85)

2016-07-28;(USA) North Dakota;US 85 Bypass (Williston);nd.us085bypwil:Route relocated from western Williston bypass (now part of US 85) to new eastern bypass

2016-07-28;(USA) North Dakota;US 2 Business (Williston);nd.us002buswil;Relocated from 2nd St., between 2nd Ave. and Main St., one block south to 1st St. and Main St.

2016-07-28;(USA) North Dakota;US 85 Business (Williston);nd.us085buswil;Relocated from 2nd St., between 2nd Ave. and Main St., one block south to 1st St. and Main St.

2016-07-28;(USA) North Dakota;ND 1804;nd.nd1804;In downtown Williston, relocated from 2nd St., Main St., and Broadway,, between 2nd Ave. and 7th Ave., south to 1st St. and 7th Ave.