### PR TITLE
QC A-70 extension

### DIFF
--- a/hwy_data/QC/canqca/qc.a070.wpt
+++ b/hwy_data/QC/canqca/qc.a070.wpt
@@ -8,4 +8,6 @@
 42 http://www.openstreetmap.org/?lat=48.396542&lon=-71.141260
 45 http://www.openstreetmap.org/?lat=48.392795&lon=-71.109867
 47 http://www.openstreetmap.org/?lat=48.386012&lon=-71.079741
-QC170 http://www.openstreetmap.org/?lat=48.373527&lon=-71.067681
+*QC170 http://www.openstreetmap.org/?lat=48.374774&lon=-71.067928
+50 http://www.openstreetmap.org/?lat=48.369059&lon=-71.061898
+ChGraAnse http://www.openstreetmap.org/?lat=48.347871&lon=-70.990359


### PR DESCRIPTION
Reflects latest eastward A-70 extension.

Updates item:

2017-07-31;(Canada) Quebec;A-70;qc.a070;East end extended from closed intersection *QC170 to new interchange with Ch. de la Grande-Anse