### PR TITLE
Minor Ontario fixes

### DIFF
--- a/hwy_data/ON/cannf/on.garexpy.wpt
+++ b/hwy_data/ON/cannf/on.garexpy.wpt
@@ -1,22 +1,22 @@
 139 http://www.openstreetmap.org/?lat=43.613490&lon=-79.549357
-KipAve http://www.openstreetmap.org/?lat=43.617947&lon=-79.525767
-EvaAve http://www.openstreetmap.org/?lat=43.619118&lon=-79.519791
-IslAve http://www.openstreetmap.org/?lat=43.620427&lon=-79.513110
-ParkLawnRd http://www.openstreetmap.org/?lat=43.626296&lon=-79.486714
-LakeShoBlvdW http://www.openstreetmap.org/?lat=43.628314&lon=-79.480339
-LakeShoBlvd http://www.openstreetmap.org/?lat=43.633043&lon=-79.473488
-SKin http://www.openstreetmap.org/?lat=43.634351&lon=-79.471208
+141 http://www.openstreetmap.org/?lat=43.617947&lon=-79.525767
+141A http://www.openstreetmap.org/?lat=43.619118&lon=-79.519791
+142 http://www.openstreetmap.org/?lat=43.620427&lon=-79.513110
+144 http://www.openstreetmap.org/?lat=43.626296&lon=-79.486714
+146 http://www.openstreetmap.org/?lat=43.628314&lon=-79.480339
+145 http://www.openstreetmap.org/?lat=43.633043&lon=-79.473488
+146A +SKin http://www.openstreetmap.org/?lat=43.634351&lon=-79.471208
 +X00 http://www.openstreetmap.org/?lat=43.638839&lon=-79.458232
 +X01 http://www.openstreetmap.org/?lat=43.638653&lon=-79.451108
-JamAve_W http://www.openstreetmap.org/?lat=43.632868&lon=-79.434374
-JamAve_E http://www.openstreetmap.org/?lat=43.632480&lon=-79.430983
+149 http://www.openstreetmap.org/?lat=43.632868&lon=-79.434374
+149A http://www.openstreetmap.org/?lat=43.632480&lon=-79.430983
 +X02 http://www.openstreetmap.org/?lat=43.637391&lon=-79.411958
-SpaAve http://www.openstreetmap.org/?lat=43.638678&lon=-79.392335
-YorkSt http://www.openstreetmap.org/?lat=43.641600&lon=-79.380949
-YonSt http://www.openstreetmap.org/?lat=43.644216&lon=-79.375843
-JarSt http://www.openstreetmap.org/?lat=43.645786&lon=-79.369875
-LowSheSt http://www.openstreetmap.org/?lat=43.646584&lon=-79.366184
+153 +SpaAve http://www.openstreetmap.org/?lat=43.638678&lon=-79.392335
+154 +YorkSt http://www.openstreetmap.org/?lat=43.641600&lon=-79.380949
+154A +YonSt http://www.openstreetmap.org/?lat=43.644216&lon=-79.375843
+155 +JarSt http://www.openstreetmap.org/?lat=43.645786&lon=-79.369875
+155A +LowSheSt http://www.openstreetmap.org/?lat=43.646584&lon=-79.366184
 +X03 http://www.openstreetmap.org/?lat=43.649100&lon=-79.356565
 +X04 http://www.openstreetmap.org/?lat=43.649060&lon=-79.352070
-DonValPkwy http://www.openstreetmap.org/?lat=43.650000&lon=-79.349640
+157 +DonValPkwy http://www.openstreetmap.org/?lat=43.650000&lon=-79.349640
 LakeShoBlvdE http://www.openstreetmap.org/?lat=43.653485&lon=-79.341200

--- a/hwy_data/ON/canon/on.on008.wpt
+++ b/hwy_data/ON/canon/on.on008.wpt
@@ -35,4 +35,6 @@ RR53 http://www.openstreetmap.org/?lat=43.430523&lon=-80.470036
 +X003(ON8) http://www.openstreetmap.org/?lat=43.431949&lon=-80.460080
 ON7_E http://www.openstreetmap.org/?lat=43.436257&lon=-80.456958
 FaiRd http://www.openstreetmap.org/?lat=43.427765&lon=-80.436938
-KingStByp_E http://www.openstreetmap.org/?lat=43.414735&lon=-80.404912
+RR8 +KingStByp_E http://www.openstreetmap.org/?lat=43.414735&lon=-80.404912
+RR38 http://www.openstreetmap.org/?lat=43.410472&lon=-80.391710
+ON401 http://www.openstreetmap.org/?lat=43.403635&lon=-80.375507

--- a/hwy_data/ON/canonf/on.ongar.wpt
+++ b/hwy_data/ON/canonf/on.ongar.wpt
@@ -1,22 +1,22 @@
 139 http://www.openstreetmap.org/?lat=43.613490&lon=-79.549357
-KipAve http://www.openstreetmap.org/?lat=43.617947&lon=-79.525767
-EvaAve http://www.openstreetmap.org/?lat=43.619118&lon=-79.519791
-IslAve http://www.openstreetmap.org/?lat=43.620427&lon=-79.513110
-ParkLawnRd http://www.openstreetmap.org/?lat=43.626296&lon=-79.486714
-LakeShoBlvdW http://www.openstreetmap.org/?lat=43.628314&lon=-79.480339
-LakeShoBlvd http://www.openstreetmap.org/?lat=43.633043&lon=-79.473488
-SKin http://www.openstreetmap.org/?lat=43.634351&lon=-79.471208
+141 http://www.openstreetmap.org/?lat=43.617947&lon=-79.525767
+141A http://www.openstreetmap.org/?lat=43.619118&lon=-79.519791
+142 http://www.openstreetmap.org/?lat=43.620427&lon=-79.513110
+144 http://www.openstreetmap.org/?lat=43.626296&lon=-79.486714
+146 http://www.openstreetmap.org/?lat=43.628314&lon=-79.480339
+145 http://www.openstreetmap.org/?lat=43.633043&lon=-79.473488
+146A +SKin http://www.openstreetmap.org/?lat=43.634351&lon=-79.471208
 +X00 http://www.openstreetmap.org/?lat=43.638839&lon=-79.458232
 +X01 http://www.openstreetmap.org/?lat=43.638653&lon=-79.451108
-JamAve_W http://www.openstreetmap.org/?lat=43.632868&lon=-79.434374
-JamAve_E http://www.openstreetmap.org/?lat=43.632480&lon=-79.430983
+149 http://www.openstreetmap.org/?lat=43.632868&lon=-79.434374
+149A http://www.openstreetmap.org/?lat=43.632480&lon=-79.430983
 +X02 http://www.openstreetmap.org/?lat=43.637391&lon=-79.411958
-SpaAve http://www.openstreetmap.org/?lat=43.638678&lon=-79.392335
-YorkSt http://www.openstreetmap.org/?lat=43.641600&lon=-79.380949
-YonSt http://www.openstreetmap.org/?lat=43.644216&lon=-79.375843
-JarSt http://www.openstreetmap.org/?lat=43.645786&lon=-79.369875
-LowSheSt http://www.openstreetmap.org/?lat=43.646584&lon=-79.366184
+153 +SpaAve http://www.openstreetmap.org/?lat=43.638678&lon=-79.392335
+154 +YorkSt http://www.openstreetmap.org/?lat=43.641600&lon=-79.380949
+154A +YonSt http://www.openstreetmap.org/?lat=43.644216&lon=-79.375843
+155 +JarSt http://www.openstreetmap.org/?lat=43.645786&lon=-79.369875
+155A +LowSheSt http://www.openstreetmap.org/?lat=43.646584&lon=-79.366184
 +X03 http://www.openstreetmap.org/?lat=43.649100&lon=-79.356565
 +X04 http://www.openstreetmap.org/?lat=43.649060&lon=-79.352070
-DonValPkwy http://www.openstreetmap.org/?lat=43.650000&lon=-79.349640
+157 +DonValPkwy http://www.openstreetmap.org/?lat=43.650000&lon=-79.349640
 LakeShoBlvdE http://www.openstreetmap.org/?lat=43.653485&lon=-79.341200

--- a/updates.csv
+++ b/updates.csv
@@ -86,6 +86,7 @@
 2016-11-19;(Canada) Nova Scotia;TCH (Main);ns.tchmai;Removed from a closed temporary connector and NS 4, and relocated onto a parallel four-lane divided highway between closed intersections labeled *OldNS104_Ant & *OldNS104_LSR
 2016-02-27;(Canada) Nova Scotia;NS 255;ns.ns255;Removed from a closed roadway and demolished bridge, and relocated onto a new parallel roadway and bridge to the east between points labeled *OldNS255_N and *OldNS255_S
 2016-01-02;(Canada) Nova Scotia;NS 103;ns.ns103;Removed from partially-closed local roads through Port Joli and East Port L'Hebert, and relocated onto a limited-access bypass to the north, between closed intersections labeled *OldNS103_PJo and *OldNS103_EPL
+2016-12-27;(Canada) Ontario;ON 8;on.on008;Extended at southern end from the interchange with RR 8 (King Street) to ON 401 along the Freeport Diversion
 2016-06-24;(Canada) Ontario;ON 407;on.on407;Extended at eastern end from Exit 105 (Brock Road, former ON 7 intersection) to Exit 127 (Harmony Road)
 2016-06-24;(Canada) Ontario;ON 412;on.on412;Added Route
 2016-06-24;(Canada) Ontario;ON 7;on.on007;Removed from a now closed alignment just to the east of Brougham, and moved onto a new alignment to the north between the intersections of Mowbray Street (formerly Brock Road) and the old alignment of ON 7 (*OldON7)


### PR DESCRIPTION
Adds in the newly posted exit numbers along the Gardiner Expressway in Toronto, and adds in the missing extension of ON-8 in Kitchener to ON-401.