### PR TITLE
NH111A relocation, and one more NMP

### DIFF
--- a/hwy_data/NH/usanh/nh.nh111.wpt
+++ b/hwy_data/NH/usanh/nh.nh111.wpt
@@ -19,7 +19,8 @@ LowRd_S http://www.openstreetmap.org/?lat=42.801010&lon=-71.304217
 LowRd_N http://www.openstreetmap.org/?lat=42.804469&lon=-71.299703
 EntDr http://www.openstreetmap.org/?lat=42.806967&lon=-71.287125
 I-93 http://www.openstreetmap.org/?lat=42.809149&lon=-71.272135
-NH111A_Win http://www.openstreetmap.org/?lat=42.806634&lon=-71.262158
+NH111A_Win http://www.openstreetmap.org/?lat=42.807248&lon=-71.264540
+RanRd http://www.openstreetmap.org/?lat=42.806902&lon=-71.262093
 NH28 http://www.openstreetmap.org/?lat=42.812285&lon=-71.248843
 ZacCroRd http://www.openstreetmap.org/?lat=42.835731&lon=-71.231242
 IslPondRd http://www.openstreetmap.org/?lat=42.852060&lon=-71.216673

--- a/hwy_data/NH/usanh/nh.nh111apel.wpt
+++ b/hwy_data/NH/usanh/nh.nh111apel.wpt
@@ -4,4 +4,5 @@ HobRd http://www.openstreetmap.org/?lat=42.751452&lon=-71.316161
 TalRd http://www.openstreetmap.org/?lat=42.764148&lon=-71.320453
 LowRd http://www.openstreetmap.org/?lat=42.775869&lon=-71.315115
 CobPondRd http://www.openstreetmap.org/?lat=42.783994&lon=-71.298287
-NH111 http://www.openstreetmap.org/?lat=42.806634&lon=-71.262158
+RanRd http://www.openstreetmap.org/?lat=42.802410&lon=-71.267565
+NH111 http://www.openstreetmap.org/?lat=42.807248&lon=-71.264540

--- a/hwy_data/NH/usasf/nh.evetpk.wpt
+++ b/hwy_data/NH/usasf/nh.evetpk.wpt
@@ -25,6 +25,6 @@ I-93/293 +I-93_S http://www.openstreetmap.org/?lat=43.048820&lon=-71.471686
 11(93) http://www.openstreetmap.org/?lat=43.086222&lon=-71.473875
 +x11b http://www.openstreetmap.org/?lat=43.106791&lon=-71.475077
 +x11c http://www.openstreetmap.org/?lat=43.159178&lon=-71.511812
-I-89 http://www.openstreetmap.org/?lat=43.170444&lon=-71.530180
+I-89 http://www.openstreetmap.org/?lat=43.170452&lon=-71.530271
 12(93) http://www.openstreetmap.org/?lat=43.179676&lon=-71.531081
 13(93) http://www.openstreetmap.org/?lat=43.193382&lon=-71.526146


### PR DESCRIPTION
2016-11-02;(USA) New Hampshire;NH 111A (Pelham);nh.nh111apel;Removed from Range Road between a point near the demolished overpass for the former northbound I-93 alignment and NH 111, and relocated onto a new roadway to the west utilizing the former I-93 north and Exit 3 right-of-way.