### PR TITLE
QC A-25 extension, CA US 101 updates

### DIFF
--- a/hwy_data/CA/usaus/ca.us101.wpt
+++ b/hwy_data/CA/usaus/ca.us101.wpt
@@ -3,18 +3,19 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 1A http://www.openstreetmap.org/?lat=34.042983&lon=-118.221066
 1B http://www.openstreetmap.org/?lat=34.047304&lon=-118.221463
 1D +I-10 +SanBerFwy http://www.openstreetmap.org/?lat=34.052201&lon=-118.224575
-2A +VigSt http://www.openstreetmap.org/?lat=34.053779&lon=-118.232385
+1E http://www.openstreetmap.org/?lat=34.052695&lon=-118.226586
+2A http://www.openstreetmap.org/?lat=34.053779&lon=-118.232385
 2B http://www.openstreetmap.org/?lat=34.055041&lon=-118.239347
 2C http://www.openstreetmap.org/?lat=34.056660&lon=-118.241950
-3A +TemSt http://www.openstreetmap.org/?lat=34.059103&lon=-118.245490
+3A http://www.openstreetmap.org/?lat=34.059103&lon=-118.245490
 3B +I-110 http://www.openstreetmap.org/?lat=34.062633&lon=-118.248800
 4A http://www.openstreetmap.org/?lat=34.069703&lon=-118.261229
-4B +CA2_E http://www.openstreetmap.org/?lat=34.072004&lon=-118.266899
+4B http://www.openstreetmap.org/?lat=34.072004&lon=-118.266899
 5A http://www.openstreetmap.org/?lat=34.074799&lon=-118.273219
 5B http://www.openstreetmap.org/?lat=34.077181&lon=-118.281700
 6A +NVerAve http://www.openstreetmap.org/?lat=34.079847&lon=-118.291705
-6B +MelAve http://www.openstreetmap.org/?lat=34.083561&lon=-118.298700
-7 +CA2_W http://www.openstreetmap.org/?lat=34.090787&lon=-118.306468
+6B http://www.openstreetmap.org/?lat=34.083561&lon=-118.298700
+7 http://www.openstreetmap.org/?lat=34.090787&lon=-118.306468
 8A +WSunBlvd http://www.openstreetmap.org/?lat=34.098071&lon=-118.314514
 8B +HolBlvd http://www.openstreetmap.org/?lat=34.101690&lon=-118.316617
 8C http://www.openstreetmap.org/?lat=34.104307&lon=-118.322453
@@ -23,9 +24,9 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 9C +CA170_S http://www.openstreetmap.org/?lat=34.114496&lon=-118.336519
 11 http://www.openstreetmap.org/?lat=34.128765&lon=-118.346990
 11B +UniCenDr http://www.openstreetmap.org/?lat=34.133192&lon=-118.352473
-12A +UniPl http://www.openstreetmap.org/?lat=34.137739&lon=-118.362901
+12A http://www.openstreetmap.org/?lat=34.137739&lon=-118.362901
 12C +VinAve http://www.openstreetmap.org/?lat=34.146889&lon=-118.370310
-13 +CA170 +CA134/170 http://www.openstreetmap.org/?lat=34.153686&lon=-118.376972
+13 +CA134/170 http://www.openstreetmap.org/?lat=34.153686&lon=-118.376972
 14 http://www.openstreetmap.org/?lat=34.154423&lon=-118.396488
 15 http://www.openstreetmap.org/?lat=34.156727&lon=-118.413778
 16 http://www.openstreetmap.org/?lat=34.155630&lon=-118.431244
@@ -36,12 +37,12 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 20 http://www.openstreetmap.org/?lat=34.165431&lon=-118.492355
 21 http://www.openstreetmap.org/?lat=34.170443&lon=-118.501105
 22 http://www.openstreetmap.org/?lat=34.171201&lon=-118.518555
-23 +ResBlvd http://www.openstreetmap.org/?lat=34.173234&lon=-118.535985
+23 http://www.openstreetmap.org/?lat=34.173234&lon=-118.535985
 24 http://www.openstreetmap.org/?lat=34.173554&lon=-118.553467
-25 +WinAve http://www.openstreetmap.org/?lat=34.172213&lon=-118.570933
+25 http://www.openstreetmap.org/?lat=34.172213&lon=-118.570933
 26A http://www.openstreetmap.org/?lat=34.168076&lon=-118.588164
 26B http://www.openstreetmap.org/?lat=34.169461&lon=-118.597433
-27A +CA27 http://www.openstreetmap.org/?lat=34.170718&lon=-118.605807
+27A http://www.openstreetmap.org/?lat=34.170718&lon=-118.605807
 27C http://www.openstreetmap.org/?lat=34.168960&lon=-118.612679
 28 http://www.openstreetmap.org/?lat=34.163344&lon=-118.626862
 29 http://www.openstreetmap.org/?lat=34.159461&lon=-118.637394
@@ -57,7 +58,7 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 41 http://www.openstreetmap.org/?lat=34.166066&lon=-118.837823
 43 +43B +CA23_N http://www.openstreetmap.org/?lat=34.176168&lon=-118.860601
 44 http://www.openstreetmap.org/?lat=34.177362&lon=-118.876550
-45 +LynnRd http://www.openstreetmap.org/?lat=34.183481&lon=-118.891565
+45 http://www.openstreetmap.org/?lat=34.183481&lon=-118.891565
 46 http://www.openstreetmap.org/?lat=34.184355&lon=-118.911134
 47A http://www.openstreetmap.org/?lat=34.184427&lon=-118.925720
 47C http://www.openstreetmap.org/?lat=34.189769&lon=-118.939297
@@ -70,7 +71,7 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 56 http://www.openstreetmap.org/?lat=34.220390&lon=-119.085445
 57 http://www.openstreetmap.org/?lat=34.221743&lon=-119.101973
 59 http://www.openstreetmap.org/?lat=34.222058&lon=-119.126837
-60 +NRiceAve +RiceAve http://www.openstreetmap.org/?lat=34.222582&lon=-119.142341
+60 +RiceAve http://www.openstreetmap.org/?lat=34.222582&lon=-119.142341
 61 http://www.openstreetmap.org/?lat=34.225136&lon=-119.158751
 62A http://www.openstreetmap.org/?lat=34.231838&lon=-119.173234
 62B +CA1_Oxn http://www.openstreetmap.org/?lat=34.239360&lon=-119.181007
@@ -90,7 +91,7 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 +X864646 http://www.openstreetmap.org/?lat=34.322386&lon=-119.375596
 +x28 http://www.openstreetmap.org/?lat=34.329915&lon=-119.397826
 +X565872 http://www.openstreetmap.org/?lat=34.341097&lon=-119.411216
-78 +CA1_Sea http://www.openstreetmap.org/?lat=34.343237&lon=-119.416693
+78 http://www.openstreetmap.org/?lat=34.343237&lon=-119.416693
 +x49999 http://www.openstreetmap.org/?lat=34.373509&lon=-119.458895
 83 http://www.openstreetmap.org/?lat=34.376259&lon=-119.477542
 84 http://www.openstreetmap.org/?lat=34.383764&lon=-119.484595
@@ -105,10 +106,10 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 92 http://www.openstreetmap.org/?lat=34.421616&lon=-119.614200
 93 http://www.openstreetmap.org/?lat=34.422426&lon=-119.631527
 94A +OliMillRd http://www.openstreetmap.org/?lat=34.420823&lon=-119.639971
-94B +CabBlvd http://www.openstreetmap.org/?lat=34.422558&lon=-119.654685
+94B http://www.openstreetmap.org/?lat=34.422558&lon=-119.654685
 95 http://www.openstreetmap.org/?lat=34.421390&lon=-119.665779
-96A +CA144 http://www.openstreetmap.org/?lat=34.420350&lon=-119.677184
-96B +GarSt http://www.openstreetmap.org/?lat=34.418261&lon=-119.689699
+96A http://www.openstreetmap.org/?lat=34.420350&lon=-119.677184
+96B http://www.openstreetmap.org/?lat=34.418261&lon=-119.689699
 97 http://www.openstreetmap.org/?lat=34.412212&lon=-119.699161
 98A http://www.openstreetmap.org/?lat=34.416385&lon=-119.707294
 98B http://www.openstreetmap.org/?lat=34.421811&lon=-119.715212
@@ -120,10 +121,10 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 102 http://www.openstreetmap.org/?lat=34.440902&lon=-119.769264
 103 http://www.openstreetmap.org/?lat=34.442327&lon=-119.789305
 104A http://www.openstreetmap.org/?lat=34.441920&lon=-119.808414
-104B +CA217 http://www.openstreetmap.org/?lat=34.441623&lon=-119.812147
-105 +FaiAve http://www.openstreetmap.org/?lat=34.439535&lon=-119.832376
+104B http://www.openstreetmap.org/?lat=34.441623&lon=-119.812147
+105 http://www.openstreetmap.org/?lat=34.439535&lon=-119.832376
 107 http://www.openstreetmap.org/?lat=34.437668&lon=-119.852916
-108 +StorkRd http://www.openstreetmap.org/?lat=34.434478&lon=-119.870817
+108 http://www.openstreetmap.org/?lat=34.434478&lon=-119.870817
 110 http://www.openstreetmap.org/?lat=34.432332&lon=-119.905907
 113 http://www.openstreetmap.org/?lat=34.444982&lon=-119.955989
 116 http://www.openstreetmap.org/?lat=34.460698&lon=-120.002375
@@ -145,20 +146,20 @@ JonParkRd http://www.openstreetmap.org/?lat=34.652820&lon=-120.182790
 AliCanRd http://www.openstreetmap.org/?lat=34.731403&lon=-120.236049
 154 http://www.openstreetmap.org/?lat=34.742573&lon=-120.270832
 PalRd http://www.openstreetmap.org/?lat=34.791691&lon=-120.332930
-165 +EClaAve http://www.openstreetmap.org/?lat=34.865414&lon=-120.396187
+165 http://www.openstreetmap.org/?lat=34.865414&lon=-120.396187
 166 http://www.openstreetmap.org/?lat=34.879977&lon=-120.408810
-167 +US101BusSMa http://www.openstreetmap.org/?lat=34.891185&lon=-120.417677
-168 +EBetRd http://www.openstreetmap.org/?lat=34.923603&lon=-120.417903
+167 http://www.openstreetmap.org/?lat=34.891185&lon=-120.417677
+168 http://www.openstreetmap.org/?lat=34.923603&lon=-120.417903
 170 http://www.openstreetmap.org/?lat=34.938345&lon=-120.417774
-171 +CA166_W http://www.openstreetmap.org/?lat=34.952997&lon=-120.417280
+171 http://www.openstreetmap.org/?lat=34.952997&lon=-120.417280
 172 http://www.openstreetmap.org/?lat=34.967658&lon=-120.422977
 173 +US101Bus/135 http://www.openstreetmap.org/?lat=34.981302&lon=-120.431426
-175 +CA166_E http://www.openstreetmap.org/?lat=34.996262&lon=-120.434725
+175 http://www.openstreetmap.org/?lat=34.996262&lon=-120.434725
 179 http://www.openstreetmap.org/?lat=35.036866&lon=-120.484604
 180 http://www.openstreetmap.org/?lat=35.055237&lon=-120.501132
 182 http://www.openstreetmap.org/?lat=35.071888&lon=-120.516286
 186 http://www.openstreetmap.org/?lat=35.116188&lon=-120.573310
-187A +US101Bus/227 http://www.openstreetmap.org/?lat=35.121370&lon=-120.583732
+187A http://www.openstreetmap.org/?lat=35.121370&lon=-120.583732
 187B http://www.openstreetmap.org/?lat=35.124279&lon=-120.593303
 188 http://www.openstreetmap.org/?lat=35.130119&lon=-120.606638
 189 http://www.openstreetmap.org/?lat=35.136155&lon=-120.621928
@@ -171,12 +172,12 @@ PalRd http://www.openstreetmap.org/?lat=34.791691&lon=-120.332930
 198 http://www.openstreetmap.org/?lat=35.224079&lon=-120.691515
 200A http://www.openstreetmap.org/?lat=35.244664&lon=-120.682153
 200B http://www.openstreetmap.org/?lat=35.256860&lon=-120.674842
-201 +CA227_N http://www.openstreetmap.org/?lat=35.266102&lon=-120.673464
-202A +MarsSt http://www.openstreetmap.org/?lat=35.274415&lon=-120.671356
+201 http://www.openstreetmap.org/?lat=35.266102&lon=-120.673464
+202A http://www.openstreetmap.org/?lat=35.274415&lon=-120.671356
 202B +BroadSt http://www.openstreetmap.org/?lat=35.283327&lon=-120.667552
 203A +CA1_SLO +OsosSt +CA1_SLu http://www.openstreetmap.org/?lat=35.286698&lon=-120.663528
 203B http://www.openstreetmap.org/?lat=35.287990&lon=-120.661860
-203C +CalBlvd_SLO http://www.openstreetmap.org/?lat=35.289903&lon=-120.659355
+203C http://www.openstreetmap.org/?lat=35.289903&lon=-120.659355
 203D http://www.openstreetmap.org/?lat=35.291878&lon=-120.653170
 204 http://www.openstreetmap.org/?lat=35.291822&lon=-120.649608
 +x33 http://www.openstreetmap.org/?lat=35.298735&lon=-120.626793
@@ -188,7 +189,7 @@ TasCrkRd http://www.openstreetmap.org/?lat=35.370628&lon=-120.641106
 216B http://www.openstreetmap.org/?lat=35.452586&lon=-120.640901
 218A http://www.openstreetmap.org/?lat=35.465922&lon=-120.651293
 218B http://www.openstreetmap.org/?lat=35.476503&lon=-120.658363
-219 +CA41 http://www.openstreetmap.org/?lat=35.485283&lon=-120.665095
+219 http://www.openstreetmap.org/?lat=35.485283&lon=-120.665095
 220A http://www.openstreetmap.org/?lat=35.488608&lon=-120.670872
 220B http://www.openstreetmap.org/?lat=35.497028&lon=-120.682991
 222 http://www.openstreetmap.org/?lat=35.513199&lon=-120.699416
@@ -200,7 +201,7 @@ TasCrkRd http://www.openstreetmap.org/?lat=35.370628&lon=-120.641106
 229 http://www.openstreetmap.org/?lat=35.611395&lon=-120.691144
 230 http://www.openstreetmap.org/?lat=35.617548&lon=-120.687063
 231A http://www.openstreetmap.org/?lat=35.632082&lon=-120.686499
-231B +CA46_E http://www.openstreetmap.org/?lat=35.642552&lon=-120.685093
+231B http://www.openstreetmap.org/?lat=35.642552&lon=-120.685093
 232 http://www.openstreetmap.org/?lat=35.653518&lon=-120.693870
 239A http://www.openstreetmap.org/?lat=35.740678&lon=-120.699824
 239B http://www.openstreetmap.org/?lat=35.747879&lon=-120.700436
@@ -217,11 +218,11 @@ TasCrkRd http://www.openstreetmap.org/?lat=35.370628&lon=-120.641106
 260 http://www.openstreetmap.org/?lat=35.975493&lon=-120.899461
 263 http://www.openstreetmap.org/?lat=36.012962&lon=-120.922238
 271 http://www.openstreetmap.org/?lat=36.093838&lon=-121.021561
-273 +CA198 http://www.openstreetmap.org/?lat=36.122026&lon=-121.023400
+273 http://www.openstreetmap.org/?lat=36.122026&lon=-121.023400
 278 http://www.openstreetmap.org/?lat=36.187559&lon=-121.072335
 281 http://www.openstreetmap.org/?lat=36.201321&lon=-121.112595
 282A http://www.openstreetmap.org/?lat=36.203330&lon=-121.129552
-282B +US101BusKin_N http://www.openstreetmap.org/?lat=36.204265&lon=-121.137636
+282B http://www.openstreetmap.org/?lat=36.204265&lon=-121.137636
 283 +CRG14 http://www.openstreetmap.org/?lat=36.197559&lon=-121.147898
 CenAve_Kin http://www.openstreetmap.org/?lat=36.233811&lon=-121.174393
 HobAve http://www.openstreetmap.org/?lat=36.276092&lon=-121.185465
@@ -230,7 +231,7 @@ HobAve http://www.openstreetmap.org/?lat=36.276092&lon=-121.185465
 294B http://www.openstreetmap.org/?lat=36.329371&lon=-121.243862
 295 http://www.openstreetmap.org/?lat=36.339388&lon=-121.254913
 301 http://www.openstreetmap.org/?lat=36.403405&lon=-121.316603
-302 +US101Bus/146 http://www.openstreetmap.org/?lat=36.419431&lon=-121.323679
+302 http://www.openstreetmap.org/?lat=36.419431&lon=-121.323679
 303 http://www.openstreetmap.org/?lat=36.431642&lon=-121.337322
 305 http://www.openstreetmap.org/?lat=36.448999&lon=-121.362888
 307 http://www.openstreetmap.org/?lat=36.464945&lon=-121.387719
@@ -243,7 +244,7 @@ US101BusSal_S http://www.openstreetmap.org/?lat=36.625146&lon=-121.583805
 326B +SSanRd http://www.openstreetmap.org/?lat=36.666552&lon=-121.628120
 327 +CA68 http://www.openstreetmap.org/?lat=36.670863&lon=-121.639144
 328 http://www.openstreetmap.org/?lat=36.677717&lon=-121.641333
-329 +US101Bus/183 http://www.openstreetmap.org/?lat=36.687100&lon=-121.652813
+329 http://www.openstreetmap.org/?lat=36.687100&lon=-121.652813
 330 http://www.openstreetmap.org/?lat=36.697802&lon=-121.664497
 331 http://www.openstreetmap.org/?lat=36.722026&lon=-121.659835
 333 http://www.openstreetmap.org/?lat=36.743729&lon=-121.660500
@@ -252,7 +253,7 @@ US101BusSal_S http://www.openstreetmap.org/?lat=36.625146&lon=-121.583805
 339 http://www.openstreetmap.org/?lat=36.818415&lon=-121.632718
 DunRd http://www.openstreetmap.org/?lat=36.845216&lon=-121.634649
 342 http://www.openstreetmap.org/?lat=36.857948&lon=-121.627954
-345 +CA156_E http://www.openstreetmap.org/?lat=36.861927&lon=-121.579568
+345 http://www.openstreetmap.org/?lat=36.861927&lon=-121.579568
 347 +CA129 http://www.openstreetmap.org/?lat=36.882539&lon=-121.561548
 349 http://www.openstreetmap.org/?lat=36.904680&lon=-121.556667
 +x60 http://www.openstreetmap.org/?lat=36.928282&lon=-121.547370
@@ -273,7 +274,7 @@ DunRd http://www.openstreetmap.org/?lat=36.845216&lon=-121.634649
 380 http://www.openstreetmap.org/?lat=37.281791&lon=-121.808359
 381 http://www.openstreetmap.org/?lat=37.294677&lon=-121.810028
 382 http://www.openstreetmap.org/?lat=37.303126&lon=-121.816707
-383 +TulRd http://www.openstreetmap.org/?lat=37.318435&lon=-121.831534
+383 http://www.openstreetmap.org/?lat=37.318435&lon=-121.831534
 385A http://www.openstreetmap.org/?lat=37.335864&lon=-121.848388
 385B +I-280(0) +I-280/680 http://www.openstreetmap.org/?lat=37.339626&lon=-121.852020
 386A http://www.openstreetmap.org/?lat=37.349887&lon=-121.861660
@@ -281,24 +282,24 @@ DunRd http://www.openstreetmap.org/?lat=36.845216&lon=-121.634649
 388A http://www.openstreetmap.org/?lat=37.363029&lon=-121.891487
 388B +I-880 http://www.openstreetmap.org/?lat=37.364176&lon=-121.901840
 389A http://www.openstreetmap.org/?lat=37.368614&lon=-121.908717
-389B +EBroRd http://www.openstreetmap.org/?lat=37.372177&lon=-121.919393
+389B http://www.openstreetmap.org/?lat=37.372177&lon=-121.919393
 390 +CA87 http://www.openstreetmap.org/?lat=37.373756&lon=-121.927718
 391 +CRG6 http://www.openstreetmap.org/?lat=37.376730&lon=-121.941623
-392 +CRG4 http://www.openstreetmap.org/?lat=37.381979&lon=-121.963938
+392 http://www.openstreetmap.org/?lat=37.381979&lon=-121.963938
 393 http://www.openstreetmap.org/?lat=37.385691&lon=-121.976845
 394 http://www.openstreetmap.org/?lat=37.391193&lon=-121.996007
 395 http://www.openstreetmap.org/?lat=37.395660&lon=-122.012808
-396A +NMatAve http://www.openstreetmap.org/?lat=37.398938&lon=-122.027770
+396A http://www.openstreetmap.org/?lat=37.398938&lon=-122.027770
 396B http://www.openstreetmap.org/?lat=37.400667&lon=-122.035645
 397 http://www.openstreetmap.org/?lat=37.404111&lon=-122.051357
 398A http://www.openstreetmap.org/?lat=37.407622&lon=-122.066329
-398B +CA85_N http://www.openstreetmap.org/?lat=37.408901&lon=-122.070572
+398B http://www.openstreetmap.org/?lat=37.408901&lon=-122.070572
 399A http://www.openstreetmap.org/?lat=37.411947&lon=-122.078082
 399B http://www.openstreetmap.org/?lat=37.414269&lon=-122.083136
 400A http://www.openstreetmap.org/?lat=37.420997&lon=-122.092486
 400B http://www.openstreetmap.org/?lat=37.428311&lon=-122.101450
 402 +EmbRd http://www.openstreetmap.org/?lat=37.447866&lon=-122.121947
-403 +CA109 http://www.openstreetmap.org/?lat=37.460438&lon=-122.140879
+403 http://www.openstreetmap.org/?lat=37.460438&lon=-122.140879
 404 http://www.openstreetmap.org/?lat=37.468859&lon=-122.155245
 406 +CA84_E http://www.openstreetmap.org/?lat=37.483338&lon=-122.180650
 408 http://www.openstreetmap.org/?lat=37.488935&lon=-122.212858
@@ -309,11 +310,11 @@ DunRd http://www.openstreetmap.org/?lat=36.845216&lon=-121.634649
 414B +CA92 http://www.openstreetmap.org/?lat=37.553117&lon=-122.295878
 415 http://www.openstreetmap.org/?lat=37.562588&lon=-122.305035
 416 http://www.openstreetmap.org/?lat=37.570854&lon=-122.313988
-417A +EPopAve http://www.openstreetmap.org/?lat=37.578970&lon=-122.322829
+417A http://www.openstreetmap.org/?lat=37.578970&lon=-122.322829
 417B http://www.openstreetmap.org/?lat=37.584335&lon=-122.328612
 419A http://www.openstreetmap.org/?lat=37.587175&lon=-122.351722
 419B +BroWay_Bur http://www.openstreetmap.org/?lat=37.589980&lon=-122.361131
-420 +EMilAve +MilAve http://www.openstreetmap.org/?lat=37.602570&lon=-122.380336
+420 http://www.openstreetmap.org/?lat=37.602570&lon=-122.380336
 422 +SanFraAir http://www.openstreetmap.org/?lat=37.613459&lon=-122.396509
 423A +ESanBruAve +SanBruAve http://www.openstreetmap.org/?lat=37.631307&lon=-122.402721
 423B +I-380 http://www.openstreetmap.org/?lat=37.636015&lon=-122.403751
@@ -334,10 +335,10 @@ DunRd http://www.openstreetmap.org/?lat=36.845216&lon=-121.634649
 433B +I-80 http://www.openstreetmap.org/?lat=37.768611&lon=-122.405934
 433C http://www.openstreetmap.org/?lat=37.769714&lon=-122.408069
 434 +VanNessAve_S +OctBlvd http://www.openstreetmap.org/?lat=37.769965&lon=-122.418841
-MarkSt http://www.openstreetmap.org/?lat=37.775158&lon=-122.419276
-GeaSt +OfaSt http://www.openstreetmap.org/?lat=37.785215&lon=-122.421287
+MarSt +MarkSt http://www.openstreetmap.org/?lat=37.775158&lon=-122.419276
+GeaSt http://www.openstreetmap.org/?lat=37.785215&lon=-122.421287
 Bro +BroWay_SFr http://www.openstreetmap.org/?lat=37.795716&lon=-122.423417
-VanNessAve_N +FraSt http://www.openstreetmap.org/?lat=37.801291&lon=-122.424548
+VanNessAve_N http://www.openstreetmap.org/?lat=37.801291&lon=-122.424548
 DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 437 +MarBlvd http://www.openstreetmap.org/?lat=37.803333&lon=-122.451307
 438 +CA1_SFr http://www.openstreetmap.org/?lat=37.803304&lon=-122.470119
@@ -346,7 +347,7 @@ DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 442 +AleAve http://www.openstreetmap.org/?lat=37.835616&lon=-122.484695
 443 http://www.openstreetmap.org/?lat=37.852877&lon=-122.492473
 444 http://www.openstreetmap.org/?lat=37.860023&lon=-122.501458
-445A +DonSt http://www.openstreetmap.org/?lat=37.871576&lon=-122.507231
+445A http://www.openstreetmap.org/?lat=37.871576&lon=-122.507231
 445B +CA1_Sau http://www.openstreetmap.org/?lat=37.880192&lon=-122.516270
 446 http://www.openstreetmap.org/?lat=37.889084&lon=-122.516736
 447 +CA131 http://www.openstreetmap.org/?lat=37.902748&lon=-122.515739
@@ -354,11 +355,11 @@ DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 449A http://www.openstreetmap.org/?lat=37.929880&lon=-122.515695
 450A http://www.openstreetmap.org/?lat=37.938182&lon=-122.516576
 450B +SFraDraBlvd +FraDraBlvd http://www.openstreetmap.org/?lat=37.944667&lon=-122.514826
-451 +BelBlvd +I-580 http://www.openstreetmap.org/?lat=37.962648&lon=-122.510540
+451 +I-580 http://www.openstreetmap.org/?lat=37.962648&lon=-122.510540
 452 +2ndSt http://www.openstreetmap.org/?lat=37.972316&lon=-122.521575
 454A http://www.openstreetmap.org/?lat=37.988261&lon=-122.526955
 454B +NSanPedRd http://www.openstreetmap.org/?lat=37.994210&lon=-122.532186
-455 +FrePkwy http://www.openstreetmap.org/?lat=38.007072&lon=-122.541482
+455 http://www.openstreetmap.org/?lat=38.007072&lon=-122.541482
 456 +LucValRd http://www.openstreetmap.org/?lat=38.021223&lon=-122.539132
 457 http://www.openstreetmap.org/?lat=38.033545&lon=-122.537121
 458 http://www.openstreetmap.org/?lat=38.049265&lon=-122.531789
@@ -373,9 +374,9 @@ DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 472B +CA116_E http://www.openstreetmap.org/?lat=38.233263&lon=-122.617946
 474 http://www.openstreetmap.org/?lat=38.246834&lon=-122.627694
 476 http://www.openstreetmap.org/?lat=38.272069&lon=-122.669950
-479 +WRaiAve http://www.openstreetmap.org/?lat=38.303691&lon=-122.708252
+479 http://www.openstreetmap.org/?lat=38.303691&lon=-122.708252
 481A http://www.openstreetmap.org/?lat=38.321311&lon=-122.713594
-481B +CA116_W http://www.openstreetmap.org/?lat=38.331268&lon=-122.712789
+481B http://www.openstreetmap.org/?lat=38.331268&lon=-122.712789
 483 http://www.openstreetmap.org/?lat=38.348387&lon=-122.713047
 484A http://www.openstreetmap.org/?lat=38.363203&lon=-122.712758
 484B http://www.openstreetmap.org/?lat=38.371905&lon=-122.714308
@@ -392,7 +393,7 @@ DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 495A http://www.openstreetmap.org/?lat=38.506715&lon=-122.769883
 495B http://www.openstreetmap.org/?lat=38.511098&lon=-122.775382
 496 http://www.openstreetmap.org/?lat=38.525792&lon=-122.790064
-498 +WinRivRd http://www.openstreetmap.org/?lat=38.546953&lon=-122.808115
+498 http://www.openstreetmap.org/?lat=38.546953&lon=-122.808115
 499 http://www.openstreetmap.org/?lat=38.561795&lon=-122.823056
 502 http://www.openstreetmap.org/?lat=38.594812&lon=-122.852839
 503 http://www.openstreetmap.org/?lat=38.603301&lon=-122.867408
@@ -401,12 +402,12 @@ DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 507 http://www.openstreetmap.org/?lat=38.659543&lon=-122.874473
 509 http://www.openstreetmap.org/?lat=38.679915&lon=-122.880669
 510 http://www.openstreetmap.org/?lat=38.696957&lon=-122.890942
-512 +CA128_E http://www.openstreetmap.org/?lat=38.713576&lon=-122.919041
+512 http://www.openstreetmap.org/?lat=38.713576&lon=-122.919041
 517 http://www.openstreetmap.org/?lat=38.759036&lon=-122.975689
 518 http://www.openstreetmap.org/?lat=38.767611&lon=-122.994738
 519 http://www.openstreetmap.org/?lat=38.783461&lon=-123.009506
 520 http://www.openstreetmap.org/?lat=38.800596&lon=-123.013079
-522 +US101Bus/128 http://www.openstreetmap.org/?lat=38.828178&lon=-123.014297
+522 http://www.openstreetmap.org/?lat=38.828178&lon=-123.014297
 ComStaRd http://www.openstreetmap.org/?lat=38.887392&lon=-123.053527
 +X482490 http://www.openstreetmap.org/?lat=38.926965&lon=-123.057003
 EasRd http://www.openstreetmap.org/?lat=38.952801&lon=-123.098416
@@ -416,9 +417,9 @@ CA175 http://www.openstreetmap.org/?lat=38.971246&lon=-123.116655
 545 http://www.openstreetmap.org/?lat=39.097345&lon=-123.189611
 546 http://www.openstreetmap.org/?lat=39.109217&lon=-123.195148
 548A http://www.openstreetmap.org/?lat=39.135911&lon=-123.195663
-548B +EGobSt http://www.openstreetmap.org/?lat=39.144831&lon=-123.196328
-549 +EPerSt http://www.openstreetmap.org/?lat=39.151574&lon=-123.196853
-551 +US101BusUki http://www.openstreetmap.org/?lat=39.171124&lon=-123.211439
+548B http://www.openstreetmap.org/?lat=39.144831&lon=-123.196328
+549 http://www.openstreetmap.org/?lat=39.151574&lon=-123.196853
+551 http://www.openstreetmap.org/?lat=39.171124&lon=-123.211439
 552 http://www.openstreetmap.org/?lat=39.191337&lon=-123.210543
 555A http://www.openstreetmap.org/?lat=39.234298&lon=-123.208258
 555B +CA20_E http://www.openstreetmap.org/?lat=39.239844&lon=-123.207443
@@ -428,7 +429,7 @@ OldUS101_S http://www.openstreetmap.org/?lat=39.293249&lon=-123.272395
 OldUS101_N http://www.openstreetmap.org/?lat=39.338870&lon=-123.312430
 +x5(CA20) http://www.openstreetmap.org/?lat=39.349546&lon=-123.322306
 +x4(CA20) http://www.openstreetmap.org/?lat=39.364222&lon=-123.315289
-568 +CA20_W http://www.openstreetmap.org/?lat=39.375851&lon=-123.325551
+568 http://www.openstreetmap.org/?lat=39.375851&lon=-123.325551
 +X977155 http://www.openstreetmap.org/?lat=39.397801&lon=-123.341779
 +X782250 http://www.openstreetmap.org/?lat=39.418243&lon=-123.338850
 573 http://www.openstreetmap.org/?lat=39.428553&lon=-123.355350
@@ -442,7 +443,7 @@ FisRd http://www.openstreetmap.org/?lat=39.707880&lon=-123.489493
 +x97 http://www.openstreetmap.org/?lat=39.753723&lon=-123.536582
 HarRd http://www.openstreetmap.org/?lat=39.774444&lon=-123.545906
 +x98 http://www.openstreetmap.org/?lat=39.804015&lon=-123.544006
-CR324 http://www.openstreetmap.org/?lat=39.827358&lon=-123.572159
+BellSprRd http://www.openstreetmap.org/?lat=39.827358&lon=-123.572159
 609 http://www.openstreetmap.org/?lat=39.834645&lon=-123.631549
 +x103 http://www.openstreetmap.org/?lat=39.825832&lon=-123.669963
 614 +CA271_SLeg +CA271_Leg http://www.openstreetmap.org/?lat=39.848534&lon=-123.707664
@@ -462,7 +463,7 @@ RicGroSP http://www.openstreetmap.org/?lat=40.022939&lon=-123.793951
 +x119 http://www.openstreetmap.org/?lat=40.034877&lon=-123.791842
 +X654956 http://www.openstreetmap.org/?lat=40.032938&lon=-123.776908
 +x123 http://www.openstreetmap.org/?lat=40.052895&lon=-123.792958
-636 +BenDr http://www.openstreetmap.org/?lat=40.065280&lon=-123.786043
+636 http://www.openstreetmap.org/?lat=40.065280&lon=-123.786043
 639A http://www.openstreetmap.org/?lat=40.098690&lon=-123.796762
 639B http://www.openstreetmap.org/?lat=40.104004&lon=-123.795673
 642 http://www.openstreetmap.org/?lat=40.141558&lon=-123.808011
@@ -478,7 +479,7 @@ RicGroSP http://www.openstreetmap.org/?lat=40.022939&lon=-123.793951
 +x140 http://www.openstreetmap.org/?lat=40.302992&lon=-123.893080
 661 http://www.openstreetmap.org/?lat=40.321543&lon=-123.921211
 +x143 http://www.openstreetmap.org/?lat=40.339082&lon=-123.934085
-663 +ToCA254 http://www.openstreetmap.org/?lat=40.355134&lon=-123.925395
+663 http://www.openstreetmap.org/?lat=40.355134&lon=-123.925395
 +x144 http://www.openstreetmap.org/?lat=40.360948&lon=-123.919902
 667A +CA254_Eng http://www.openstreetmap.org/?lat=40.395776&lon=-123.938645
 667B http://www.openstreetmap.org/?lat=40.397549&lon=-123.947904
@@ -492,7 +493,7 @@ MainSt_Sco http://www.openstreetmap.org/?lat=40.468184&lon=-124.095523
 680 http://www.openstreetmap.org/?lat=40.499181&lon=-124.099057
 681 http://www.openstreetmap.org/?lat=40.505589&lon=-124.109502
 MetRd http://www.openstreetmap.org/?lat=40.524279&lon=-124.149531
-685 +CA36 http://www.openstreetmap.org/?lat=40.548615&lon=-124.145331
+685 http://www.openstreetmap.org/?lat=40.548615&lon=-124.145331
 687 http://www.openstreetmap.org/?lat=40.574864&lon=-124.149043
 688 http://www.openstreetmap.org/?lat=40.587983&lon=-124.155357
 689 http://www.openstreetmap.org/?lat=40.599625&lon=-124.168134
@@ -528,7 +529,7 @@ BayCutRd http://www.openstreetmap.org/?lat=40.835007&lon=-124.081993
 725 http://www.openstreetmap.org/?lat=41.013507&lon=-124.107951
 726A http://www.openstreetmap.org/?lat=41.032201&lon=-124.110141
 726B http://www.openstreetmap.org/?lat=41.035778&lon=-124.112302
-728 +MainSt_Tri http://www.openstreetmap.org/?lat=41.062127&lon=-124.139253
+728 http://www.openstreetmap.org/?lat=41.062127&lon=-124.139253
 731 http://www.openstreetmap.org/?lat=41.098612&lon=-124.153362
 734 http://www.openstreetmap.org/?lat=41.136125&lon=-124.146645
 BigLagRd http://www.openstreetmap.org/?lat=41.155890&lon=-124.126925
@@ -554,7 +555,7 @@ CalBarRd http://www.openstreetmap.org/?lat=41.381502&lon=-123.995004
 765 +NBDScePkwy_N +NewDruPkwy_N http://www.openstreetmap.org/?lat=41.466765&lon=-124.039014
 +x179 http://www.openstreetmap.org/?lat=41.486206&lon=-124.050922
 768 http://www.openstreetmap.org/?lat=41.511437&lon=-124.028606
-769 +CA169 http://www.openstreetmap.org/?lat=41.523150&lon=-124.034153
+769 http://www.openstreetmap.org/?lat=41.523150&lon=-124.034153
 CHD7 http://www.openstreetmap.org/?lat=41.554120&lon=-124.055220
 WilCrkRd http://www.openstreetmap.org/?lat=41.603261&lon=-124.100060
 +x181 http://www.openstreetmap.org/?lat=41.633920&lon=-124.115725
@@ -563,7 +564,7 @@ HamRd http://www.openstreetmap.org/?lat=41.723868&lon=-124.139532
 HumRd http://www.openstreetmap.org/?lat=41.736159&lon=-124.154166
 CHD2_S http://www.openstreetmap.org/?lat=41.752213&lon=-124.185537
 FroSt http://www.openstreetmap.org/?lat=41.752977&lon=-124.192618
-9thSt_Cre http://www.openstreetmap.org/?lat=41.758356&lon=-124.197671
+9thSt http://www.openstreetmap.org/?lat=41.758356&lon=-124.197671
 791 http://www.openstreetmap.org/?lat=41.772736&lon=-124.187372
 794 +US199 http://www.openstreetmap.org/?lat=41.801879&lon=-124.149252
 CA197 http://www.openstreetmap.org/?lat=41.881524&lon=-124.136732

--- a/hwy_data/QC/canqca/qc.a025.wpt
+++ b/hwy_data/QC/canqca/qc.a025.wpt
@@ -26,3 +26,4 @@ A-20 http://www.openstreetmap.org/?lat=45.577575&lon=-73.471338
 44 http://www.openstreetmap.org/?lat=45.861205&lon=-73.649769
 +X12 http://www.openstreetmap.org/?lat=45.876619&lon=-73.649861
 46 http://www.openstreetmap.org/?lat=45.884930&lon=-73.660498
+QC125/158_N http://www.openstreetmap.org/?lat=45.904144&lon=-73.658909


### PR DESCRIPTION
A-25 extended north from exit 46 to northern QC 125/158 intersection. Missing exit 1E added to US 101 in downtown Los Angeles, and rest of route scrubbed to remove unused alternate waypoint labels.

Update entry for A-25 extension to be added later, directly to Updates table.