### PR TITLE
Change "Seattle Freeway" to "West Seattle Bridge"

### DIFF
--- a/hwy_data/_systems/usasf.csv
+++ b/hwy_data/_systems/usasf.csv
@@ -57,7 +57,7 @@ usasf;TN;SamCooBlvd;;;Sam Cooper Boulevard;tn.samcooblvd;
 usasf;IN;SamJonExpy;;;Sam Jones Expressway;in.samjonexpy;
 usasf;NY;SawMillPkwy;;;Saw Mill River Parkway;ny.sawmillpkwy;
 usasf;ME;ScaCon;;;Scarborough Connector;me.scacon;
-usasf;WA;WSeaBri;;;West Seattle Bridge;wa.wseabri;
+usasf;WA;WSeaBri;;;West Seattle Bridge;wa.wseabri;SeaFwy
 usasf;IN;ShaAve;;;Shadeland Avenue;in.shaave;
 usasf;NY;SouStaPkwy;;;Southern State Parkway;ny.soustapkwy;
 usasf;NY;SprBroPkwy;;;Sprain Brook Parkway;ny.sprbropkwy;

--- a/hwy_data/_systems/usasf.csv
+++ b/hwy_data/_systems/usasf.csv
@@ -57,7 +57,7 @@ usasf;TN;SamCooBlvd;;;Sam Cooper Boulevard;tn.samcooblvd;
 usasf;IN;SamJonExpy;;;Sam Jones Expressway;in.samjonexpy;
 usasf;NY;SawMillPkwy;;;Saw Mill River Parkway;ny.sawmillpkwy;
 usasf;ME;ScaCon;;;Scarborough Connector;me.scacon;
-usasf;WA;WSeaBrdg;;;West Seattle Bridge;wa.wseabrdg;
+usasf;WA;WSeaBri;;;West Seattle Bridge;wa.wseabri;
 usasf;IN;ShaAve;;;Shadeland Avenue;in.shaave;
 usasf;NY;SouStaPkwy;;;Southern State Parkway;ny.soustapkwy;
 usasf;NY;SprBroPkwy;;;Sprain Brook Parkway;ny.sprbropkwy;

--- a/hwy_data/_systems/usasf.csv
+++ b/hwy_data/_systems/usasf.csv
@@ -57,7 +57,7 @@ usasf;TN;SamCooBlvd;;;Sam Cooper Boulevard;tn.samcooblvd;
 usasf;IN;SamJonExpy;;;Sam Jones Expressway;in.samjonexpy;
 usasf;NY;SawMillPkwy;;;Saw Mill River Parkway;ny.sawmillpkwy;
 usasf;ME;ScaCon;;;Scarborough Connector;me.scacon;
-usasf;WA;SeaFwy;;;Seattle Freeway;wa.seafwy;
+usasf;WA;WSeaBrdg;;;West Seattle Bridge;wa.wseabrdg;
 usasf;IN;ShaAve;;;Shadeland Avenue;in.shaave;
 usasf;NY;SouStaPkwy;;;Southern State Parkway;ny.soustapkwy;
 usasf;NY;SprBroPkwy;;;Sprain Brook Parkway;ny.sprbropkwy;


### PR DESCRIPTION
This is the actual name for the freeway. Note that the "West" is not a directional prefix, but it refers to the West Seattle neighborhood that the freeway serves.