### PR TITLE
usaca CA 260 truncation

### DIFF
--- a/hwy_data/CA/usaca/ca.ca260.wpt
+++ b/hwy_data/CA/usaca/ca.ca260.wpt
@@ -1,5 +1,3 @@
-CA61_S http://www.openstreetmap.org/?lat=37.771440&lon=-122.276883
-LinAve http://www.openstreetmap.org/?lat=37.775184&lon=-122.276716
 AtlAve http://www.openstreetmap.org/?lat=37.779661&lon=-122.276523
 ConWay http://www.openstreetmap.org/?lat=37.784795&lon=-122.276802
 7thSt http://www.openstreetmap.org/?lat=37.798340&lon=-122.271239


### PR DESCRIPTION
This is part of an oddball situation in Oakland I'll discuss on the forum. It's clear enough CA 260 should be truncated if it remains in the HB, though what to do with concurrent route CA 61 (including the mileage removed from CA 260, and perhaps absorbing the rest of CA 260) is less clear.