### PR TITLE
Restore my fixes to recent Nevada entries

### DIFF
--- a/updates.csv
+++ b/updates.csv
@@ -2123,8 +2123,8 @@
 2015-08-18;(USA) Nebraska;US 75;ne.us075;Moved waypoint US34_E from NE 66 to Platteview Road.
 2018-08-23;(USA) Nevada;NV 172;nv.nv172;Truncated west end from I-11 exit 14 to I-11 exit 2
 2018-08-23;(USA) Nevada;US 93 Truck (Laughlin);nv.us093trklau;Truncated north end from Boulder City Parkway to I-11 exit 14
-2018-08-23;(USA) Nevada;I-11 Future (Hoover Dam);(NONE);Deleted route (folded into I-11)
-2018-08-19;(USA) Nevada;US 93 Business (Wendover);(NONE);Route Deleted
+2018-08-23;(USA) Nevada;I-11 Future (Hoover Dam);;Deleted route (folded into I-11)
+2018-08-19;(USA) Nevada;US 93 Business (Wendover);;Route Deleted
 2018-08-09;(USA) Nevada;I-11;nv.i011;Extended route south to Arizona border
 2018-08-09;(USA) Nevada;US 93;nv.us093;Relocated from Boulder City Parkway to new I-11 freeway, between exits 2 and 15B
 2018-08-09;(USA) Nevada;US 95;nv.us095;Relocated from Old US 95 and part of Boulder City Parkway, to I-11 freeway between exits 14 and 15B
@@ -2132,7 +2132,7 @@
 2018-08-09;(USA) Nevada;NV 172;nv.nv172;Amended route to old US 95 alignment
 2017-10-08;(USA) Nevada;I-11;nv.i011;New route
 2017-10-08;(USA) Nevada;I-515;nv.i515;Truncated route to Exit 61 per I-11 designation
-2017-10-08;(USA) Nevada;I-11 Future (Henderson);(NONE);Deleted route
+2017-10-08;(USA) Nevada;I-11 Future (Henderson);;Deleted route
 2017-09-26;(USA) Nevada;NV 439;nv.nv439;Extended to US 50.
 2017-09-04;(USA) Nevada;I-580;nv.i580;extended at south end from exit 38 to US50/395 junction
 2017-09-04;(USA) Nevada;US 50;nv.us050;rerouted onto I-580 from Stewart St and Fairview Lane between exit 38 and south end of interstate


### PR DESCRIPTION
I removed (NONE) from a field in three recent Nevada updates items. My guess is the removals were undone by someone editing an old version of updates.csv.