### PR TITLE
Adjustment of south endpoint of ND 67

### DIFF
--- a/hwy_data/ND/usand/nd.nd067.wpt
+++ b/hwy_data/ND/usand/nd.nd067.wpt
@@ -1,7 +1,8 @@
-US12 http://www.openstreetmap.org/?lat=46.145106&lon=-103.145227
+US12 http://www.openstreetmap.org/?lat=46.144221&lon=-103.143275
+133rdAve http://www.openstreetmap.org/?lat=46.144251&lon=-103.146000
 85thSt http://www.openstreetmap.org/?lat=46.191299&lon=-103.140936
 78thSt_W http://www.openstreetmap.org/?lat=46.279818&lon=-103.134627
-78thSt_E http://www.openstreetmap.org/?lat=46.279944&lon=-103.118663
+78thSt_E http://www.openstreetmap.org/?lat=46.279936&lon=-103.119189
 73rdSt http://www.openstreetmap.org/?lat=46.352230&lon=-103.113298
 64thSt http://www.openstreetmap.org/?lat=46.482629&lon=-103.115444
 ND21 http://www.openstreetmap.org/?lat=46.526158&lon=-103.114741

--- a/hwy_data/ND/usaus/nd.us012.wpt
+++ b/hwy_data/ND/usaus/nd.us012.wpt
@@ -12,7 +12,7 @@ US85_S http://www.openstreetmap.org/?lat=46.178649&lon=-103.409951
 US85_N http://www.openstreetmap.org/?lat=46.176777&lon=-103.396615
 BufSprRd http://www.openstreetmap.org/?lat=46.174794&lon=-103.235178
 CirKRd http://www.openstreetmap.org/?lat=46.165547&lon=-103.203356
-ND67 http://www.openstreetmap.org/?lat=46.145106&lon=-103.145227
+ND67 http://www.openstreetmap.org/?lat=46.144221&lon=-103.143275
 MainSt_Gas http://www.openstreetmap.org/?lat=46.119611&lon=-103.078837
 ND22_S http://www.openstreetmap.org/?lat=46.117224&lon=-102.954372
 2ndSt http://www.openstreetmap.org/?lat=46.107421&lon=-102.933413


### PR DESCRIPTION
I noticed that ND 67 was a bit off (it goes over the railroad tracks on a bridge at the south end), so the adjustment was made.

If this causes any problems let me know (I figured a small thing would be good for my first HighwayData pull request).

Source: http://mapserver.co.bowman.nd.us/