### PR TITLE
AR US64: temporarily remove AR162 primary label

### DIFF
--- a/hwy_data/AR/usausb/ar.us064busalm.wpt
+++ b/hwy_data/AR/usausb/ar.us064busalm.wpt
@@ -1,2 +1,2 @@
-AR162 +AR162_S http://www.openstreetmap.org/?lat=35.480627&lon=-94.222236
+AR162_S http://www.openstreetmap.org/?lat=35.480627&lon=-94.222236
 US64 +US64_E http://www.openstreetmap.org/?lat=35.488319&lon=-94.206616


### PR DESCRIPTION
Label not in use. In the next few weeks, this label will be needed elsewhere in the file due to a [relocation of AR162](http://tm.teresco.org/forum/index.php?topic=2112.new#new). Proactively removing the label now, just to ensure nobody adds it to a .list file in the meantime.