### PR TITLE
QC exit number changes

### DIFF
--- a/hwy_data/QC/canqca/qc.a020.wpt
+++ b/hwy_data/QC/canqca/qc.a020.wpt
@@ -154,4 +154,4 @@ IleCla http://www.openstreetmap.org/?lat=45.400348&lon=-73.958266
 527 http://www.openstreetmap.org/?lat=47.994000&lon=-69.371324
 531 http://www.openstreetmap.org/?lat=48.006244&lon=-69.318066
 539 http://www.openstreetmap.org/?lat=48.060145&lon=-69.257560
-543 http://www.openstreetmap.org/?lat=48.081864&lon=-69.225615
+542 +543 http://www.openstreetmap.org/?lat=48.081864&lon=-69.225615

--- a/hwy_data/QC/canqca/qc.a085not.wpt
+++ b/hwy_data/QC/canqca/qc.a085not.wpt
@@ -12,7 +12,7 @@ NB/QC http://www.openstreetmap.org/?lat=47.484975&lon=-68.484703
 *OldQC185_C http://www.openstreetmap.org/?lat=47.607053&lon=-68.789488
 29 http://www.openstreetmap.org/?lat=47.611255&lon=-68.803200
 30 http://www.openstreetmap.org/?lat=47.614980&lon=-68.808242
-32 http://www.openstreetmap.org/?lat=47.633817&lon=-68.834742
+33 http://www.openstreetmap.org/?lat=47.633817&lon=-68.834742
 37 http://www.openstreetmap.org/?lat=47.668758&lon=-68.867417
 40 http://www.openstreetmap.org/?lat=47.681017&lon=-68.898375
 +X390440 http://www.openstreetmap.org/?lat=47.686886&lon=-68.924618

--- a/hwy_data/QC/cantch/qc.tchmai.wpt
+++ b/hwy_data/QC/cantch/qc.tchmai.wpt
@@ -164,7 +164,7 @@ A-85(47) http://www.openstreetmap.org/?lat=47.667389&lon=-68.979485
 +X390440 http://www.openstreetmap.org/?lat=47.686886&lon=-68.924618
 A-85(40) http://www.openstreetmap.org/?lat=47.681017&lon=-68.898375
 A-85(37) http://www.openstreetmap.org/?lat=47.668758&lon=-68.867417
-A-85(32) http://www.openstreetmap.org/?lat=47.633817&lon=-68.834742
+A-85(33) http://www.openstreetmap.org/?lat=47.633817&lon=-68.834742
 A-85(30) http://www.openstreetmap.org/?lat=47.614980&lon=-68.808242
 A-85(29) http://www.openstreetmap.org/?lat=47.611255&lon=-68.803200
 *OldQC185_C http://www.openstreetmap.org/?lat=47.607053&lon=-68.789488


### PR DESCRIPTION
Exit number corrections for A-85Not (32 -> 33), TCHMai (conforming to A-85 change), and A-20 (543 -> 542). Only label in use retained as alternate label.