### PR TITLE
US 19 Label Change At PA 27

### DIFF
--- a/hwy_data/PA/usaus/pa.us019.wpt
+++ b/hwy_data/PA/usaus/pa.us019.wpt
@@ -86,7 +86,7 @@ I-79 http://www.openstreetmap.org/?lat=41.622565&lon=-80.181313
 PA102 http://www.openstreetmap.org/?lat=41.620615&lon=-80.168867
 +X2A http://www.openstreetmap.org/?lat=41.621362&lon=-80.160155
 US322_E http://www.openstreetmap.org/?lat=41.629735&lon=-80.156701
-PA27 +ReyAve http://www.openstreetmap.org/?lat=41.646148&lon=-80.155665
+PA27 http://www.openstreetmap.org/?lat=41.646148&lon=-80.155665
 BalSt http://www.openstreetmap.org/?lat=41.676342&lon=-80.167150
 PA198_E http://www.openstreetmap.org/?lat=41.714619&lon=-80.146401
 PA198_W http://www.openstreetmap.org/?lat=41.724501&lon=-80.148890


### PR DESCRIPTION
Deleting ReyAve as a label due to it not being in use.  I also did the same to US 6.