### PR TITLE
WV: WV-972 absorbed by WV-93

### DIFF
--- a/hwy_data/WV/usaus/wv.us050rom.wpt
+++ b/hwy_data/WV/usaus/wv.us050rom.wpt
@@ -8,8 +8,8 @@ WV42_S http://www.openstreetmap.org/?lat=39.277015&lon=-79.241233
 +X028(US50) http://www.openstreetmap.org/?lat=39.299900&lon=-79.213585
 +X029(US50) http://www.openstreetmap.org/?lat=39.312249&lon=-79.211742
 WV42_N http://www.openstreetmap.org/?lat=39.323260&lon=-79.129538
-WV93 http://www.openstreetmap.org/?lat=39.342514&lon=-79.066656
-WV972 http://www.openstreetmap.org/?lat=39.368584&lon=-79.033668
+WV93_W +WV93 http://www.openstreetmap.org/?lat=39.342514&lon=-79.066656
+WV93_E +WV972 http://www.openstreetmap.org/?lat=39.368584&lon=-79.033668
 CR220/3 http://www.openstreetmap.org/?lat=39.368669&lon=-79.031509
 +X030(US50) http://www.openstreetmap.org/?lat=39.364860&lon=-79.029870
 US220_N http://www.openstreetmap.org/?lat=39.362292&lon=-79.004560

--- a/hwy_data/WV/usaus/wv.us220.wpt
+++ b/hwy_data/WV/usaus/wv.us220.wpt
@@ -47,7 +47,7 @@ CR11_S http://www.openstreetmap.org/?lat=39.337565&lon=-78.917649
 +X031(US50) http://www.openstreetmap.org/?lat=39.335467&lon=-78.962415
 US50_W http://www.openstreetmap.org/?lat=39.362292&lon=-79.004560
 +X025(US220) http://www.openstreetmap.org/?lat=39.389337&lon=-79.004949
-WV972 http://www.openstreetmap.org/?lat=39.394986&lon=-79.012553
+WV93 +WV972 http://www.openstreetmap.org/?lat=39.394986&lon=-79.012553
 +X026(US220) http://www.openstreetmap.org/?lat=39.422640&lon=-78.996938
 WV46 +WV46_E WV46_W http://www.openstreetmap.org/?lat=39.440953&lon=-78.976395
 WV/MD http://www.openstreetmap.org/?lat=39.444678&lon=-78.972816

--- a/hwy_data/WV/usawv/wv.wv093.wpt
+++ b/hwy_data/WV/usawv/wv.wv093.wpt
@@ -16,4 +16,6 @@ WV42_N http://www.openstreetmap.org/?lat=39.219013&lon=-79.211050
 WV42_S http://www.openstreetmap.org/?lat=39.192318&lon=-79.171644
 ToUS48_E +ToUS48 http://www.openstreetmap.org/?lat=39.219824&lon=-79.158618
 CR42/2 http://www.openstreetmap.org/?lat=39.271950&lon=-79.123707
-US50 http://www.openstreetmap.org/?lat=39.342514&lon=-79.066656
+US50_W +US50 http://www.openstreetmap.org/?lat=39.342514&lon=-79.066656
+US50_E http://www.openstreetmap.org/?lat=39.368584&lon=-79.033668
+US220 http://www.openstreetmap.org/?lat=39.394986&lon=-79.012553

--- a/hwy_data/WV/usawv/wv.wv972.wpt
+++ b/hwy_data/WV/usawv/wv.wv972.wpt
@@ -1,2 +1,0 @@
-US50 http://www.openstreetmap.org/?lat=39.368545&lon=-79.033885
-US220 http://www.openstreetmap.org/?lat=39.395048&lon=-79.012341

--- a/hwy_data/_systems/usawv.csv
+++ b/hwy_data/_systems/usawv.csv
@@ -132,4 +132,3 @@ usawv;WV;WV892;;;;wv.wv892;
 usawv;WV;WV901;;;;wv.wv901;
 usawv;WV;WV956;;;;wv.wv956;
 usawv;WV;WV971;;;;wv.wv971;
-usawv;WV;WV972;;;;wv.wv972;

--- a/hwy_data/_systems/usawv_con.csv
+++ b/hwy_data/_systems/usawv_con.csv
@@ -132,4 +132,3 @@ usawv;WV892;;;wv.wv892
 usawv;WV901;;;wv.wv901
 usawv;WV956;;;wv.wv956
 usawv;WV971;;;wv.wv971
-usawv;WV972;;;wv.wv972

--- a/updates.csv
+++ b/updates.csv
@@ -1892,6 +1892,8 @@
 2016-11-26;(USA) Washington;WA 92;wa.wa092;East end removed from Granite Falls Highway between Quary Road and Granite Avenue, and relocated onto Quarry Road between Granite Falls Highway and Mountain Loop Highway
 2016-07-28;(USA) Washington;I-90 Business Loop (Spokane Valley);wa.i090blspo;Route added
 2016-05-01;(USA) Washington;US395 Future (Spokane);wa.us395futspo;New Route
+2017-08-05;(USA) West Virginia;WV 93;wv.wv093;Extended eastward from former eastern end (now 'US50_W') along US 50 and former WV 972 to a new eastern terminus at US 220.
+2017-08-05;(USA) West Virginia;WV 972;wv.wv093;Route Deleted. Absorbed by WV 93.
 2017-06-25;(USA) West Virginia;US 19;wv.us019;Removed from the former, now demolished, Hood Street Bridge in Shinnston, and rerouted onto the replacement bridge to the north between Clement Street & Hood Avenue.
 2017-06-25;(USA) West Virginia;WV 279;wv.wv279;Extended westward from it's former western end at I-79 to County Route 707.
 2017-04-02;(USA) West Virginia;US 48;wv.us048;Extended westward from it's former temporary western end at the old WV 93 alignment in Tucker County along WV 32, US 219, and US 33 to it's permanent western end at an interchange with I-79.


### PR DESCRIPTION
http://tm.teresco.org/forum/index.php?topic=2153.0

Now, you might wonder why I didn't add 'WV972' to the 'altlabels' for WV-93.  The reason is because I'm trying to avoid FPs in people's lists, as both routes had the 'US50' label at each end, and I could only 'hide' it in one location, and since WV-972 was absorbed by WV-93, the original location of 'US50' in WV-93's file got the 'hidden' label.