### PR TITLE
CA active routes updates

### DIFF
--- a/hwy_data/CA/usaib/ca.i005bldun.wpt
+++ b/hwy_data/CA/usaib/ca.i005bldun.wpt
@@ -1,4 +1,9 @@
-I-5_S http://www.openstreetmap.org/?lat=41.193433&lon=-122.284564
+I-5(729) +I-5_S http://www.openstreetmap.org/?lat=41.193433&lon=-122.284564
 KatSt http://www.openstreetmap.org/?lat=41.202153&lon=-122.275026
 WilSt http://www.openstreetmap.org/?lat=41.213114&lon=-122.271754
-I-5_N http://www.openstreetmap.org/?lat=41.217798&lon=-122.274640
+I-5(730) +I-5_N http://www.openstreetmap.org/?lat=41.217798&lon=-122.274640
+SisAve http://www.openstreetmap.org/?lat=41.223763&lon=-122.275922
+ScaWay http://www.openstreetmap.org/?lat=41.228451&lon=-122.275922
+WelSt http://www.openstreetmap.org/?lat=41.231154&lon=-122.275300
+DunAve_N http://www.openstreetmap.org/?lat=41.235987&lon=-122.270289
+I-5(732) http://www.openstreetmap.org/?lat=41.235488&lon=-122.269592

--- a/hwy_data/CA/usaus/ca.us101.wpt
+++ b/hwy_data/CA/usaus/ca.us101.wpt
@@ -367,7 +367,7 @@ DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 462A +US101BusNov_S http://www.openstreetmap.org/?lat=38.092198&lon=-122.559168
 462B http://www.openstreetmap.org/?lat=38.105032&lon=-122.562237
 463 http://www.openstreetmap.org/?lat=38.117690&lon=-122.565108
-OloSPRd http://www.openstreetmap.org/?lat=38.150348&lon=-122.566513
+467 http://www.openstreetmap.org/?lat=38.163020&lon=-122.575219
 *SanAntRd_N http://www.openstreetmap.org/?lat=38.188023&lon=-122.601006
 472A http://www.openstreetmap.org/?lat=38.220768&lon=-122.607524
 472B +CA116_E http://www.openstreetmap.org/?lat=38.233263&lon=-122.617946

--- a/hwy_data/CA/usausb/ca.us101buspet.wpt
+++ b/hwy_data/CA/usausb/ca.us101buspet.wpt
@@ -1,4 +1,4 @@
-US101_S http://www.openstreetmap.org/?lat=38.223954&lon=-122.612180
+US101_S http://www.openstreetmap.org/?lat=38.220768&lon=-122.607524
 WasSt http://www.openstreetmap.org/?lat=38.235711&lon=-122.641153
 StoPoiRd http://www.openstreetmap.org/?lat=38.268974&lon=-122.670593
 US101_N http://www.openstreetmap.org/?lat=38.272069&lon=-122.669950


### PR DESCRIPTION
Three updates of CA routes in active systems:

I-5BLDun extended north one exit, as discussed in the forum

Added new exit 467 to US 101

Re-synched southern end of US101BusPet with US 101

Only first item needs an Updates entry, which I'll add to the Updates table separately.

@si404:  First item affects US99HisDun, as noted in the forum.