### PR TITLE
WA 99: Adding AtlSt waypoint, removing 1stAve waypoint

### DIFF
--- a/hwy_data/WA/usawa/wa.wa099.wpt
+++ b/hwy_data/WA/usawa/wa.wa099.wpt
@@ -8,7 +8,7 @@ MicSt http://www.openstreetmap.org/?lat=47.544134&lon=-122.334030
 MarWay http://www.openstreetmap.org/?lat=47.547900&lon=-122.333987
 LucSt http://www.openstreetmap.org/?lat=47.553360&lon=-122.336926
 WSeaBri +SeaFwy http://www.openstreetmap.org/?lat=47.571575&lon=-122.339501
-1stAve http://www.openstreetmap.org/?lat=47.597728&lon=-122.335639
+AtlSt +1stAve http://www.openstreetmap.org/?lat=47.590579&lon=-122.336926
 ColSt http://www.openstreetmap.org/?lat=47.602271&lon=-122.336723
 SenSt http://www.openstreetmap.org/?lat=47.604904&lon=-122.339158
 WesAve http://www.openstreetmap.org/?lat=47.612695&lon=-122.347398


### PR DESCRIPTION
The AtlSt waypoint effectively replaces the 1stAve one. 

http://tm.teresco.org/forum/index.php?topic=1966.msg5528#msg5528