### PR TITLE
AR US67: Swifton to Walnut Ridge

### DIFF
--- a/hwy_data/AR/usaus/ar.us063.wpt
+++ b/hwy_data/AR/usaus/ar.us063.wpt
@@ -124,8 +124,8 @@ AR228_E http://www.openstreetmap.org/?lat=35.976930&lon=-90.860195
 AR228_W http://www.openstreetmap.org/?lat=35.978666&lon=-90.862727
 AR91_N http://www.openstreetmap.org/?lat=36.032755&lon=-90.940361
 US63BusHox_S http://www.openstreetmap.org/?lat=36.034729&lon=-90.945318
-US67_N http://www.openstreetmap.org/?lat=36.035358&lon=-90.956669
-US67_S http://www.openstreetmap.org/?lat=36.036850&lon=-90.984907
+US67  +US67_N http://www.openstreetmap.org/?lat=36.035358&lon=-90.956669
+AR367 http://www.openstreetmap.org/?lat=36.036850&lon=-90.984907
 +X135816 http://www.openstreetmap.org/?lat=36.039383&lon=-91.001773
 US63BusHox_N http://www.openstreetmap.org/?lat=36.062132&lon=-91.004133
 US412_E http://www.openstreetmap.org/?lat=36.077130&lon=-91.041427

--- a/hwy_data/AR/usaus/ar.us067.wpt
+++ b/hwy_data/AR/usaus/ar.us067.wpt
@@ -131,13 +131,11 @@ CR43 http://www.openstreetmap.org/?lat=35.660661&lon=-91.210856
 +X101 http://www.openstreetmap.org/?lat=35.680690&lon=-91.126699
 AR37 http://www.openstreetmap.org/?lat=35.724671&lon=-91.097174
 AR226 http://www.openstreetmap.org/?lat=35.796165&lon=-91.023188
-AR224 http://www.openstreetmap.org/?lat=35.799141&lon=-91.124382
-AR367 +Old67 http://www.openstreetmap.org/?lat=35.799785&lon=-91.150045
-MainSt_Swi http://www.openstreetmap.org/?lat=35.825277&lon=-91.132321
-AR230 http://www.openstreetmap.org/?lat=35.894752&lon=-91.085458
-AR228 http://www.openstreetmap.org/?lat=35.973734&lon=-91.029067
-US63_N +US63/67Bus http://www.openstreetmap.org/?lat=36.036850&lon=-90.984907
-US63_S http://www.openstreetmap.org/?lat=36.035358&lon=-90.956669
++X931873 http://www.openstreetmap.org/?lat=35.879083&lon=-91.000481
+AR230 http://www.openstreetmap.org/?lat=35.898735&lon=-90.999716
++X146053 http://www.openstreetmap.org/?lat=35.947478&lon=-90.979344
++X797383 http://www.openstreetmap.org/?lat=36.003385&lon=-90.977944
+US63 +US63_S http://www.openstreetmap.org/?lat=36.035358&lon=-90.956669
 US412 http://www.openstreetmap.org/?lat=36.068666&lon=-90.934010
 AR34 http://www.openstreetmap.org/?lat=36.082055&lon=-90.936842
 CR429 http://www.openstreetmap.org/?lat=36.085974&lon=-90.940061


### PR DESCRIPTION
2016-08-12;(USA) Arkansas;US 67;ar.us067;Removed from AR 226, AR 367 and US63, and relocated onto a divided freeway between AR 226 and US63.