### PR TITLE
PA: I-90/I-86 nmp

### DIFF
--- a/hwy_data/NY/usai/ny.i086.wpt
+++ b/hwy_data/NY/usai/ny.i086.wpt
@@ -1,4 +1,4 @@
-PA/NY http://www.openstreetmap.org/?lat=42.129771&lon=-79.761729
+PA/NY http://www.openstreetmap.org/?lat=42.129835&lon=-79.761944
 4 http://www.openstreetmap.org/?lat=42.130567&lon=-79.741945
 +X01 http://www.openstreetmap.org/?lat=42.145057&lon=-79.706326
 +X02 http://www.openstreetmap.org/?lat=42.146457&lon=-79.605732

--- a/hwy_data/NY/usai/ny.i090.wpt
+++ b/hwy_data/NY/usai/ny.i090.wpt
@@ -1,4 +1,4 @@
-PA/NY +0 http://www.openstreetmap.org/?lat=42.252473&lon=-79.761515
+PA/NY +0 http://www.openstreetmap.org/?lat=42.252441&lon=-79.761912
 61(NYST) http://www.openstreetmap.org/?lat=42.261684&lon=-79.744949
 +X01 http://www.openstreetmap.org/?lat=42.314140&lon=-79.619293
 60(NYST) http://www.openstreetmap.org/?lat=42.338562&lon=-79.583673

--- a/hwy_data/NY/usany/ny.ny017.wpt
+++ b/hwy_data/NY/usany/ny.ny017.wpt
@@ -1,4 +1,4 @@
-PA/NY http://www.openstreetmap.org/?lat=42.129771&lon=-79.761729
+PA/NY http://www.openstreetmap.org/?lat=42.129835&lon=-79.761944
 4 http://www.openstreetmap.org/?lat=42.130567&lon=-79.741945
 +X01 http://www.openstreetmap.org/?lat=42.145057&lon=-79.706326
 +X02 http://www.openstreetmap.org/?lat=42.146457&lon=-79.605732

--- a/hwy_data/OH/usai/oh.i090.wpt
+++ b/hwy_data/OH/usai/oh.i090.wpt
@@ -87,4 +87,4 @@ IN/OH +0 http://www.openstreetmap.org/?lat=41.628563&lon=-84.805695
 +x120 http://www.openstreetmap.org/?lat=41.850821&lon=-80.701329
 235 http://www.openstreetmap.org/?lat=41.880649&lon=-80.666385
 241 http://www.openstreetmap.org/?lat=41.916841&lon=-80.568666
-OH/PA +999 http://www.openstreetmap.org/?lat=41.937211&lon=-80.518928
+OH/PA +999 http://www.openstreetmap.org/?lat=41.937307&lon=-80.519314

--- a/hwy_data/PA/usai/pa.i079.wpt
+++ b/hwy_data/PA/usai/pa.i079.wpt
@@ -79,7 +79,7 @@ WV/PA +0 https://www.openstreetmap.org/?lat=39.721130&lon=-80.061485
 166 https://www.openstreetmap.org/?lat=41.879851&lon=-80.176119
 +X21 http://www.openstreetmap.org/?lat=41.980613&lon=-80.177193
 174 http://www.openstreetmap.org/?lat=41.996657&lon=-80.166035
-178 http://www.openstreetmap.org/?lat=42.031923&lon=-80.122475
+178 http://www.openstreetmap.org/?lat=42.031823&lon=-80.122475
 180 http://www.openstreetmap.org/?lat=42.065893&lon=-80.105910
 182 http://www.openstreetmap.org/?lat=42.093637&lon=-80.121531
 183 https://www.openstreetmap.org/?lat=42.108539&lon=-80.122475

--- a/hwy_data/PA/usai/pa.i090.wpt
+++ b/hwy_data/PA/usai/pa.i090.wpt
@@ -1,17 +1,18 @@
 OH/PA +0 http://www.openstreetmap.org/?lat=41.937307&lon=-80.519314
-3 https://www.openstreetmap.org/?lat=41.943245&lon=-80.463137
-6 https://www.openstreetmap.org/?lat=41.945088&lon=-80.402176
-9 http://www.openstreetmap.org/?lat=41.962713&lon=-80.340528
-16 https://www.openstreetmap.org/?lat=42.004885&lon=-80.238947
-18 http://www.openstreetmap.org/?lat=42.018597&lon=-80.188094
-22 http://www.openstreetmap.org/?lat=42.031795&lon=-80.122518
-24 http://www.openstreetmap.org/?lat=42.049452&lon=-80.081191
++X976418 http://www.openstreetmap.org/?lat=41.943001&lon=-80.506922
+3 http://www.openstreetmap.org/?lat=41.943245&lon=-80.463137
+6 http://www.openstreetmap.org/?lat=41.945088&lon=-80.402176
+9 http://www.openstreetmap.org/?lat=41.962757&lon=-80.340576
+16 https://www.openstreetmap.org/?lat=42.004869&lon=-80.239049
+18 http://www.openstreetmap.org/?lat=42.018505&lon=-80.188250
+22 http://www.openstreetmap.org/?lat=42.031823&lon=-80.122475
+24 http://www.openstreetmap.org/?lat=42.049448&lon=-80.081314
 27 https://www.openstreetmap.org/?lat=42.069947&lon=-80.040035
-29 http://www.openstreetmap.org/?lat=42.093446&lon=-80.005831
+29 http://www.openstreetmap.org/?lat=42.093454&lon=-80.005890
 32 http://www.openstreetmap.org/?lat=42.118790&lon=-79.963259
 35 https://www.openstreetmap.org/?lat=42.139493&lon=-79.923391
 37 https://www.openstreetmap.org/?lat=42.153637&lon=-79.892320
 +X630694 http://www.openstreetmap.org/?lat=42.169129&lon=-79.851208
 41 https://www.openstreetmap.org/?lat=42.188020&lon=-79.830007
 45 http://www.openstreetmap.org/?lat=42.233507&lon=-79.780054
-PA/NY +999 http://www.openstreetmap.org/?lat=42.252473&lon=-79.761944
+PA/NY +999 http://www.openstreetmap.org/?lat=42.252441&lon=-79.761912

--- a/hwy_data/PA/usapa/pa.pa008.wpt
+++ b/hwy_data/PA/usapa/pa.pa008.wpt
@@ -79,7 +79,7 @@ PhiRd http://www.openstreetmap.org/?lat=42.058486&lon=-79.863524
 MayRd http://www.openstreetmap.org/?lat=42.057594&lon=-79.912362
 MarkRd http://www.openstreetmap.org/?lat=42.067988&lon=-79.956329
 TateRd http://www.openstreetmap.org/?lat=42.066893&lon=-79.978033
-I-90 http://www.openstreetmap.org/?lat=42.093478&lon=-80.005703
+I-90 http://www.openstreetmap.org/?lat=42.093454&lon=-80.005890
 38thSt http://www.openstreetmap.org/?lat=42.108491&lon=-80.049734
 PA97_N https://www.openstreetmap.org/?lat=42.113422&lon=-80.063767
 US20 https://www.openstreetmap.org/?lat=42.115129&lon=-80.064969

--- a/hwy_data/PA/usapa/pa.pa018.wpt
+++ b/hwy_data/PA/usapa/pa.pa018.wpt
@@ -130,7 +130,7 @@ US6N_W http://www.openstreetmap.org/?lat=41.890841&lon=-80.366363
 US6N_E http://www.openstreetmap.org/?lat=41.889595&lon=-80.340399
 KidRd http://www.openstreetmap.org/?lat=41.926117&lon=-80.339370
 FraCenRd http://www.openstreetmap.org/?lat=41.940100&lon=-80.327611
-I-90 http://www.openstreetmap.org/?lat=41.962841&lon=-80.340528
+I-90 http://www.openstreetmap.org/?lat=41.962757&lon=-80.340576
 US20_W http://www.openstreetmap.org/?lat=41.993707&lon=-80.337932
 US20_E http://www.openstreetmap.org/?lat=41.999273&lon=-80.319779
 HatSt http://www.openstreetmap.org/?lat=42.006647&lon=-80.324650

--- a/hwy_data/PA/usapa/pa.pa098.wpt
+++ b/hwy_data/PA/usapa/pa.pa098.wpt
@@ -7,6 +7,6 @@ PontRd http://www.openstreetmap.org/?lat=41.825036&lon=-80.244656
 +X1 http://www.openstreetmap.org/?lat=41.835409&lon=-80.227511
 US6N https://www.openstreetmap.org/?lat=41.879946&lon=-80.225773
 PA832 https://www.openstreetmap.org/?lat=41.997036&lon=-80.234656
-I-90 https://www.openstreetmap.org/?lat=42.004885&lon=-80.238947
+I-90 https://www.openstreetmap.org/?lat=42.004869&lon=-80.239049
 US20 https://www.openstreetmap.org/?lat=42.031508&lon=-80.255470
 PA5 http://www.openstreetmap.org/?lat=42.045464&lon=-80.269847

--- a/hwy_data/PA/usapa/pa.pa832.wpt
+++ b/hwy_data/PA/usapa/pa.pa832.wpt
@@ -1,6 +1,6 @@
 PA98 https://www.openstreetmap.org/?lat=41.997036&lon=-80.234656
 WestRd http://www.openstreetmap.org/?lat=42.004714&lon=-80.202470
-I-90 http://www.openstreetmap.org/?lat=42.018525&lon=-80.188222
+I-90 http://www.openstreetmap.org/?lat=42.018505&lon=-80.188250
 US20 http://www.openstreetmap.org/?lat=42.088032&lon=-80.137796
 PA5 https://www.openstreetmap.org/?lat=42.099815&lon=-80.145575
 PA5Alt http://www.openstreetmap.org/?lat=42.103954&lon=-80.148268

--- a/hwy_data/PA/usaus/pa.us019.wpt
+++ b/hwy_data/PA/usaus/pa.us019.wpt
@@ -97,7 +97,7 @@ PA99_S https://www.openstreetmap.org/?lat=41.806205&lon=-80.054895
 US6/6N +US6_E https://www.openstreetmap.org/?lat=41.882311&lon=-80.000596
 PA97_S http://www.openstreetmap.org/?lat=41.934146&lon=-79.980683
 PA97_N http://www.openstreetmap.org/?lat=41.953107&lon=-79.992571
-I-90 http://www.openstreetmap.org/?lat=42.049579&lon=-80.081363
+I-90 http://www.openstreetmap.org/?lat=42.049448&lon=-80.081314
 PA99_N http://www.openstreetmap.org/?lat=42.065384&lon=-80.093422
 38thSt http://www.openstreetmap.org/?lat=42.096567&lon=-80.082006
 US20 https://www.openstreetmap.org/?lat=42.111468&lon=-80.075011

--- a/hwy_data/PA/usaus/pa.us020.wpt
+++ b/hwy_data/PA/usaus/pa.us020.wpt
@@ -18,5 +18,5 @@ PA531 http://www.openstreetmap.org/?lat=42.165852&lon=-79.954892
 PA955 http://www.openstreetmap.org/?lat=42.168016&lon=-79.953347
 MooRd http://www.openstreetmap.org/?lat=42.191915&lon=-79.910173
 PA89 http://www.openstreetmap.org/?lat=42.216027&lon=-79.834513
-I-90 http://www.openstreetmap.org/?lat=42.233633&lon=-79.780011
+I-90 http://www.openstreetmap.org/?lat=42.233507&lon=-79.780054
 PA/NY http://www.openstreetmap.org/?lat=42.243292&lon=-79.762244

--- a/hwy_data/PA/usaush/pa.us020hisnor.wpt
+++ b/hwy_data/PA/usaush/pa.us020hisnor.wpt
@@ -1,3 +1,3 @@
 MooRd http://www.openstreetmap.org/?lat=42.191915&lon=-79.910173
 PA89 http://www.openstreetmap.org/?lat=42.216027&lon=-79.834513
-I-90 http://www.openstreetmap.org/?lat=42.233633&lon=-79.780011
+I-90 http://www.openstreetmap.org/?lat=42.233507&lon=-79.780054


### PR DESCRIPTION
This should clear all NMP errors that have to deal with I-90 in PA.

Also quickly synced up NY's I-86/NY-17 with PA's I-86, as PA's point seemed to be right on target for the state line.

Not much, but should clear out several lines from the log.