### PR TITLE
cansk cleanup

### DIFF
--- a/hwy_data/SK/cansk/sk.sk056.wpt
+++ b/hwy_data/SK/cansk/sk.sk056.wpt
@@ -8,7 +8,7 @@ TR204 http://www.openstreetmap.org/?lat=50.629949&lon=-103.692691
 SK619 http://www.openstreetmap.org/?lat=50.680877&lon=-103.612033
 RegAve http://www.openstreetmap.org/?lat=50.694740&lon=-103.623034
 SalRd http://www.openstreetmap.org/?lat=50.723475&lon=-103.644660
-BouAve http://www.openstreetmap.org/?lat=50.728668&lon=-103.648090
+CenAve http://www.openstreetmap.org/?lat=50.729368&lon=-103.648345
 RueMaz http://www.openstreetmap.org/?lat=50.757106&lon=-103.702829
 SK22/35 http://www.openstreetmap.org/?lat=50.775570&lon=-103.783604
 BouAve http://www.openstreetmap.org/?lat=50.775227&lon=-103.794615

--- a/hwy_data/SK/cansk/sk.sk202.wpt
+++ b/hwy_data/SK/cansk/sk.sk202.wpt
@@ -1,5 +1,4 @@
 SK2 http://www.openstreetmap.org/?lat=50.571749&lon=-105.564795
 SK301 http://www.openstreetmap.org/?lat=50.572608&lon=-105.425942
 +X248701 http://www.openstreetmap.org/?lat=50.589049&lon=-105.419430
-BufPouPP http://www.openstreetmap.org/?lat=50.607365&lon=-105.436118
-
+BufPouPP http://www.openstreetmap.org/?lat=50.606681&lon=-105.434939

--- a/hwy_data/SK/cansk/sk.sk364.wpt
+++ b/hwy_data/SK/cansk/sk.sk364.wpt
@@ -1,0 +1,8 @@
+SK46 http://www.openstreetmap.org/?lat=50.480285&lon=-104.288224
+RigSt http://www.openstreetmap.org/?lat=50.484290&lon=-104.274215
+RaiSt http://www.openstreetmap.org/?lat=50.491183&lon=-104.274196
+SK734 http://www.openstreetmap.org/?lat=50.571599&lon=-104.272962
+SK640 http://www.openstreetmap.org/?lat=50.630011&lon=-104.270017
+HinSt http://www.openstreetmap.org/?lat=50.629981&lon=-104.246914
+RR162 http://www.openstreetmap.org/?lat=50.630055&lon=-104.131447
+SK10 http://www.openstreetmap.org/?lat=50.632199&lon=-103.993004

--- a/hwy_data/_systems/cansk.csv
+++ b/hwy_data/_systems/cansk.csv
@@ -123,6 +123,7 @@ cansk;SK;SK357;;;;sk.sk357;
 cansk;SK;SK358;;;;sk.sk358;
 cansk;SK;SK361;;;;sk.sk361;
 cansk;SK;SK363;;;;sk.sk363;
+cansk;SK;SK364;;;;sk.sk364;
 cansk;SK;SK365;;;;sk.sk365;
 cansk;SK;SK367;;;;sk.sk367;
 cansk;SK;SK368;;;;sk.sk368;

--- a/hwy_data/_systems/cansk_con.csv
+++ b/hwy_data/_systems/cansk_con.csv
@@ -123,6 +123,7 @@ cansk;SK357;;;sk.sk357
 cansk;SK358;;;sk.sk358
 cansk;SK361;;;sk.sk361
 cansk;SK363;;;sk.sk363
+cansk;SK364;;;sk.sk364
 cansk;SK365;;;sk.sk365
 cansk;SK367;;;sk.sk367
 cansk;SK368;;;sk.sk368


### PR DESCRIPTION
Restores SK 364 to HB, fixes duplicate label error in SK 56, and re-adjusts SK 202 endpoint.