### PR TITLE
Fixing WA 9 Spur (Sumas)

### DIFF
--- a/hwy_data/WA/usawa/wa.wa009sprsum.wpt
+++ b/hwy_data/WA/usawa/wa.wa009sprsum.wpt
@@ -1,3 +1,3 @@
 WA9 http://www.openstreetmap.org/?lat=49.000007&lon=-122.264925
 GarSt http://www.openstreetmap.org/?lat=49.000014&lon=-122.263370
-WA/BC http://www.openstreetmap.org/?lat=49.000000&lon=-122.263681
+WA/BC http://www.openstreetmap.org/?lat=49.002400&lon=-122.263713


### PR DESCRIPTION
Fixing location of WA/BC waypoint. Apparently, the border isn't quite at a latitude of 49 degrees.