### PR TITLE
ND - Killdeer Bypass changes

### DIFF
--- a/hwy_data/ND/usand/nd.nd022.wpt
+++ b/hwy_data/ND/usand/nd.nd022.wpt
@@ -31,9 +31,9 @@ ND22Trk_N http://www.openstreetmap.org/?lat=46.933103&lon=-102.789812
 12thSt http://www.openstreetmap.org/?lat=47.241395&lon=-102.769386
 11thSt http://www.openstreetmap.org/?lat=47.255903&lon=-102.763270
 7thSt http://www.openstreetmap.org/?lat=47.313755&lon=-102.757777
-ND200 http://www.openstreetmap.org/?lat=47.357526&lon=-102.758678
-HighSt http://www.openstreetmap.org/?lat=47.372028&lon=-102.754167
-104thAve http://www.openstreetmap.org/?lat=47.385838&lon=-102.759483
+ND200/22Bus http://www.openstreetmap.org/?lat=47.357526&lon=-102.758678
+ND200_W http://www.openstreetmap.org/?lat=47.357611&lon=-102.801176
+ND22Bus_N http://www.openstreetmap.org/?lat=47.4116828&lon=-102.7972932
 MainSt http://www.openstreetmap.org/?lat=47.415544&lon=-102.800671
 1stSt http://www.openstreetmap.org/?lat=47.430018&lon=-102.800982
 3rdSt http://www.openstreetmap.org/?lat=47.458969&lon=-102.842846

--- a/hwy_data/ND/usand/nd.nd022buskil.wpt
+++ b/hwy_data/ND/usand/nd.nd022buskil.wpt
@@ -1,0 +1,4 @@
+ND22_S http://www.openstreetmap.org/?lat=47.357526&lon=-102.758678
+HighSt http://www.openstreetmap.org/?lat=47.372028&lon=-102.754167
+104thAve http://www.openstreetmap.org/?lat=47.385838&lon=-102.759483
+ND22_N http://www.openstreetmap.org/?lat=47.4116828&lon=-102.7972932

--- a/hwy_data/ND/usand/nd.nd200.wpt
+++ b/hwy_data/ND/usand/nd.nd200.wpt
@@ -27,7 +27,8 @@ US85_S http://www.openstreetmap.org/?lat=47.343112&lon=-103.184205
 125thAve http://www.openstreetmap.org/?lat=47.343156&lon=-103.131108
 119thAve http://www.openstreetmap.org/?lat=47.356647&lon=-103.077765
 111thAve http://www.openstreetmap.org/?lat=47.357635&lon=-102.907648
-ND22 http://www.openstreetmap.org/?lat=47.357526&lon=-102.758678
+ND22_N http://www.openstreetmap.org/?lat=47.357611&lon=-102.801176
+ND22.22Bus http://www.openstreetmap.org/?lat=47.357526&lon=-102.758678
 4thSt_Dun http://www.openstreetmap.org/?lat=47.357301&lon=-102.641702
 CenAve http://www.openstreetmap.org/?lat=47.349611&lon=-102.620566
 94thAve http://www.openstreetmap.org/?lat=47.343039&lon=-102.545872

--- a/hwy_data/_systems/usand.csv
+++ b/hwy_data/_systems/usand.csv
@@ -18,6 +18,7 @@ usand;ND;ND19;;;;nd.nd019;
 usand;ND;ND20;;;;nd.nd020;
 usand;ND;ND21;;;;nd.nd021;
 usand;ND;ND22;;;;nd.nd022;
+usand;ND;ND22;Bus;Kil;Killdeer;nd.nd022buskil;
 usand;ND;ND22;Trk;Dic;Dickonson;nd.nd022trkdic;
 usand;ND;ND23;;;;nd.nd023;
 usand;ND;ND23;Bus;Wat;Watford City;nd.nd023buswat;

--- a/hwy_data/_systems/usand_con.csv
+++ b/hwy_data/_systems/usand_con.csv
@@ -18,6 +18,7 @@ usand;ND19;;;nd.nd019
 usand;ND20;;;nd.nd020
 usand;ND21;;;nd.nd021
 usand;ND22;;;nd.nd022
+usand;ND22;Bus;Killdeer;nd.nd022buskil
 usand;ND22;Trk;Dickinson;nd.nd022trkdic
 usand;ND23;;;nd.nd023
 usand;ND23;Bus;Watford City;nd.nd023buswat


### PR DESCRIPTION
Changes from relocation of ND22 to new pypass, and conversion of old alignment to new ND 22 business route.

Updates items:

2017-02-24;(USA) North Dakota;ND 22;nd.nd022;Relocated from former route through Killdeer (now ND 22 Business) west to new Killdeer Bypass

2017-02-24;(USA) North Dakota;ND 22 Business (Killdeer);nd.nd022buskil;New route

