### PR TITLE
BC/CA/NM/QC/YT unused alt label removals

### DIFF
--- a/hwy_data/BC/cantch/bc.tchyel.wpt
+++ b/hwy_data/BC/cantch/bc.tchyel.wpt
@@ -1,4 +1,4 @@
-SkiFry +Fry http://www.openstreetmap.org/?lat=54.297657&lon=-130.353899
+SkiFry http://www.openstreetmap.org/?lat=54.297657&lon=-130.353899
 AMHSFry http://www.openstreetmap.org/?lat=54.293121&lon=-130.352188
 McBSt http://www.openstreetmap.org/?lat=54.315647&lon=-130.322056
 11thAve http://www.openstreetmap.org/?lat=54.309375&lon=-130.308977

--- a/hwy_data/CA/usaca/ca.ca018.wpt
+++ b/hwy_data/CA/usaca/ca.ca018.wpt
@@ -36,8 +36,8 @@ DivDr http://www.openstreetmap.org/?lat=34.260470&lon=-116.866154
 StaCut http://www.openstreetmap.org/?lat=34.256728&lon=-116.883013
 FoxFarmRd http://www.openstreetmap.org/?lat=34.248733&lon=-116.883003
 SumBlvd http://www.openstreetmap.org/?lat=34.243355&lon=-116.888394
-PineKnotAve +CA18Bus_N http://www.openstreetmap.org/?lat=34.243679&lon=-116.911461
-VilDr +CA18Bus_S http://www.openstreetmap.org/?lat=34.241282&lon=-116.917089
+PineKnotAve http://www.openstreetmap.org/?lat=34.243679&lon=-116.911461
+VilDr http://www.openstreetmap.org/?lat=34.241282&lon=-116.917089
 BlueJayRd http://www.openstreetmap.org/?lat=34.238546&lon=-116.946834
 CA38 http://www.openstreetmap.org/?lat=34.242059&lon=-116.978087
 +y26 http://www.openstreetmap.org/?lat=34.251075&lon=-117.017870

--- a/hwy_data/CA/usaca/ca.ca099.wpt
+++ b/hwy_data/CA/usaca/ca.ca099.wpt
@@ -116,7 +116,7 @@ I-5(221) http://www.openstreetmap.org/?lat=35.010213&lon=-118.952826
 179 http://www.openstreetmap.org/?lat=37.225544&lon=-120.374799
 185 http://www.openstreetmap.org/?lat=37.274821&lon=-120.437526
 186A http://www.openstreetmap.org/?lat=37.288501&lon=-120.456607
-186B +186C http://www.openstreetmap.org/?lat=37.294851&lon=-120.468103
+186B http://www.openstreetmap.org/?lat=37.294851&lon=-120.468103
 187A http://www.openstreetmap.org/?lat=37.295171&lon=-120.477839
 187B http://www.openstreetmap.org/?lat=37.296537&lon=-120.482527
 188 http://www.openstreetmap.org/?lat=37.301952&lon=-120.497317

--- a/hwy_data/NM/usaib/nm.i010bllor.wpt
+++ b/hwy_data/NM/usaib/nm.i010bllor.wpt
@@ -1,4 +1,4 @@
 I-10_W http://www.openstreetmap.org/?lat=32.352739&lon=-108.740659
-US70_W +US70 +NM90 http://www.openstreetmap.org/?lat=32.350492&lon=-108.709829
+US70_W +US70 http://www.openstreetmap.org/?lat=32.350492&lon=-108.709829
 NM494 http://www.openstreetmap.org/?lat=32.350247&lon=-108.708676
 I-10_E http://www.openstreetmap.org/?lat=32.339288&lon=-108.679161

--- a/hwy_data/NM/usaib/nm.i025blrat.wpt
+++ b/hwy_data/NM/usaib/nm.i025blrat.wpt
@@ -1,5 +1,5 @@
 I-25_S http://www.openstreetmap.org/?lat=36.864790&lon=-104.438910
 NM555 http://www.openstreetmap.org/?lat=36.867742&lon=-104.440069
-US64_E +ClaRd +US87_S http://www.openstreetmap.org/?lat=36.885010&lon=-104.440155
+US64_E +US87_S http://www.openstreetmap.org/?lat=36.885010&lon=-104.440155
 SugAve http://www.openstreetmap.org/?lat=36.905186&lon=-104.438975
 I-25_N http://www.openstreetmap.org/?lat=36.917921&lon=-104.446163

--- a/hwy_data/NM/usaib/nm.i040blgal.wpt
+++ b/hwy_data/NM/usaib/nm.i040blgal.wpt
@@ -3,6 +3,6 @@ NizBlvd http://www.openstreetmap.org/?lat=35.509837&lon=-108.807178
 GalMunApt http://www.openstreetmap.org/?lat=35.516194&lon=-108.780355
 NM602 http://www.openstreetmap.org/?lat=35.523111&lon=-108.757954
 NM610 +2ndSt http://www.openstreetmap.org/?lat=35.527896&lon=-108.743577
-NM609 +FordDr http://www.openstreetmap.org/?lat=35.530096&lon=-108.727140
+NM609 http://www.openstreetmap.org/?lat=35.530096&lon=-108.727140
 NM564 http://www.openstreetmap.org/?lat=35.529432&lon=-108.709116
 I-40_E http://www.openstreetmap.org/?lat=35.530794&lon=-108.671565

--- a/hwy_data/NM/usaib/nm.i040blgra.wpt
+++ b/hwy_data/NM/usaib/nm.i040blgra.wpt
@@ -3,5 +3,5 @@ NM122_W http://www.openstreetmap.org/?lat=35.183187&lon=-107.896842
 AspSt http://www.openstreetmap.org/?lat=35.164288&lon=-107.887378
 NM53 http://www.openstreetmap.org/?lat=35.157460&lon=-107.871537
 NM547 http://www.openstreetmap.org/?lat=35.150621&lon=-107.849994
-NM117 +NM117_E http://www.openstreetmap.org/?lat=35.139950&lon=-107.828965
+NM117 http://www.openstreetmap.org/?lat=35.139950&lon=-107.828965
 I-40_E http://www.openstreetmap.org/?lat=35.123945&lon=-107.829695

--- a/hwy_data/NM/usaib/nm.i040bltuc.wpt
+++ b/hwy_data/NM/usaib/nm.i040bltuc.wpt
@@ -3,5 +3,5 @@ TucBlvd_W http://www.openstreetmap.org/?lat=35.156547&lon=-103.776169
 CamCor http://www.openstreetmap.org/?lat=35.170125&lon=-103.748059
 NM237 http://www.openstreetmap.org/?lat=35.171844&lon=-103.744154
 NM104 http://www.openstreetmap.org/?lat=35.171844&lon=-103.724928
-US54 +MtnRd http://www.openstreetmap.org/?lat=35.171914&lon=-103.702397
+US54 http://www.openstreetmap.org/?lat=35.171914&lon=-103.702397
 I-40_E http://www.openstreetmap.org/?lat=35.170651&lon=-103.674717

--- a/hwy_data/NM/usanm/nm.nm118.wpt
+++ b/hwy_data/NM/usanm/nm.nm118.wpt
@@ -6,8 +6,8 @@ CedBluRd http://www.openstreetmap.org/?lat=35.480133&lon=-108.912224
 CR32 http://www.openstreetmap.org/?lat=35.488105&lon=-108.892161
 DefDrawRd http://www.openstreetmap.org/?lat=35.492516&lon=-108.892660
 I-40(16) http://www.openstreetmap.org/?lat=35.505680&lon=-108.830781
-MenBlvd +NizBlvd http://www.openstreetmap.org/?lat=35.509811&lon=-108.807049
-FloSt +GalMunApt http://www.openstreetmap.org/?lat=35.517906&lon=-108.774594
+MenBlvd http://www.openstreetmap.org/?lat=35.509811&lon=-108.807049
+FloSt http://www.openstreetmap.org/?lat=35.517906&lon=-108.774594
 NM602 http://www.openstreetmap.org/?lat=35.523111&lon=-108.757954
 NM610 http://www.openstreetmap.org/?lat=35.527896&lon=-108.743577
 NM609 http://www.openstreetmap.org/?lat=35.530096&lon=-108.727140

--- a/hwy_data/NM/usanm/nm.nm161.wpt
+++ b/hwy_data/NM/usanm/nm.nm161.wpt
@@ -15,4 +15,4 @@ NM97 http://www.openstreetmap.org/?lat=35.798684&lon=-104.981130
 I-25(366) http://www.openstreetmap.org/?lat=35.807964&lon=-104.979129
 SanFeTrl http://www.openstreetmap.org/?lat=35.834293&lon=-104.997105
 +X397643 http://www.openstreetmap.org/?lat=35.892874&lon=-105.022473
-FtUniNM +End http://www.openstreetmap.org/?lat=35.904590&lon=-105.011058
+FtUniNM http://www.openstreetmap.org/?lat=35.904590&lon=-105.011058

--- a/hwy_data/NM/usanm/nm.nm181.wpt
+++ b/hwy_data/NM/usanm/nm.nm181.wpt
@@ -1,6 +1,6 @@
 I-25(79) http://www.openstreetmap.org/?lat=33.157098&lon=-107.253170
 I-25BL http://www.openstreetmap.org/?lat=33.153326&lon=-107.246947
-WarmSprBlvd +NM171 http://www.openstreetmap.org/?lat=33.172882&lon=-107.239480
+WarmSprBlvd http://www.openstreetmap.org/?lat=33.172882&lon=-107.239480
 NM195 http://www.openstreetmap.org/?lat=33.221067&lon=-107.254420
 I-25(83) http://www.openstreetmap.org/?lat=33.223323&lon=-107.256260
 AirRd http://www.openstreetmap.org/?lat=33.238499&lon=-107.265181

--- a/hwy_data/NM/usanm/nm.nm528.wpt
+++ b/hwy_data/NM/usanm/nm.nm528.wpt
@@ -1,4 +1,4 @@
-2ndSt +NM47 http://www.openstreetmap.org/?lat=35.188115&lon=-106.613935
+2ndSt http://www.openstreetmap.org/?lat=35.188115&lon=-106.613935
 NM448_S http://www.openstreetmap.org/?lat=35.203340&lon=-106.647205
 NM45 http://www.openstreetmap.org/?lat=35.211264&lon=-106.660037
 HighResBlvd http://www.openstreetmap.org/?lat=35.248484&lon=-106.652961

--- a/hwy_data/NM/usaus/nm.us070.wpt
+++ b/hwy_data/NM/usaus/nm.us070.wpt
@@ -5,7 +5,7 @@ CRA024 http://www.openstreetmap.org/?lat=32.490090&lon=-108.844954
 NM464 http://www.openstreetmap.org/?lat=32.397220&lon=-108.726518
 NM90 http://www.openstreetmap.org/?lat=32.380360&lon=-108.708172
 I-10BL_W http://www.openstreetmap.org/?lat=32.350492&lon=-108.709829
-NM494 +I-10BL_E http://www.openstreetmap.org/?lat=32.350247&lon=-108.708676
+NM494 http://www.openstreetmap.org/?lat=32.350247&lon=-108.708676
 I-10(24) http://www.openstreetmap.org/?lat=32.339288&lon=-108.679161
 I-10(29) http://www.openstreetmap.org/?lat=32.312053&lon=-108.607492
 I-10(34) http://www.openstreetmap.org/?lat=32.270079&lon=-108.536124
@@ -42,7 +42,7 @@ WSMR21 http://www.openstreetmap.org/?lat=32.477746&lon=-106.407266
 WSMR253 http://www.openstreetmap.org/?lat=32.535698&lon=-106.361668
 WSMR15 http://www.openstreetmap.org/?lat=32.615783&lon=-106.298883
 WSMR266 http://www.openstreetmap.org/?lat=32.639664&lon=-106.279979
-DunDr +DunesDr http://www.openstreetmap.org/?lat=32.778597&lon=-106.172379
+DunDr http://www.openstreetmap.org/?lat=32.778597&lon=-106.172379
 1stSt http://www.openstreetmap.org/?lat=32.831432&lon=-106.068192
 US54/70Bus_W http://www.openstreetmap.org/?lat=32.871460&lon=-105.969486
 US54_W http://www.openstreetmap.org/?lat=32.869378&lon=-105.968821
@@ -80,10 +80,10 @@ CRE034 http://www.openstreetmap.org/?lat=33.365625&lon=-104.949753
 MosRd http://www.openstreetmap.org/?lat=33.368779&lon=-104.840920
 CR1 http://www.openstreetmap.org/?lat=33.380328&lon=-104.752750
 TieGraBlvd http://www.openstreetmap.org/?lat=33.394069&lon=-104.690652
-US70Trk_W +US285/380 http://www.openstreetmap.org/?lat=33.394213&lon=-104.584984
+US70Trk_W http://www.openstreetmap.org/?lat=33.394213&lon=-104.584984
 US380 http://www.openstreetmap.org/?lat=33.394278&lon=-104.522754
 NM246 http://www.openstreetmap.org/?lat=33.452319&lon=-104.523196
-US70Trk_E +US285Trk/US70 http://www.openstreetmap.org/?lat=33.473838&lon=-104.520755
+US70Trk_E http://www.openstreetmap.org/?lat=33.473838&lon=-104.520755
 CapAve http://www.openstreetmap.org/?lat=33.503516&lon=-104.475174
 OldCloHwy http://www.openstreetmap.org/?lat=33.563193&lon=-104.386725
 CR1/52 http://www.openstreetmap.org/?lat=33.597758&lon=-104.329712

--- a/hwy_data/NM/usaus/nm.us084.wpt
+++ b/hwy_data/NM/usaus/nm.us084.wpt
@@ -39,7 +39,7 @@ NM30 http://www.openstreetmap.org/?lat=35.987990&lon=-106.080444
 NM369_W http://www.openstreetmap.org/?lat=35.988624&lon=-106.067204
 NM68 http://www.openstreetmap.org/?lat=35.988789&lon=-106.065724
 NM369_E http://www.openstreetmap.org/?lat=35.986836&lon=-106.058031
-NM106/399 +NM106 http://www.openstreetmap.org/?lat=35.976901&lon=-106.044805
+NM106/399 http://www.openstreetmap.org/?lat=35.976901&lon=-106.044805
 PueRd http://www.openstreetmap.org/?lat=35.962824&lon=-106.029385
 ShiSun http://www.openstreetmap.org/?lat=35.907232&lon=-106.017852
 NM503 http://www.openstreetmap.org/?lat=35.897377&lon=-106.021148

--- a/hwy_data/NM/usaus/nm.us285.wpt
+++ b/hwy_data/NM/usaus/nm.us285.wpt
@@ -91,7 +91,7 @@ NM502 http://www.openstreetmap.org/?lat=35.890465&lon=-106.022723
 NM503 http://www.openstreetmap.org/?lat=35.897377&lon=-106.021148
 ShiSun http://www.openstreetmap.org/?lat=35.907232&lon=-106.017852
 PueRd http://www.openstreetmap.org/?lat=35.962824&lon=-106.029385
-NM106/399 +NM106 http://www.openstreetmap.org/?lat=35.976901&lon=-106.044805
+NM106/399 http://www.openstreetmap.org/?lat=35.976901&lon=-106.044805
 NM369_E http://www.openstreetmap.org/?lat=35.986836&lon=-106.058031
 NM68 http://www.openstreetmap.org/?lat=35.988789&lon=-106.065724
 NM369_W http://www.openstreetmap.org/?lat=35.988624&lon=-106.067204

--- a/hwy_data/NM/usausb/nm.us064busfar.wpt
+++ b/hwy_data/NM/usausb/nm.us064busfar.wpt
@@ -1,4 +1,4 @@
 US64_W http://www.openstreetmap.org/?lat=36.731592&lon=-108.232627
-LakeSt +NM371 http://www.openstreetmap.org/?lat=36.728033&lon=-108.218271
+LakeSt http://www.openstreetmap.org/?lat=36.728033&lon=-108.218271
 ScoAve http://www.openstreetmap.org/?lat=36.728210&lon=-108.192308
 US64_E http://www.openstreetmap.org/?lat=36.719357&lon=-108.182652

--- a/hwy_data/QC/canqca/qc.a020.wpt
+++ b/hwy_data/QC/canqca/qc.a020.wpt
@@ -44,9 +44,9 @@ IleCla http://www.openstreetmap.org/?lat=45.400348&lon=-73.958266
 78E http://www.openstreetmap.org/?lat=45.484778&lon=-73.508706
 78O +3(BMV) http://www.openstreetmap.org/?lat=45.494255&lon=-73.513738
 79 http://www.openstreetmap.org/?lat=45.505008&lon=-73.518984
-81 +7(BMV) http://www.openstreetmap.org/?lat=45.521579&lon=-73.524156
-82 +8(BMV) http://www.openstreetmap.org/?lat=45.530764&lon=-73.521709
-85 +11(BMV) http://www.openstreetmap.org/?lat=45.550452&lon=-73.501968
+81 http://www.openstreetmap.org/?lat=45.521579&lon=-73.524156
+82 http://www.openstreetmap.org/?lat=45.530764&lon=-73.521709
+85 http://www.openstreetmap.org/?lat=45.550452&lon=-73.501968
 89 +15(BMV) http://www.openstreetmap.org/?lat=45.580136&lon=-73.474009
 90 http://www.openstreetmap.org/?lat=45.577575&lon=-73.471338
 91 http://www.openstreetmap.org/?lat=45.575029&lon=-73.459375

--- a/hwy_data/QC/canqca/qc.a020rim.wpt
+++ b/hwy_data/QC/canqca/qc.a020rim.wpt
@@ -6,5 +6,5 @@
 +X02 http://www.openstreetmap.org/?lat=48.445031&lon=-68.466368
 +X03 http://www.openstreetmap.org/?lat=48.481684&lon=-68.460703
 621 http://www.openstreetmap.org/?lat=48.493857&lon=-68.442078
-629 +630 http://www.openstreetmap.org/?lat=48.537096&lon=-68.361654
+629 http://www.openstreetmap.org/?lat=48.537096&lon=-68.361654
 QC132_MtJ +QC132MJo http://www.openstreetmap.org/?lat=48.593498&lon=-68.208103

--- a/hwy_data/QC/canqca/qc.a030.wpt
+++ b/hwy_data/QC/canqca/qc.a030.wpt
@@ -18,12 +18,12 @@
 55 http://www.openstreetmap.org/?lat=45.355342&lon=-73.519950
 58 http://www.openstreetmap.org/?lat=45.375001&lon=-73.497205
 +X200 http://www.openstreetmap.org/?lat=45.387782&lon=-73.471928
-62 +104 http://www.openstreetmap.org/?lat=45.403573&lon=-73.461242
+62 http://www.openstreetmap.org/?lat=45.403573&lon=-73.461242
 65 http://www.openstreetmap.org/?lat=45.423787&lon=-73.448388
 67A http://www.openstreetmap.org/?lat=45.434418&lon=-73.442187
 67 +109 http://www.openstreetmap.org/?lat=45.443964&lon=-73.428690
 69 http://www.openstreetmap.org/?lat=45.454660&lon=-73.413091
-73 +115 http://www.openstreetmap.org/?lat=45.479242&lon=-73.385067
+73 http://www.openstreetmap.org/?lat=45.479242&lon=-73.385067
 73A http://www.openstreetmap.org/?lat=45.486312&lon=-73.380625
 76A http://www.openstreetmap.org/?lat=45.501978&lon=-73.372900
 76 http://www.openstreetmap.org/?lat=45.510986&lon=-73.371871
@@ -48,4 +48,4 @@
 140 http://www.openstreetmap.org/?lat=46.030000&lon=-73.148561
 141 http://www.openstreetmap.org/?lat=46.030544&lon=-73.133347
 QC133 http://www.openstreetmap.org/?lat=46.026946&lon=-73.117747
-BlvdPol +BlvdPol_S http://www.openstreetmap.org/?lat=46.024591&lon=-73.100646
+BlvdPol http://www.openstreetmap.org/?lat=46.024591&lon=-73.100646

--- a/hwy_data/QC/canqca/qc.a050.wpt
+++ b/hwy_data/QC/canqca/qc.a050.wpt
@@ -31,7 +31,7 @@ BlvdAll http://www.openstreetmap.org/?lat=45.432224&lon=-75.728256
 233 http://www.openstreetmap.org/?lat=45.660187&lon=-74.659009
 239 http://www.openstreetmap.org/?lat=45.654488&lon=-74.582062
 252 http://www.openstreetmap.org/?lat=45.634326&lon=-74.423618
-254 +QC148 http://www.openstreetmap.org/?lat=45.629735&lon=-74.397011
+254 http://www.openstreetmap.org/?lat=45.629735&lon=-74.397011
 258 http://www.openstreetmap.org/?lat=45.623763&lon=-74.349289
 260 http://www.openstreetmap.org/?lat=45.634176&lon=-74.325900
 +X01345 http://www.openstreetmap.org/?lat=45.648398&lon=-74.234233

--- a/hwy_data/QC/canqca/qc.a410.wpt
+++ b/hwy_data/QC/canqca/qc.a410.wpt
@@ -2,7 +2,7 @@ A-10 http://www.openstreetmap.org/?lat=45.420564&lon=-71.972723
 2 http://www.openstreetmap.org/?lat=45.402970&lon=-71.960836
 4 http://www.openstreetmap.org/?lat=45.391443&lon=-71.957595
 6 +BlvdUni http://www.openstreetmap.org/?lat=45.376207&lon=-71.950643
-7 +QC216 http://www.openstreetmap.org/?lat=45.368218&lon=-71.934228
+7 http://www.openstreetmap.org/?lat=45.368218&lon=-71.934228
 7A http://www.openstreetmap.org/?lat=45.368387&lon=-71.920382
 10 http://www.openstreetmap.org/?lat=45.358927&lon=-71.894821
 13 http://www.openstreetmap.org/?lat=45.355180&lon=-71.861047

--- a/hwy_data/QC/canqca/qc.a530.wpt
+++ b/hwy_data/QC/canqca/qc.a530.wpt
@@ -1,5 +1,5 @@
-QC201_S +QC132/201 http://www.openstreetmap.org/?lat=45.230264&lon=-74.114799
+QC201_S http://www.openstreetmap.org/?lat=45.230264&lon=-74.114799
 RueEra http://www.openstreetmap.org/?lat=45.243258&lon=-74.106688
-5 +BlvdMgrLan http://www.openstreetmap.org/?lat=45.267094&lon=-74.079952
-9 +BlvdPieXII http://www.openstreetmap.org/?lat=45.287931&lon=-74.039311
+5 ttp://www.openstreetmap.org/?lat=45.267094&lon=-74.079952
+9 http://www.openstreetmap.org/?lat=45.287931&lon=-74.039311
 12 http://www.openstreetmap.org/?lat=45.295358&lon=-74.004292

--- a/hwy_data/YT/canyt/yt.yt004.wpt
+++ b/hwy_data/YT/canyt/yt.yt004.wpt
@@ -133,7 +133,7 @@ LapCanCamp http://www.openstreetmap.org/?lat=61.986850&lon=-132.607410
 +X419405 http://www.openstreetmap.org/?lat=62.145778&lon=-133.143997
 +x47 http://www.openstreetmap.org/?lat=62.167495&lon=-133.269997
 +x46 http://www.openstreetmap.org/?lat=62.162113&lon=-133.327932
-MitRd +YT15 http://www.openstreetmap.org/?lat=62.181128&lon=-133.415651
+MitRd http://www.openstreetmap.org/?lat=62.181128&lon=-133.415651
 +x45 http://www.openstreetmap.org/?lat=62.204706&lon=-133.522854
 +X788370 http://www.openstreetmap.org/?lat=62.198306&lon=-133.596754
 +X851981 http://www.openstreetmap.org/?lat=62.200868&lon=-133.621902

--- a/hwy_data/YT/canyt/yt.yt007.wpt
+++ b/hwy_data/YT/canyt/yt.yt007.wpt
@@ -8,4 +8,4 @@ YT8 http://www.openstreetmap.org/?lat=60.328546&lon=-134.004892
 SawRd http://www.openstreetmap.org/?lat=60.152125&lon=-133.835103
 SnaLakeRd http://www.openstreetmap.org/?lat=60.131077&lon=-133.823538
 TarLakeRd http://www.openstreetmap.org/?lat=60.075918&lon=-133.810395
-YT/BC +BC/YT http://www.openstreetmap.org/?lat=59.999705&lon=-133.794787
+YT/BC http://www.openstreetmap.org/?lat=59.999705&lon=-133.794787

--- a/hwy_data/YT/canyt/yt.yt011.wpt
+++ b/hwy_data/YT/canyt/yt.yt011.wpt
@@ -13,7 +13,7 @@ DevElbTr http://www.openstreetmap.org/?lat=63.426330&lon=-136.511320
 +x09 http://www.openstreetmap.org/?lat=63.610803&lon=-135.971432
 +x10 http://www.openstreetmap.org/?lat=63.610955&lon=-135.945339
 +x11 http://www.openstreetmap.org/?lat=63.616448&lon=-135.924911
-MayoRd +ConSt http://www.openstreetmap.org/?lat=63.601792&lon=-135.887071
+MayoRd http://www.openstreetmap.org/?lat=63.601792&lon=-135.887071
 MayoAir http://www.openstreetmap.org/?lat=63.613910&lon=-135.882190
 +x12 http://www.openstreetmap.org/?lat=63.645040&lon=-135.887661
 FiveMileCamp http://www.openstreetmap.org/?lat=63.653280&lon=-135.876580


### PR DESCRIPTION
Removes remaining unused alt labels in my regions, except NT (to be included in separate pull request adding new route), and AK and two in CA (other updates to those files in progress).