### PR TITLE
HI 3800 addition

### DIFF
--- a/hwy_data/HI/usahi/hi.hi036a.wpt
+++ b/hwy_data/HI/usahi/hi.hi036a.wpt
@@ -1,3 +1,3 @@
 HI36 http://www.openstreetmap.org/?lat=20.888361&lon=-156.457371
-HI380 http://www.openstreetmap.org/?lat=20.887835&lon=-156.451695
-End http://www.openstreetmap.org/?lat=20.889108&lon=-156.449292
+HI380 http://www.openstreetmap.org/?lat=20.887815&lon=-156.451754
+KahAir +End http://www.openstreetmap.org/?lat=20.889148&lon=-156.449206

--- a/hwy_data/HI/usahi/hi.hi380.wpt
+++ b/hwy_data/HI/usahi/hi.hi380.wpt
@@ -1,8 +1,8 @@
-HI36A http://www.openstreetmap.org/?lat=20.887835&lon=-156.451695
+HI36A http://www.openstreetmap.org/?lat=20.887815&lon=-156.451754
 HI36 http://www.openstreetmap.org/?lat=20.885514&lon=-156.452862
-*OldDaiRd_N +PakSt_N http://www.openstreetmap.org/?lat=20.879168&lon=-156.457575
-AirAccRd_N +PakSt_S http://www.openstreetmap.org/?lat=20.878431&lon=-156.457382
-*OldDaiRd_S +AirAccRd http://www.openstreetmap.org/?lat=20.877619&lon=-156.459002
+*OldHI380_N +OldDaiRd_N +PakSt_N http://www.openstreetmap.org/?lat=20.879168&lon=-156.457575
+HI3800_N +AirAccRd_N http://www.openstreetmap.org/?lat=20.878431&lon=-156.457382
+*OldHI380_S +OldDaiRd_S +AirAccRd http://www.openstreetmap.org/?lat=20.877619&lon=-156.459002
 HI311/3500 http://www.openstreetmap.org/?lat=20.876292&lon=-156.460447
 WaiRd http://www.openstreetmap.org/?lat=20.848762&lon=-156.484850
 HI30 http://www.openstreetmap.org/?lat=20.816765&lon=-156.506925

--- a/hwy_data/HI/usahi/hi.hi3800.wpt
+++ b/hwy_data/HI/usahi/hi.hi3800.wpt
@@ -1,0 +1,6 @@
+KahAir http://www.openstreetmap.org/?lat=20.891517&lon=-156.439830
+HalHwy http://www.openstreetmap.org/?lat=20.888144&lon=-156.442458
+HI36 http://www.openstreetmap.org/?lat=20.883313&lon=-156.449083
+HI380_N +DaiRd +AirAccRd_N +PakSt_S http://www.openstreetmap.org/?lat=20.878431&lon=-156.457382
+*OldHI380 http://www.openstreetmap.org/?lat=20.877619&lon=-156.459002
+HI311/380 http://www.openstreetmap.org/?lat=20.876292&lon=-156.460447

--- a/hwy_data/_systems/usahi.csv
+++ b/hwy_data/_systems/usahi.csv
@@ -59,6 +59,7 @@ usahi;HI;HI2000;;;;hi.hi2000;
 usahi;HI;HI3000;;;;hi.hi3000;
 usahi;HI;HI3400;;;;hi.hi3400;
 usahi;HI;HI3500;;;;hi.hi3500;
+usahi;HI;HI3800;;;;hi.hi3800;
 usahi;HI;HI7012;;;;hi.hi7012;
 usahi;HI;HI7101;;;;hi.hi7101;
 usahi;HI;HI7110;;;;hi.hi7110;

--- a/hwy_data/_systems/usahi_con.csv
+++ b/hwy_data/_systems/usahi_con.csv
@@ -59,6 +59,7 @@ usahi;HI2000;;;hi.hi2000
 usahi;HI3000;;;hi.hi3000
 usahi;HI3400;;;hi.hi3400
 usahi;HI3500;;;hi.hi3500
+usahi;HI3800;;;hi.hi3800
 usahi;HI7012;;;hi.hi7012
 usahi;HI7101;;;hi.hi7101
 usahi;HI7110;;;hi.hi7110


### PR DESCRIPTION
Adds HI 3800, and makes minor conforming changes to related routes HI 36A and 380.

Updates item:  

2017-03-03;(USA) Hawaii;HI 3800;hi.hi3800;Route added



03;