### PR TITLE
KS10: South Lawrence Trafficway completion

### DIFF
--- a/hwy_data/KS/usaks/ks.ks010.wpt
+++ b/hwy_data/KS/usaks/ks.ks010.wpt
@@ -3,10 +3,10 @@ US40 +US40_W http://www.openstreetmap.org/?lat=38.971488&lon=-95.334291
 CliPkwy http://www.openstreetmap.org/?lat=38.943514&lon=-95.335788
 27thSt http://www.openstreetmap.org/?lat=38.935941&lon=-95.307067
 KasDr http://www.openstreetmap.org/?lat=38.922420&lon=-95.278791
-US59_S http://www.openstreetmap.org/?lat=38.919954&lon=-95.260600
-US59_N http://www.openstreetmap.org/?lat=38.942747&lon=-95.260520
-MasSt http://www.openstreetmap.org/?lat=38.942772&lon=-95.235919
-1750Rd http://www.openstreetmap.org/?lat=38.938954&lon=-95.175666
+US59  +US59_S http://www.openstreetmap.org/?lat=38.919954&lon=-95.260600
+HasAve http://www.openstreetmap.org/?lat=38.924874&lon=-95.220416
++X120680 http://www.openstreetmap.org/?lat=38.923743&lon=-95.189431
+23rdSt http://www.openstreetmap.org/?lat=38.934414&lon=-95.171878
 1900Rd http://www.openstreetmap.org/?lat=38.935052&lon=-95.149434
 ChuSt http://www.openstreetmap.org/?lat=38.929665&lon=-95.094738
 1400Rd http://www.openstreetmap.org/?lat=38.941157&lon=-95.072840

--- a/hwy_data/KS/usaus/ks.us059.wpt
+++ b/hwy_data/KS/usaus/ks.us059.wpt
@@ -65,12 +65,12 @@ StaRd http://www.openstreetmap.org/?lat=38.709560&lon=-95.268347
 US56 http://www.openstreetmap.org/?lat=38.782349&lon=-95.268996
 650thRd http://www.openstreetmap.org/?lat=38.833256&lon=-95.268974
 1000thRd http://www.openstreetmap.org/?lat=38.884498&lon=-95.258326
-KS10_W http://www.openstreetmap.org/?lat=38.919954&lon=-95.260600
-KS10_E http://www.openstreetmap.org/?lat=38.942747&lon=-95.260520
+KS10 +KS10_W http://www.openstreetmap.org/?lat=38.919954&lon=-95.260600
+23rdSt +KS10_E http://www.openstreetmap.org/?lat=38.942747&lon=-95.260520
 US40_W +6thSt http://www.openstreetmap.org/?lat=38.972856&lon=-95.260820
 MasSt http://www.openstreetmap.org/?lat=38.973156&lon=-95.236058
 I-70(204KT) http://www.openstreetmap.org/?lat=38.991537&lon=-95.233397
-US24/40  +US24/40_E http://www.openstreetmap.org/?lat=39.000643&lon=-95.233483
+US24/40 +US24/40_E http://www.openstreetmap.org/?lat=39.000643&lon=-95.233483
 1400Rd http://www.openstreetmap.org/?lat=39.029686&lon=-95.242238
 PhiRd http://www.openstreetmap.org/?lat=39.055274&lon=-95.298216
 13thSt http://www.openstreetmap.org/?lat=39.065806&lon=-95.299745


### PR DESCRIPTION
2016-11-14;(USA) Kansas;KS 10;ks.ks010;Removed from US 59 and 23rd Street and relocated onto the South Lawrence Trafficway between its US 59 and 23rd Street interchanges.