### PR TITLE
CA 299 error fix

### DIFF
--- a/hwy_data/CA/usaca/ca.ca299.wpt
+++ b/hwy_data/CA/usaca/ca.ca299.wpt
@@ -68,10 +68,10 @@ CorBotRd http://www.openstreetmap.org/?lat=40.739803&lon=-123.251839
 +x134 http://www.openstreetmap.org/?lat=40.734706&lon=-122.955980
 +x135 http://www.openstreetmap.org/?lat=40.736527&lon=-122.950745
 +x136 http://www.openstreetmap.org/?lat=40.735096&lon=-122.941904
-CA3_S http://www.openstreetmap.org/?lat=40.651294&lon=-122.939297
-UniHillRd http://www.openstreetmap.org/?lat=40.672859&lon=-122.943599
-IndPkwy http://www.openstreetmap.org/?lat=40.710313&lon=-122.923987
 CA3_N http://www.openstreetmap.org/?lat=40.732793&lon=-122.940493
+IndPkwy http://www.openstreetmap.org/?lat=40.710313&lon=-122.923987
+UniHillRd http://www.openstreetmap.org/?lat=40.672859&lon=-122.943599
+CA3_S http://www.openstreetmap.org/?lat=40.651294&lon=-122.939297
 +x137 http://www.openstreetmap.org/?lat=40.658178&lon=-122.917786
 +x138 http://www.openstreetmap.org/?lat=40.654467&lon=-122.909975
 +x139 http://www.openstreetmap.org/?lat=40.653295&lon=-122.898989
@@ -120,7 +120,7 @@ QuaHillRd http://www.openstreetmap.org/?lat=40.594273&lon=-122.389455
 BenDr http://www.openstreetmap.org/?lat=40.599584&lon=-122.383876
 +x1(CA273) http://www.openstreetmap.org/?lat=40.607143&lon=-122.377052
 CA273 http://www.openstreetmap.org/?lat=40.609489&lon=-122.376623
-I-5 http://www.openstreetmap.org/?lat=40.612273&lon=-122.363238 
+I-5 http://www.openstreetmap.org/?lat=40.612273&lon=-122.363238
 141 http://www.openstreetmap.org/?lat=40.614685&lon=-122.349758
 143 http://www.openstreetmap.org/?lat=40.620826&lon=-122.318730
 StiWay http://www.openstreetmap.org/?lat=40.625582&lon=-122.296661
@@ -173,10 +173,10 @@ CA89 http://www.openstreetmap.org/?lat=40.938184&lon=-121.606636
 +x202 http://www.openstreetmap.org/?lat=41.002184&lon=-121.505013
 +x203 http://www.openstreetmap.org/?lat=40.993763&lon=-121.492653
 +x204 http://www.openstreetmap.org/?lat=40.992403&lon=-121.472397
-CHA20 http://www.openstreetmap.org/?lat=41.001213&lon=-121.446648
+CRA20 http://www.openstreetmap.org/?lat=41.001213&lon=-121.446648
 RivSt http://www.openstreetmap.org/?lat=41.004063&lon=-121.438665
 FallRivAir http://www.openstreetmap.org/?lat=41.017599&lon=-121.430511
-CHA19 http://www.openstreetmap.org/?lat=41.049906&lon=-121.403217
+CRA19 http://www.openstreetmap.org/?lat=41.049906&lon=-121.403217
 MainSt http://www.openstreetmap.org/?lat=41.050165&lon=-121.398454
 PitRd http://www.openstreetmap.org/?lat=41.058903&lon=-121.375751
 +x205 http://www.openstreetmap.org/?lat=41.077863&lon=-121.317043
@@ -188,7 +188,7 @@ OldHwyRd http://www.openstreetmap.org/?lat=41.094166&lon=-121.277862
 +x209 http://www.openstreetmap.org/?lat=41.059744&lon=-121.214733
 KraRd http://www.openstreetmap.org/?lat=41.095847&lon=-121.182418
 BriSt http://www.openstreetmap.org/?lat=41.121521&lon=-121.144910
-CHA2 http://www.openstreetmap.org/?lat=41.132060&lon=-121.131735
+CRA2 http://www.openstreetmap.org/?lat=41.132060&lon=-121.131735
 +x210 http://www.openstreetmap.org/?lat=41.145828&lon=-121.110878
 +x211 http://www.openstreetmap.org/?lat=41.146862&lon=-121.041441
 AdinAir http://www.openstreetmap.org/?lat=41.184386&lon=-120.950042


### PR DESCRIPTION
When synching CA 299 to revised CA 3 route file, I spliced CA 3 coordinates in the wrong order. This fix corrects the waypoint order for CA 299.