### PR TITLE
ND 200 typo fix

### DIFF
--- a/hwy_data/ND/usand/nd.nd200.wpt
+++ b/hwy_data/ND/usand/nd.nd200.wpt
@@ -28,7 +28,7 @@ US85_S http://www.openstreetmap.org/?lat=47.343112&lon=-103.184205
 119thAve http://www.openstreetmap.org/?lat=47.356647&lon=-103.077765
 111thAve http://www.openstreetmap.org/?lat=47.357635&lon=-102.907648
 ND22_N http://www.openstreetmap.org/?lat=47.357611&lon=-102.801176
-ND22.22Bus http://www.openstreetmap.org/?lat=47.357526&lon=-102.758678
+ND22/22Bus http://www.openstreetmap.org/?lat=47.357526&lon=-102.758678
 4thSt_Dun http://www.openstreetmap.org/?lat=47.357301&lon=-102.641702
 CenAve http://www.openstreetmap.org/?lat=47.349611&lon=-102.620566
 94thAve http://www.openstreetmap.org/?lat=47.343039&lon=-102.545872


### PR DESCRIPTION
In ND200 route file, corrects one waypoint label from ND22.22Bus to ND22/22Bus.