### PR TITLE
NS: Antigonish phase 2 & Port Mouton bypasses

### DIFF
--- a/hwy_data/NS/cannsc/ns.ns316.wpt
+++ b/hwy_data/NS/cannsc/ns.ns316.wpt
@@ -1,4 +1,4 @@
-NS104 http://www.openstreetmap.org/?lat=45.597379&lon=-61.907073
+NS4 +NS104 http://www.openstreetmap.org/?lat=45.597314&lon=-61.906811
 AntGuyRd http://www.openstreetmap.org/?lat=45.555555&lon=-61.889056
 OldPinRd http://www.openstreetmap.org/?lat=45.494984&lon=-61.937015
 LochKatRd http://www.openstreetmap.org/?lat=45.430125&lon=-61.934048

--- a/hwy_data/NS/cannsf/ns.ns103.wpt
+++ b/hwy_data/NS/cannsf/ns.ns103.wpt
@@ -36,8 +36,10 @@ HilDr http://www.openstreetmap.org/?lat=44.178094&lon=-64.637587
 20A http://www.openstreetmap.org/?lat=44.018650&lon=-64.739382
 +X12 http://www.openstreetmap.org/?lat=44.006058&lon=-64.739644
 +x12a http://www.openstreetmap.org/?lat=43.974446&lon=-64.772470
-20 http://www.openstreetmap.org/?lat=43.958580&lon=-64.829604
-21 http://www.openstreetmap.org/?lat=43.927696&lon=-64.848338
+*OldNS103_Sum http://www.openstreetmap.org/?lat=43.961034&lon=-64.824433
++X179921 http://www.openstreetmap.org/?lat=43.957217&lon=-64.835832
+21 http://www.openstreetmap.org/?lat=43.945929&lon=-64.844484&zoom=15
+*OldNS103_PMo http://www.openstreetmap.org/?lat=43.922418&lon=-64.855405
 *OldNS103_PJo http://www.openstreetmap.org/?lat=43.899023&lon=-64.890060
 22 http://www.openstreetmap.org/?lat=43.894045&lon=-64.897873
 *OldNS103_EPL http://www.openstreetmap.org/?lat=43.884117&lon=-64.929200

--- a/hwy_data/NS/cannsf/ns.ns104.wpt
+++ b/hwy_data/NS/cannsf/ns.ns104.wpt
@@ -44,7 +44,7 @@ NB/NS http://www.openstreetmap.org/?lat=45.856543&lon=-64.263668
 +X26a http://www.openstreetmap.org/?lat=45.592705&lon=-62.536915
 27 http://www.openstreetmap.org/?lat=45.592705&lon=-62.515921
 *ChuRd http://www.openstreetmap.org/?lat=45.589773&lon=-62.502475
-*OldNS104 *Old104 http://www.openstreetmap.org/?lat=45.585122&lon=-62.491844
+*OldNS104_Sut +OldNS104 http://www.openstreetmap.org/?lat=45.585122&lon=-62.491844
 +X28 http://www.openstreetmap.org/?lat=45.572708&lon=-62.387872
 29 http://www.openstreetmap.org/?lat=45.594203&lon=-62.266420
 +x29b http://www.openstreetmap.org/?lat=45.586036&lon=-62.220039
@@ -54,8 +54,10 @@ NB/NS http://www.openstreetmap.org/?lat=45.856543&lon=-64.263668
 31 http://www.openstreetmap.org/?lat=45.600923&lon=-62.023793
 32 http://www.openstreetmap.org/?lat=45.611465&lon=-61.999218
 33 http://www.openstreetmap.org/?lat=45.609921&lon=-61.968191
-34 http://www.openstreetmap.org/?lat=45.604937&lon=-61.948124
-35 http://www.openstreetmap.org/?lat=45.597314&lon=-61.906811
+*OldNS104_Ant http://www.openstreetmap.org/?lat=45.606742&lon=-61.957054
++X34 http://www.openstreetmap.org/?lat=45.600527&lon=-61.947098
+35 http://www.openstreetmap.org/?lat=45.600794&lon=-61.904597
+*OldNS104_LSR http://www.openstreetmap.org/?lat=45.595680&lon=-61.880475
 35B http://www.openstreetmap.org/?lat=45.590417&lon=-61.815243
 36 http://www.openstreetmap.org/?lat=45.590700&lon=-61.789855
 36A http://www.openstreetmap.org/?lat=45.588938&lon=-61.774544

--- a/hwy_data/NS/cannss/ns.ligrte.wpt
+++ b/hwy_data/NS/cannss/ns.ligrte.wpt
@@ -103,8 +103,11 @@ WhiPtCon http://www.openstreetmap.org/?lat=44.018526&lon=-64.725500
 GullIslRd http://www.openstreetmap.org/?lat=43.991642&lon=-64.729237
 WhiPt2Rd_N http://www.openstreetmap.org/?lat=43.963894&lon=-64.749992
 SilRockDr http://www.openstreetmap.org/?lat=43.952037&lon=-64.785736
-NS103(20) http://www.openstreetmap.org/?lat=43.958580&lon=-64.829604
-NS103(21) http://www.openstreetmap.org/?lat=43.927696&lon=-64.848338
+*OldNS3 http://www.openstreetmap.org/?lat=43.957729&lon=-64.827891
+*OldNS103_Sum http://www.openstreetmap.org/?lat=43.957406&lon=-64.831005
+OldNS103_PMoE http://www.openstreetmap.org/?lat=43.942437&lon=-64.840351
+NS103(21) http://www.openstreetmap.org/?lat=43.945929&lon=-64.844484&zoom=15
+*OldNS103_PMoW http://www.openstreetmap.org/?lat=43.922418&lon=-64.855405
 *OldNS103_PJo http://www.openstreetmap.org/?lat=43.899023&lon=-64.890060
 NS103(22) http://www.openstreetmap.org/?lat=43.894045&lon=-64.897873
 *OldNS103_EPL http://www.openstreetmap.org/?lat=43.884117&lon=-64.929200

--- a/hwy_data/NS/cannst/ns.ns003liv.wpt
+++ b/hwy_data/NS/cannst/ns.ns003liv.wpt
@@ -7,4 +7,7 @@ WhiPtCon http://www.openstreetmap.org/?lat=44.018526&lon=-64.725500
 GullIslRd http://www.openstreetmap.org/?lat=43.991642&lon=-64.729237
 WhiPt2Rd_N http://www.openstreetmap.org/?lat=43.963894&lon=-64.749992
 SilRockDr http://www.openstreetmap.org/?lat=43.952037&lon=-64.785736
-NS103(20) http://www.openstreetmap.org/?lat=43.958580&lon=-64.829604
+*OldNS3 +NS103(20) http://www.openstreetmap.org/?lat=43.957729&lon=-64.827891
+*OldNS103_E http://www.openstreetmap.org/?lat=43.957406&lon=-64.831005
+OldNS103_W http://www.openstreetmap.org/?lat=43.942437&lon=-64.840351
+NS103(21) http://www.openstreetmap.org/?lat=43.945929&lon=-64.844484&zoom=15

--- a/hwy_data/NS/cannst/ns.ns004ant.wpt
+++ b/hwy_data/NS/cannst/ns.ns004ant.wpt
@@ -3,11 +3,16 @@ BeaMeaRd http://www.openstreetmap.org/?lat=45.570300&lon=-62.131596
 BriBroRd http://www.openstreetmap.org/?lat=45.587581&lon=-62.088512
 SchRd http://www.openstreetmap.org/?lat=45.600779&lon=-62.054988
 NS104(31) http://www.openstreetmap.org/?lat=45.601548&lon=-62.024496
-UniBlvd http://www.openstreetmap.org/?lat=45.614119&lon=-62.005030
+UniBlvd_W +UniBlvd http://www.openstreetmap.org/?lat=45.614119&lon=-62.005030
 NS7 http://www.openstreetmap.org/?lat=45.616586&lon=-61.999032
 NS245 http://www.openstreetmap.org/?lat=45.621978&lon=-61.994770
 ChuSt http://www.openstreetmap.org/?lat=45.622621&lon=-61.989301
 NS337 http://www.openstreetmap.org/?lat=45.624514&lon=-61.984086
 BeeHillDr http://www.openstreetmap.org/?lat=45.616875&lon=-61.971095
 WilPtRd http://www.openstreetmap.org/?lat=45.616097&lon=-61.963535
-NS104(34) http://www.openstreetmap.org/?lat=45.604937&lon=-61.948124
+UniBlvd_E +NS104(34) http://www.openstreetmap.org/?lat=45.604937&lon=-61.948124
+OldNS104_W http://www.openstreetmap.org/?lat=45.604175&lon=-61.928697
++x24802-14(12.0) http://www.openstreetmap.org/?lat=45.604680&lon=-61.925803
+OldNS104_E http://www.openstreetmap.org/?lat=45.601506&lon=-61.917909
+NS316 http://www.openstreetmap.org/?lat=45.597314&lon=-61.906811
+NS104(35) http://www.openstreetmap.org/?lat=45.600794&lon=-61.904597

--- a/hwy_data/NS/cantch/ns.tchmai.wpt
+++ b/hwy_data/NS/cantch/ns.tchmai.wpt
@@ -44,7 +44,7 @@ NS104(26) http://www.openstreetmap.org/?lat=45.571224&lon=-62.605375
 +X26a http://www.openstreetmap.org/?lat=45.592705&lon=-62.536915
 NS104(27) http://www.openstreetmap.org/?lat=45.592705&lon=-62.515921
 *ChuRd http://www.openstreetmap.org/?lat=45.589773&lon=-62.502475
-*OldNS104 +Old104 http://www.openstreetmap.org/?lat=45.585122&lon=-62.491844
+*OldNS104_Sut http://www.openstreetmap.org/?lat=45.585122&lon=-62.491844
 +X28 http://www.openstreetmap.org/?lat=45.572708&lon=-62.387872
 NS104(29) http://www.openstreetmap.org/?lat=45.594203&lon=-62.266420
 +x29b http://www.openstreetmap.org/?lat=45.586036&lon=-62.220039
@@ -54,8 +54,10 @@ NS104(30) http://www.openstreetmap.org/?lat=45.566924&lon=-62.129120
 NS104(31) http://www.openstreetmap.org/?lat=45.600923&lon=-62.023793
 NS104(32) http://www.openstreetmap.org/?lat=45.611465&lon=-61.999218
 NS104(33) http://www.openstreetmap.org/?lat=45.609921&lon=-61.968191
-NS104(34) http://www.openstreetmap.org/?lat=45.604937&lon=-61.948124
-NS104(35) http://www.openstreetmap.org/?lat=45.597314&lon=-61.906811
+*OldNS104_Ant http://www.openstreetmap.org/?lat=45.606742&lon=-61.957054
++X34 http://www.openstreetmap.org/?lat=45.600527&lon=-61.947098
+NS104(35) http://www.openstreetmap.org/?lat=45.600794&lon=-61.904597
+*OldNS104_LSR http://www.openstreetmap.org/?lat=45.595680&lon=-61.880475
 NS104(35B) http://www.openstreetmap.org/?lat=45.590417&lon=-61.815243
 NS104(36) http://www.openstreetmap.org/?lat=45.590700&lon=-61.789855
 NS104(36A) http://www.openstreetmap.org/?lat=45.588938&lon=-61.774544


### PR DESCRIPTION
2016-11-19;(Canada) Nova Scotia;NS 103;ns.ns103;Removed from closed two-lane highway and the surface road through Port Mouton village (now partially NS3), and relocated onto the northwestern Port Mouton bypass between closed intersections labeled *OldNS103_Sum & *OldNS103_PMo
2016-11-19;(Canada) Nova Scotia;NS 104;ns.ns104;Removed from a closed temporary connector and NS 4, and relocated onto a parallel four-lane divided highway between closed intersections labeled *OldNS104_Ant & *OldNS104_LSR
2016-11-19;(Canada) Nova Scotia;TCH (Main);ns.tchmai;Removed from a closed temporary connector and NS 4, and relocated onto a parallel four-lane divided highway between closed intersections labeled *OldNS104_Ant & *OldNS104_LSR
2016-11-19;(Canada) Nova Scotia;NS 3 (Liverpool);ns.ns003liv;West end removed from a closed roadway between a point labeled *OldNS3 and the closed former alignment of NS 103, and relocated onto the surface road through Port Mouton village and a new access road to NS 103 Exit 21
2016-11-19;(Canada) Nova Scotia;NS 4 (Antigonish);ns.ns004ant;Extended east from the eastern intersection with University Boulevard to Exit 35 of NS 104