### PR TITLE
Carson City NV concurrencies, other fixes

### DIFF
--- a/hwy_data/NV/usai/nv.i580.wpt
+++ b/hwy_data/NV/usai/nv.i580.wpt
@@ -1,8 +1,7 @@
-US50/US395 http://www.openstreetmap.org/?lat=39.120880&lon=-119.772027
-+X834139 http://www.openstreetmap.org/?lat=39.124109&lon=-119.748541
-38 http://www.openstreetmap.org/?lat=39.150081&lon=-119.744925
-+X891278 http://www.openstreetmap.org/?lat=39.161804&lon=-119.740248
-39 http://www.openstreetmap.org/?lat=39.174896&lon=-119.740527
+US50/395 +US50/US395 http://www.openstreetmap.org/?lat=39.120747&lon=-119.771919
++X589597 http://www.openstreetmap.org/?lat=39.123868&lon=-119.748852
+38 http://www.openstreetmap.org/?lat=39.150131&lon=-119.745119
+39 http://www.openstreetmap.org/?lat=39.174736&lon=-119.740540
 41 http://www.openstreetmap.org/?lat=39.190007&lon=-119.754066
 42 http://www.openstreetmap.org/?lat=39.198255&lon=-119.774623
 43 http://www.openstreetmap.org/?lat=39.202629&lon=-119.780502

--- a/hwy_data/NV/usaus/nv.us050.wpt
+++ b/hwy_data/NV/usaus/nv.us050.wpt
@@ -1,4 +1,4 @@
-CA/NV http://www.openstreetmap.org/?lat=38.959150&lon=-119.942057
+CA/NV http://www.openstreetmap.org/?lat=38.959196&lon=-119.942089
 NV207 http://www.openstreetmap.org/?lat=38.967676&lon=-119.936467
 NV760 http://www.openstreetmap.org/?lat=38.983944&lon=-119.942738
 MarDr http://www.openstreetmap.org/?lat=39.002110&lon=-119.955812
@@ -8,13 +8,13 @@ GleBroRd http://www.openstreetmap.org/?lat=39.081498&lon=-119.942486
 NV28 http://www.openstreetmap.org/?lat=39.100825&lon=-119.909710
 +X02 http://www.openstreetmap.org/?lat=39.108427&lon=-119.878934
 +X03 http://www.openstreetmap.org/?lat=39.115507&lon=-119.886927
+GolfClubDr http://www.openstreetmap.org/?lat=39.117638&lon=-119.845278
 +X04 http://www.openstreetmap.org/?lat=39.122751&lon=-119.826408
 +X05 http://www.openstreetmap.org/?lat=39.113243&lon=-119.792307
-US395_S http://www.openstreetmap.org/?lat=39.120880&lon=-119.772027
-+X589597 http://www.openstreetmap.org/?lat=39.123402&lon=-119.748402
-38 http://www.openstreetmap.org/?lat=39.150081&lon=-119.744925
-+X891278 http://www.openstreetmap.org/?lat=39.161804&lon=-119.740248
-US395_N http://www.openstreetmap.org/?lat=39.174896&lon=-119.740527
+US395_S http://www.openstreetmap.org/?lat=39.120747&lon=-119.771919
++X589597 http://www.openstreetmap.org/?lat=39.123868&lon=-119.748852
+I-580(38) +38 http://www.openstreetmap.org/?lat=39.150131&lon=-119.745119
+I-580(39) +US395_N http://www.openstreetmap.org/?lat=39.174736&lon=-119.740540
 DraWay http://www.openstreetmap.org/?lat=39.192279&lon=-119.695425
 LinRd http://www.openstreetmap.org/?lat=39.210763&lon=-119.679415
 NV341 http://www.openstreetmap.org/?lat=39.220418&lon=-119.646778

--- a/hwy_data/NV/usaus/nv.us395.wpt
+++ b/hwy_data/NV/usaus/nv.us395.wpt
@@ -1,4 +1,4 @@
-CA/NV http://www.openstreetmap.org/?lat=38.687294&lon=-119.548620
+CA/NV http://www.openstreetmap.org/?lat=38.687733&lon=-119.548566
 NV208 http://www.openstreetmap.org/?lat=38.728066&lon=-119.555347
 OhoRidRd http://www.openstreetmap.org/?lat=38.838379&lon=-119.634515
 +X01 http://www.openstreetmap.org/?lat=38.870134&lon=-119.681349
@@ -8,28 +8,27 @@ NV88 http://www.openstreetmap.org/?lat=38.960961&lon=-119.778711
 NV757 http://www.openstreetmap.org/?lat=38.970479&lon=-119.779161
 NV206 http://www.openstreetmap.org/?lat=38.996432&lon=-119.779687
 NV759 http://www.openstreetmap.org/?lat=39.001043&lon=-119.779730
-SunRidDr +SunRdgDr http://www.openstreetmap.org/?lat=39.074144&lon=-119.779408
-US50_W http://www.openstreetmap.org/?lat=39.121180&lon=-119.771909
-+X589597 http://www.openstreetmap.org/?lat=39.123402&lon=-119.748402
-38 http://www.openstreetmap.org/?lat=39.150081&lon=-119.744925
-+X891278 http://www.openstreetmap.org/?lat=39.161804&lon=-119.740248
-39 http://www.openstreetmap.org/?lat=39.174896&lon=-119.740527
+SunRidDr http://www.openstreetmap.org/?lat=39.074144&lon=-119.779408
+US50_W http://www.openstreetmap.org/?lat=39.120747&lon=-119.771919
++X589597 http://www.openstreetmap.org/?lat=39.123868&lon=-119.748852
+38 http://www.openstreetmap.org/?lat=39.150131&lon=-119.745119
+39  http://www.openstreetmap.org/?lat=39.174736&lon=-119.740540
 41 +I-580(41) http://www.openstreetmap.org/?lat=39.190007&lon=-119.754066
-42 +I-580(42) http://www.openstreetmap.org/?lat=39.198255&lon=-119.774623
-43 +US395BusCar_N +I-580(43) http://www.openstreetmap.org/?lat=39.202629&lon=-119.780502
-44 +I-580(44) http://www.openstreetmap.org/?lat=39.213411&lon=-119.806777
-46 +I-580(46) http://www.openstreetmap.org/?lat=39.247136&lon=-119.813837
+42 http://www.openstreetmap.org/?lat=39.198255&lon=-119.774623
+43 +US395BusCar_N http://www.openstreetmap.org/?lat=39.202629&lon=-119.780502
+44 http://www.openstreetmap.org/?lat=39.213411&lon=-119.806777
+46 http://www.openstreetmap.org/?lat=39.247136&lon=-119.813837
 50 +I-580(50) http://www.openstreetmap.org/?lat=39.305513&lon=-119.825993
 +X846719 http://www.openstreetmap.org/?lat=39.339343&lon=-119.806209
 +X469326 http://www.openstreetmap.org/?lat=39.370568&lon=-119.756427
 56 +NV431 +I-580(56) http://www.openstreetmap.org/?lat=39.397071&lon=-119.757972
-57 +US395BusRen_A +US395BusRen_1 +I-580(57) http://www.openstreetmap.org/?lat=39.409133&lon=-119.750311
-59 +DamRanPkwy +I-580(59) http://www.openstreetmap.org/?lat=39.422983&lon=-119.751352
-60 +I-580(60) http://www.openstreetmap.org/?lat=39.439126&lon=-119.765375
-61 +US395BusRen_B +US395BusRen_2 +I-580(61) http://www.openstreetmap.org/?lat=39.449872&lon=-119.776061
-62 +I-580(62) http://www.openstreetmap.org/?lat=39.467574&lon=-119.788098
-63 +I-580(63) http://www.openstreetmap.org/?lat=39.478572&lon=-119.789901
-64 +I-580(64) http://www.openstreetmap.org/?lat=39.492914&lon=-119.784665
+57 +I-580(57) http://www.openstreetmap.org/?lat=39.409133&lon=-119.750311
+59 http://www.openstreetmap.org/?lat=39.422983&lon=-119.751352
+60 http://www.openstreetmap.org/?lat=39.439126&lon=-119.765375
+61 http://www.openstreetmap.org/?lat=39.449872&lon=-119.776061
+62 http://www.openstreetmap.org/?lat=39.467574&lon=-119.788098
+63 http://www.openstreetmap.org/?lat=39.478572&lon=-119.789901
+64 http://www.openstreetmap.org/?lat=39.492914&lon=-119.784665
 65 +I-580(65) http://www.openstreetmap.org/?lat=39.502782&lon=-119.781876
 65A +I-580(65A) http://www.openstreetmap.org/?lat=39.509421&lon=-119.780266
 66 +I-580(66) http://www.openstreetmap.org/?lat=39.519784&lon=-119.783378
@@ -38,13 +37,13 @@ US50_W http://www.openstreetmap.org/?lat=39.121180&lon=-119.771909
 69 +OddBlvd http://www.openstreetmap.org/?lat=39.545411&lon=-119.787916
 70 +NV659 http://www.openstreetmap.org/?lat=39.556504&lon=-119.788560
 71 +ParrBlvd http://www.openstreetmap.org/?lat=39.574047&lon=-119.808547
-72 +US395BusRen_N http://www.openstreetmap.org/?lat=39.589741&lon=-119.826454
-73 +GolValRd http://www.openstreetmap.org/?lat=39.600017&lon=-119.837526
-74 +LemDr http://www.openstreetmap.org/?lat=39.611086&lon=-119.851055
-76 +NV673 +SteBlvd http://www.openstreetmap.org/?lat=39.619111&lon=-119.882212
-78 +RedRockRd http://www.openstreetmap.org/?lat=39.626276&lon=-119.916061
+72 http://www.openstreetmap.org/?lat=39.589741&lon=-119.826454
+73 http://www.openstreetmap.org/?lat=39.600017&lon=-119.837526
+74 http://www.openstreetmap.org/?lat=39.611086&lon=-119.851055
+76 +SteBlvd http://www.openstreetmap.org/?lat=39.619111&lon=-119.882212
+78 http://www.openstreetmap.org/?lat=39.626276&lon=-119.916061
 +X04 http://www.openstreetmap.org/?lat=39.628521&lon=-119.930392
-80 +RenoParkBlvd http://www.openstreetmap.org/?lat=39.643842&lon=-119.958258
+80 http://www.openstreetmap.org/?lat=39.643842&lon=-119.958258
 +X05 http://www.openstreetmap.org/?lat=39.654416&lon=-119.984581
-83 +WhiLkPkwy http://www.openstreetmap.org/?lat=39.668011&lon=-119.996431
-NV/CA http://www.openstreetmap.org/?lat=39.673519&lon=-120.001087
+83 http://www.openstreetmap.org/?lat=39.668011&lon=-119.996431
+NV/CA http://www.openstreetmap.org/?lat=39.673590&lon=-120.001157

--- a/hwy_data/NV/usausb/nv.us050buscar.wpt
+++ b/hwy_data/NV/usausb/nv.us050buscar.wpt
@@ -1,7 +1,6 @@
-US395_S http://www.openstreetmap.org/?lat=39.120880&lon=-119.772027
+US50_W +US395_S http://www.openstreetmap.org/?lat=39.120747&lon=-119.771919
 KooLn http://www.openstreetmap.org/?lat=39.133839&lon=-119.769752
 FaiDr http://www.openstreetmap.org/?lat=39.149957&lon=-119.767220
 5thSt +NV513 http://www.openstreetmap.org/?lat=39.161290&lon=-119.766989
 US395Bus_N http://www.openstreetmap.org/?lat=39.170455&lon=-119.767005
-RoopSt http://www.openstreetmap.org/?lat=39.170415&lon=-119.761064
-US50_E http://www.openstreetmap.org/?lat=39.174896&lon=-119.740527
+US50_E http://www.openstreetmap.org/?lat=39.174736&lon=-119.740540

--- a/hwy_data/NV/usausb/nv.us395buscar.wpt
+++ b/hwy_data/NV/usausb/nv.us395buscar.wpt
@@ -1,4 +1,4 @@
-US395_S http://www.openstreetmap.org/?lat=39.120880&lon=-119.772027
+US395_S http://www.openstreetmap.org/?lat=39.120747&lon=-119.771919
 KooLn http://www.openstreetmap.org/?lat=39.133839&lon=-119.769752
 FaiDr http://www.openstreetmap.org/?lat=39.149957&lon=-119.767220
 5thSt +NV513 http://www.openstreetmap.org/?lat=39.161290&lon=-119.766989


### PR DESCRIPTION
Fixes broken concurrencies for freeways in Carson City NV area, as discussed in forum. Also some related NMP fixes, and removals of unused alt labels.