### PR TITLE
MN 36/WI 64 Stillwater Bridge

### DIFF
--- a/hwy_data/MN/usamn/mn.mn036.wpt
+++ b/hwy_data/MN/usamn/mn.mn036.wpt
@@ -21,6 +21,5 @@ KeaAve http://www.openstreetmap.org/?lat=45.035625&lon=-92.903910
 CSAH5/15 +MN5 http://www.openstreetmap.org/?lat=45.036079&lon=-92.846446
 OsgAve http://www.openstreetmap.org/?lat=45.035807&lon=-92.807565
 BeaRd http://www.openstreetmap.org/?lat=45.036777&lon=-92.797136
-MN95_S http://www.openstreetmap.org/?lat=45.040022&lon=-92.794733
-MN95_N http://www.openstreetmap.org/?lat=45.055804&lon=-92.805827
-MN/WI http://www.openstreetmap.org/?lat=45.056880&lon=-92.801771
+MN95 +MN95_S http://www.openstreetmap.org/?lat=45.03602&lon=-92.79286
+MN/WI http://www.openstreetmap.org/?lat=45.04206&lon=-92.78487

--- a/hwy_data/MN/usamn/mn.mn095.wpt
+++ b/hwy_data/MN/usamn/mn.mn095.wpt
@@ -49,8 +49,8 @@ CR51 http://www.openstreetmap.org/?lat=45.110498&lon=-92.782116
 +X855166 http://www.openstreetmap.org/?lat=45.088975&lon=-92.781215
 MN96 http://www.openstreetmap.org/?lat=45.075400&lon=-92.807286
 MyrSt http://www.openstreetmap.org/?lat=45.056607&lon=-92.806213
-MN36_E http://www.openstreetmap.org/?lat=45.055804&lon=-92.805827
-MN36_W http://www.openstreetmap.org/?lat=45.040022&lon=-92.794733
+CheSt +MN36_E http://www.openstreetmap.org/?lat=45.055804&lon=-92.805827
+MN36 +MN36_W http://www.openstreetmap.org/?lat=45.03602&lon=-92.79286
 5thAve http://www.openstreetmap.org/?lat=45.021582&lon=-92.780957
 22ndSt http://www.openstreetmap.org/?lat=44.979902&lon=-92.777674
 I-94(258) http://www.openstreetmap.org/?lat=44.961898&lon=-92.773404

--- a/hwy_data/WI/usawi/wi.wi035.wpt
+++ b/hwy_data/WI/usawi/wi.wi035.wpt
@@ -115,9 +115,9 @@ I-94(1) http://www.openstreetmap.org/?lat=44.962581&lon=-92.752376
 CRUU_StC http://www.openstreetmap.org/?lat=44.977033&lon=-92.757053
 CRA_StC http://www.openstreetmap.org/?lat=44.982558&lon=-92.757225
 CRV_StCS http://www.openstreetmap.org/?lat=45.027982&lon=-92.747612
-CRE_StC http://www.openstreetmap.org/?lat=45.060616&lon=-92.791729
-WI64_W http://www.openstreetmap.org/?lat=45.064549&lon=-92.792072
-+X18 http://www.openstreetmap.org/?lat=45.071460&lon=-92.788467
+MainSt_Hou http://www.openstreetmap.org/?lat=45.05598&lon=-92.79075
+WI64/CRE http://www.openstreetmap.org/?lat=45.05991&lon=-92.78056
+*Old35Hou http://www.openstreetmap.org/?lat=45.07189&lon=-92.77485
 +X29 http://www.openstreetmap.org/?lat=45.073642&lon=-92.757225
 CRV_StC http://www.openstreetmap.org/?lat=45.089520&lon=-92.740145
 WI64BusSom_W http://www.openstreetmap.org/?lat=45.107091&lon=-92.723665

--- a/hwy_data/WI/usawi/wi.wi064.wpt
+++ b/hwy_data/WI/usawi/wi.wi064.wpt
@@ -1,7 +1,6 @@
-MN/WI http://www.openstreetmap.org/?lat=45.056956&lon=-92.801771
-CRE_StC http://www.openstreetmap.org/?lat=45.059108&lon=-92.796535
-WI35_S http://www.openstreetmap.org/?lat=45.064549&lon=-92.792072
-+X00a http://www.openstreetmap.org/?lat=45.071460&lon=-92.788467
+MN/WI http://www.openstreetmap.org/?lat=45.04206&lon=-92.78487
+WI35/CRE http://www.openstreetmap.org/?lat=45.05991&lon=-92.78056
+*Old64Hou http://www.openstreetmap.org/?lat=45.07189&lon=-92.77485
 +X00b http://www.openstreetmap.org/?lat=45.073642&lon=-92.757225
 CRV_StC http://www.openstreetmap.org/?lat=45.089520&lon=-92.740145
 WI64BusSom_W http://www.openstreetmap.org/?lat=45.107091&lon=-92.723665


### PR DESCRIPTION
Changes needed due to the completion of the new MN 36/WI 64 Stillwater Bridge.