### PR TITLE
TN: US-11/70 reroute in Knoxville

### DIFF
--- a/hwy_data/TN/usaus/tn.us011.wpt
+++ b/hwy_data/TN/usaus/tn.us011.wpt
@@ -75,14 +75,14 @@ BucDr http://www.openstreetmap.org/?lat=35.928498&lon=-84.036162
 PapDr http://www.openstreetmap.org/?lat=35.932503&lon=-84.017542
 TNs332_Kno http://www.openstreetmap.org/?lat=35.932872&lon=-84.002559
 LyoViewPike http://www.openstreetmap.org/?lat=35.940950&lon=-83.978532
-TN158 http://www.openstreetmap.org/?lat=35.951469&lon=-83.947027
-US129 http://www.openstreetmap.org/?lat=35.952598&lon=-83.942714
-17thSt +17thStSW http://www.openstreetmap.org/?lat=35.956532&lon=-83.932382
-US441_S +US441 http://www.openstreetmap.org/?lat=35.960518&lon=-83.920827
-I-40/275 http://www.openstreetmap.org/?lat=35.963757&lon=-83.922844
-TNs62 http://www.openstreetmap.org/?lat=35.964834&lon=-83.924088
-MagAve http://www.openstreetmap.org/?lat=35.970227&lon=-83.924099
-US441_N http://www.openstreetmap.org/?lat=35.972491&lon=-83.923944
-HallFameDr http://www.openstreetmap.org/?lat=35.975733&lon=-83.916745
+KinPk_E +TN158 http://www.openstreetmap.org/?lat=35.951469&lon=-83.947027
+US129 http://www.openstreetmap.org/?lat=35.948073&lon=-83.944860
++X005(US11) http://www.openstreetmap.org/?lat=35.943417&lon=-83.933766
+LakeLouBlvd http://www.openstreetmap.org/?lat=35.949428&lon=-83.924909
+WalSt http://www.openstreetmap.org/?lat=35.959224&lon=-83.917340
+TN158/71 http://www.openstreetmap.org/?lat=35.962559&lon=-83.913719
+HallFameDr_S http://www.openstreetmap.org/?lat=35.963814&lon=-83.911616
+SumHillDr http://www.openstreetmap.org/?lat=35.969619&lon=-83.915570
+HallFameDr_N http://www.openstreetmap.org/?lat=35.975733&lon=-83.916745
 CheSt +NCheSt http://www.openstreetmap.org/?lat=35.986992&lon=-83.893865
 US11E/11W http://www.openstreetmap.org/?lat=36.001749&lon=-83.874811

--- a/hwy_data/TN/usaus/tn.us070.wpt
+++ b/hwy_data/TN/usaus/tn.us070.wpt
@@ -208,15 +208,15 @@ BucDr http://www.openstreetmap.org/?lat=35.928498&lon=-84.036162
 PapDr http://www.openstreetmap.org/?lat=35.932503&lon=-84.017542
 TNs332_Kno http://www.openstreetmap.org/?lat=35.932872&lon=-84.002559
 LyoViewPike http://www.openstreetmap.org/?lat=35.940950&lon=-83.978532
-TN158 +NeyDr http://www.openstreetmap.org/?lat=35.951469&lon=-83.947027
-US129 http://www.openstreetmap.org/?lat=35.952598&lon=-83.942714
-17thSt +17thStSW http://www.openstreetmap.org/?lat=35.956532&lon=-83.932382
-US441_S +US441 http://www.openstreetmap.org/?lat=35.960518&lon=-83.920827
-I-40/275 http://www.openstreetmap.org/?lat=35.963757&lon=-83.922844
-TNs62 http://www.openstreetmap.org/?lat=35.964834&lon=-83.924088
-MagAve http://www.openstreetmap.org/?lat=35.970227&lon=-83.924099
-US441_N http://www.openstreetmap.org/?lat=35.972491&lon=-83.923944
-HallFameDr http://www.openstreetmap.org/?lat=35.975733&lon=-83.916745
+KinPk_E +TN158 http://www.openstreetmap.org/?lat=35.951469&lon=-83.947027
+US129 http://www.openstreetmap.org/?lat=35.948073&lon=-83.944860
++X005(US11) http://www.openstreetmap.org/?lat=35.943417&lon=-83.933766
+LakeLouBlvd http://www.openstreetmap.org/?lat=35.949428&lon=-83.924909
+WalSt http://www.openstreetmap.org/?lat=35.959224&lon=-83.917340
+TN158/71 http://www.openstreetmap.org/?lat=35.962559&lon=-83.913719
+HallFameDr_S http://www.openstreetmap.org/?lat=35.963814&lon=-83.911616
+SumHillDr http://www.openstreetmap.org/?lat=35.969619&lon=-83.915570
+HallFameDr_N http://www.openstreetmap.org/?lat=35.975733&lon=-83.916745
 CheSt +NCheSt http://www.openstreetmap.org/?lat=35.986992&lon=-83.893865
 US11/11W +US11W_N http://www.openstreetmap.org/?lat=36.001749&lon=-83.874811
 I-40(394) http://www.openstreetmap.org/?lat=36.010501&lon=-83.841514

--- a/hwy_data/TN/usaus/tn.us129.wpt
+++ b/hwy_data/TN/usaus/tn.us129.wpt
@@ -31,6 +31,6 @@ TNs333 http://www.openstreetmap.org/?lat=35.866535&lon=-83.959590
 TNs168 http://www.openstreetmap.org/?lat=35.885226&lon=-83.954333
 MalRd http://www.openstreetmap.org/?lat=35.905137&lon=-83.953797
 CheTrl http://www.openstreetmap.org/?lat=35.937215&lon=-83.948679
-TNs158 http://www.openstreetmap.org/?lat=35.948073&lon=-83.944860
-US11/70 http://www.openstreetmap.org/?lat=35.952598&lon=-83.942714
+US11/70 +TNs158 http://www.openstreetmap.org/?lat=35.948073&lon=-83.944860
+KinPk http://www.openstreetmap.org/?lat=35.952598&lon=-83.942714
 I-40 +I-40(386) http://www.openstreetmap.org/?lat=35.963545&lon=-83.946769

--- a/hwy_data/TN/usaus/tn.us441.wpt
+++ b/hwy_data/TN/usaus/tn.us441.wpt
@@ -20,14 +20,14 @@ ZionHillRd http://www.openstreetmap.org/?lat=35.865848&lon=-83.660041
 WyeDr http://www.openstreetmap.org/?lat=35.847578&lon=-83.709791
 US411_S http://www.openstreetmap.org/?lat=35.870734&lon=-83.757062
 TNs168 http://www.openstreetmap.org/?lat=35.907623&lon=-83.840092
-MooAve +EMooAveSE http://www.openstreetmap.org/?lat=35.937980&lon=-83.908167
+MooAve http://www.openstreetmap.org/?lat=35.937980&lon=-83.908167
 TNs33_S http://www.openstreetmap.org/?lat=35.942175&lon=-83.910742
-US11/70_S +US11/70 http://www.openstreetmap.org/?lat=35.960518&lon=-83.920827
+CumAve +US11/70_S +US11/70 http://www.openstreetmap.org/?lat=35.960518&lon=-83.920827
 I-40/275 +I-40(387) http://www.openstreetmap.org/?lat=35.963757&lon=-83.922844
 TNs62 http://www.openstreetmap.org/?lat=35.964834&lon=-83.924088
 MagAve +WMagAve http://www.openstreetmap.org/?lat=35.970227&lon=-83.924099
-US11/70_N http://www.openstreetmap.org/?lat=35.972491&lon=-83.923944
-HallFameDr +TN158 http://www.openstreetmap.org/?lat=35.987582&lon=-83.920988
+5thAve +US11/70_N http://www.openstreetmap.org/?lat=35.972491&lon=-83.923944
+HallFameDr http://www.openstreetmap.org/?lat=35.987582&lon=-83.920988
 I-640 +I-640(6) http://www.openstreetmap.org/?lat=36.018867&lon=-83.922399
 TNs331 http://www.openstreetmap.org/?lat=36.022065&lon=-83.924496
 CedLn http://www.openstreetmap.org/?lat=36.034828&lon=-83.932178


### PR DESCRIPTION
See: http://tm.teresco.org/forum/index.php?topic=361.0

Update log entries: (note, US-129 gets one because of the label location changing for it's interchange with US-11/70)

2016-08-16;(USA) Tennessee;US 11;tn.us011;Removed from Kingston Pike, Cumberland Avenue, US 441, and East 5th Avenue in Knoxville, and rerouted along Neyland Drive (former TN 158) and Hall of Fame Drive between the intersections of Kingston Pike/Neyland Drive and East 5th Avenue/Hall of Fame Drive.
2016-08-16;(USA) Tennessee;US 70;tn.us070;Removed from Kingston Pike, Cumberland Avenue, US 441, and East 5th Avenue in Knoxville, and rerouted along Neyland Drive (former TN 158) and Hall of Fame Drive between the intersections of Kingston Pike/Neyland Drive and East 5th Avenue/Hall of Fame Drive.
2016-08-16;(USA) Tennessee;US 129;tn.us129;Relocated the 'US11/70' point from Kingston Pike (now KinPk) to the intersection with Neyland Drive (former TNs158).
