### PR TITLE
Update al.us031.wpt

### DIFF
--- a/hwy_data/AL/usaus/al.us031.wpt
+++ b/hwy_data/AL/usaus/al.us031.wpt
@@ -57,8 +57,9 @@ CR24 http://www.openstreetmap.org/?lat=31.455465&lon=-86.778431
 +x19 http://www.openstreetmap.org/?lat=31.458649&lon=-86.772895
 +x20 http://www.openstreetmap.org/?lat=31.488077&lon=-86.771607
 CR71 http://www.openstreetmap.org/?lat=31.510160&lon=-86.763947
-AL55 http://www.openstreetmap.org/?lat=31.538091&lon=-86.726632
+AL55_S +AL55 http://www.openstreetmap.org/?lat=31.538091&lon=-86.726632
 CR8 http://www.openstreetmap.org/?lat=31.563215&lon=-86.740451
+AL55_N http://www.openstreetmap.org/?lat=31.59719&lon=-86.73453
 +x21 http://www.openstreetmap.org/?lat=31.604380&lon=-86.731052
 CR16Geo http://www.openstreetmap.org/?lat=31.633360&lon=-86.729722
 AL106 http://www.openstreetmap.org/?lat=31.641216&lon=-86.728864


### PR DESCRIPTION
Added missing point at the northern US 31/AL 55 intersection near Georgiana.  AL 55 extension to I-65 (on the west side of Georgiana) did not exist when the US 31 list was initially made.