### PR TITLE
QC A-73 completion

### DIFF
--- a/hwy_data/QC/canqca/qc.a073.wpt
+++ b/hwy_data/QC/canqca/qc.a073.wpt
@@ -1,3 +1,7 @@
+QC204 http://www.openstreetmap.org/?lat=46.134441&lon=-70.643967
++X564199 http://www.openstreetmap.org/?lat=46.157941&lon=-70.652561
+48 http://www.openstreetmap.org/?lat=46.167587&lon=-70.679287
+53 http://www.openstreetmap.org/?lat=46.204569&lon=-70.710330
 61 http://www.openstreetmap.org/?lat=46.251277&lon=-70.784311
 +X0 http://www.openstreetmap.org/?lat=46.261662&lon=-70.798945
 +X01 http://www.openstreetmap.org/?lat=46.288122&lon=-70.808516

--- a/hwy_data/QC/canqca/qc.a073stg.wpt
+++ b/hwy_data/QC/canqca/qc.a073stg.wpt
@@ -1,4 +1,0 @@
-QC204 http://www.openstreetmap.org/?lat=46.134441&lon=-70.643967
-+X564199 http://www.openstreetmap.org/?lat=46.157941&lon=-70.652561
-48 http://www.openstreetmap.org/?lat=46.167587&lon=-70.679287
-RtePetPie http://www.openstreetmap.org/?lat=46.204584&lon=-70.710073

--- a/hwy_data/_systems/canqca.csv
+++ b/hwy_data/_systems/canqca.csv
@@ -15,8 +15,7 @@ canqca;QC;A-40;;;;qc.a040;
 canqca;QC;A-50;;;;qc.a050;A-50_W,A-50Gat
 canqca;QC;A-55;;;;qc.a055;
 canqca;QC;A-70;;;;qc.a070;
-canqca;QC;A-73;;;Québec;qc.a073;
-canqca;QC;A-73;;StG;St-Georges;qc.a073stg;
+canqca;QC;A-73;;;;qc.a073;A-73StG
 canqca;QC;A-85;;Not;Notre-Dame-du-Lac;qc.a085not;
 canqca;QC;A-85;;;Rivière-du-Loup;qc.a085;
 canqca;QC;A-410;;;;qc.a410;

--- a/hwy_data/_systems/canqca_con.csv
+++ b/hwy_data/_systems/canqca_con.csv
@@ -15,8 +15,7 @@ canqca;A-40;;;qc.a040
 canqca;A-50;;;qc.a050
 canqca;A-55;;;qc.a055
 canqca;A-70;;;qc.a070
-canqca;A-73;;QuÃ©bec;qc.a073
-canqca;A-73;;St-Georges;qc.a073stg
+canqca;A-73;;;qc.a073
 canqca;A-85;;Notre-Dame-du-Lac;qc.a085not
 canqca;A-85;;Rivière-du-Loup;qc.a085
 canqca;A-410;;;qc.a410


### PR DESCRIPTION
Extends main A-73 route south to QC 204 in St-Georges, and deletes A-73 (St-Georges), with today's opening of new connection between those route segments.

Updates items:

2016-09-30;(Canada) Quebec:A-73;qc.a073;Route extended south from exit 61 near Beauceville, to QC 204 in St.-Georges, absorbing former A-73 (St-Georges) segment

2016-09-30;(Canada) Quebec;A-73 (St-Georges);(NONE);Route deleted (folded into rest of A-73)