### PR TITLE
AL/GA border point corrections

### DIFF
--- a/hwy_data/AL/usai/al.i059.wpt
+++ b/hwy_data/AL/usai/al.i059.wpt
@@ -76,4 +76,4 @@ MS/AL +0 http://www.openstreetmap.org/?lat=32.448723&lon=-88.404190
 231 http://www.openstreetmap.org/?lat=34.594145&lon=-85.641174
 +x13 http://www.openstreetmap.org/?lat=34.620221&lon=-85.630703
 239 http://www.openstreetmap.org/?lat=34.696580&lon=-85.569205
-AL/GA +999 http://www.openstreetmap.org/?lat=34.714141&lon=-85.553595
+AL/GA +999 http://www.openstreetmap.org/?lat=34.714214&lon=-85.553552

--- a/hwy_data/AL/usaus/al.us011.wpt
+++ b/hwy_data/AL/usaus/al.us011.wpt
@@ -148,4 +148,5 @@ HawRd http://www.openstreetmap.org/?lat=34.625271&lon=-85.607631
 CR751 http://www.openstreetmap.org/?lat=34.630966&lon=-85.614374
 CR731 http://www.openstreetmap.org/?lat=34.655001&lon=-85.601113
 CR140 http://www.openstreetmap.org/?lat=34.695407&lon=-85.565810
-AL/GA http://www.openstreetmap.org/?lat=34.706464&lon=-85.552093
+AL/GA http://www.openstreetmap.org/?lat=34.706580&lon=-85.552028
+

--- a/hwy_data/AL/usaus/al.us078.wpt
+++ b/hwy_data/AL/usaus/al.us078.wpt
@@ -109,4 +109,4 @@ CR61 http://www.openstreetmap.org/?lat=33.717410&lon=-85.497263
 +x18 http://www.openstreetmap.org/?lat=33.730131&lon=-85.466917
 CR35_Fru http://www.openstreetmap.org/?lat=33.730925&lon=-85.432756
 CR49 http://www.openstreetmap.org/?lat=33.745075&lon=-85.392845
-AL/GA http://www.openstreetmap.org/?lat=33.747928&lon=-85.356766
+AL/GA http://www.openstreetmap.org/?lat=33.747990&lon=-85.356925

--- a/hwy_data/AL/usaus/al.us084.wpt
+++ b/hwy_data/AL/usaus/al.us084.wpt
@@ -133,4 +133,4 @@ OldUS84_E http://www.openstreetmap.org/?lat=31.166875&lon=-85.199318
 +x24 http://www.openstreetmap.org/?lat=31.134095&lon=-85.137434
 TifRd http://www.openstreetmap.org/?lat=31.133710&lon=-85.097249
 AL95 http://www.openstreetmap.org/?lat=31.128571&lon=-85.075631
-AL/GA http://www.openstreetmap.org/?lat=31.123423&lon=-85.055820
+AL/GA http://www.openstreetmap.org/?lat=31.123311&lon=-85.055788

--- a/hwy_data/GA/usaga/ga.ga005.wpt
+++ b/hwy_data/GA/usaga/ga.ga005.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=33.466116&lon=-85.301266
+AL/GA http://www.openstreetmap.org/?lat=33.466213&lon=-85.300802
 GA100_S http://www.openstreetmap.org/?lat=33.470191&lon=-85.295432
 GA100_N http://www.openstreetmap.org/?lat=33.475023&lon=-85.290614
 StoPoiRd http://www.openstreetmap.org/?lat=33.467720&lon=-85.202296

--- a/hwy_data/GA/usaga/ga.ga008.wpt
+++ b/hwy_data/GA/usaga/ga.ga008.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=33.747928&lon=-85.356766
+AL/GA http://www.openstreetmap.org/?lat=33.747990&lon=-85.356925
 +X000(GA8) http://www.openstreetmap.org/?lat=33.740257&lon=-85.332817
 GA100_N http://www.openstreetmap.org/?lat=33.744428&lon=-85.290325
 GA100_S http://www.openstreetmap.org/?lat=33.744366&lon=-85.288142

--- a/hwy_data/GA/usaga/ga.ga020.wpt
+++ b/hwy_data/GA/usaga/ga.ga020.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=34.250714&lon=-85.455063
+AL/GA http://www.openstreetmap.org/?lat=34.250794&lon=-85.454814
 GA100_N http://www.openstreetmap.org/?lat=34.265651&lon=-85.395248
 +X000 http://www.openstreetmap.org/?lat=34.266428&lon=-85.380592
 +X001 http://www.openstreetmap.org/?lat=34.256141&lon=-85.376547

--- a/hwy_data/GA/usaga/ga.ga037.wpt
+++ b/hwy_data/GA/usaga/ga.ga037.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=31.604242&lon=-85.056004
+AL/GA http://www.openstreetmap.org/?lat=31.604241&lon=-85.056088
 GA39_N http://www.openstreetmap.org/?lat=31.603784&lon=-85.049919
 GA39_S http://www.openstreetmap.org/?lat=31.603576&lon=-85.048746
 +X000 http://www.openstreetmap.org/?lat=31.606091&lon=-84.980901

--- a/hwy_data/GA/usaga/ga.ga038.wpt
+++ b/hwy_data/GA/usaga/ga.ga038.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=31.123423&lon=-85.055820
+AL/GA http://www.openstreetmap.org/?lat=31.123311&lon=-85.055788
 GA370 http://www.openstreetmap.org/?lat=31.115300&lon=-85.036953
 JanRd http://www.openstreetmap.org/?lat=31.086080&lon=-84.984747
 GA91Alt http://www.openstreetmap.org/?lat=31.040470&lon=-84.882533

--- a/hwy_data/GA/usaga/ga.ga039sproma.wpt
+++ b/hwy_data/GA/usaga/ga.ga039sproma.wpt
@@ -1,2 +1,2 @@
-AL/GA http://www.openstreetmap.org/?lat=32.140927&lon=-85.049798
+AL/GA http://www.openstreetmap.org/?lat=32.141077&lon=-85.049983
 GA39 http://www.openstreetmap.org/?lat=32.140459&lon=-85.025058

--- a/hwy_data/GA/usaga/ga.ga058.wpt
+++ b/hwy_data/GA/usaga/ga.ga058.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=34.706261&lon=-85.552168
+AL/GA http://www.openstreetmap.org/?lat=34.706580&lon=-85.552028
 CloRd http://www.openstreetmap.org/?lat=34.734268&lon=-85.536938
 +X000(GA58) http://www.openstreetmap.org/?lat=34.755603&lon=-85.531697
 PudRidRd http://www.openstreetmap.org/?lat=34.772780&lon=-85.536933

--- a/hwy_data/GA/usaga/ga.ga062.wpt
+++ b/hwy_data/GA/usaga/ga.ga062.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=31.283897&lon=-85.099780
+AL/GA http://www.openstreetmap.org/?lat=31.284029&lon=-85.099883
 GA370 http://www.openstreetmap.org/?lat=31.283213&lon=-85.070041
 RockHillRd http://www.openstreetmap.org/?lat=31.319426&lon=-85.031919
 +X000 http://www.openstreetmap.org/?lat=31.332586&lon=-84.993128

--- a/hwy_data/GA/usaga/ga.ga114.wpt
+++ b/hwy_data/GA/usaga/ga.ga114.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=34.328177&lon=-85.470440
+AL/GA http://www.openstreetmap.org/?lat=34.328076&lon=-85.470548
 HolChaRd http://www.openstreetmap.org/?lat=34.345475&lon=-85.446863
 +X000 http://www.openstreetmap.org/?lat=34.392737&lon=-85.420578
 OakHillRd http://www.openstreetmap.org/?lat=34.403387&lon=-85.407231

--- a/hwy_data/GA/usaga/ga.ga136.wpt
+++ b/hwy_data/GA/usaga/ga.ga136.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=34.867455&lon=-85.584478
+AL/GA http://www.openstreetmap.org/?lat=34.867427&lon=-85.584553
 GA301 http://www.openstreetmap.org/?lat=34.863880&lon=-85.549673
 I-59 http://www.openstreetmap.org/?lat=34.869614&lon=-85.515959
 US11_N http://www.openstreetmap.org/?lat=34.868737&lon=-85.511763

--- a/hwy_data/GA/usaga/ga.ga301.wpt
+++ b/hwy_data/GA/usaga/ga.ga301.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=34.823673&lon=-85.576121
+AL/GA http://www.openstreetmap.org/?lat=34.823591&lon=-85.576179
 +X000 http://www.openstreetmap.org/?lat=34.838913&lon=-85.562712
 GA136 http://www.openstreetmap.org/?lat=34.863880&lon=-85.549673
 WOakGapRd http://www.openstreetmap.org/?lat=34.877192&lon=-85.537534

--- a/hwy_data/GA/usai/ga.i059.wpt
+++ b/hwy_data/GA/usai/ga.i059.wpt
@@ -1,4 +1,4 @@
-AL/GA +0 http://www.openstreetmap.org/?lat=34.713818&lon=-85.553802
+AL/GA +0 http://www.openstreetmap.org/?lat=34.714214&lon=-85.553552
 +X000(I59) http://www.openstreetmap.org/?lat=34.733193&lon=-85.538317
 4 http://www.openstreetmap.org/?lat=34.772181&lon=-85.540382
 +X001(I59) http://www.openstreetmap.org/?lat=34.803268&lon=-85.549808

--- a/hwy_data/GA/usaus/ga.us011.wpt
+++ b/hwy_data/GA/usaus/ga.us011.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=34.706261&lon=-85.552168
+AL/GA http://www.openstreetmap.org/?lat=34.706580&lon=-85.552028
 CloRd http://www.openstreetmap.org/?lat=34.734268&lon=-85.536938
 +X000(US11) http://www.openstreetmap.org/?lat=34.755603&lon=-85.531697
 PudRidRd http://www.openstreetmap.org/?lat=34.772780&lon=-85.536933

--- a/hwy_data/GA/usaus/ga.us078.wpt
+++ b/hwy_data/GA/usaus/ga.us078.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=33.747928&lon=-85.356766
+AL/GA http://www.openstreetmap.org/?lat=33.747990&lon=-85.356925
 +X000(US78) http://www.openstreetmap.org/?lat=33.740257&lon=-85.332817
 GA100_N +GA100/120_N http://www.openstreetmap.org/?lat=33.744428&lon=-85.290325
 GA100_S http://www.openstreetmap.org/?lat=33.744366&lon=-85.288142

--- a/hwy_data/GA/usaus/ga.us084.wpt
+++ b/hwy_data/GA/usaus/ga.us084.wpt
@@ -1,4 +1,4 @@
-AL/GA http://www.openstreetmap.org/?lat=31.123423&lon=-85.055820
+AL/GA http://www.openstreetmap.org/?lat=31.123311&lon=-85.055788
 GA370 http://www.openstreetmap.org/?lat=31.115300&lon=-85.036953
 JanRd http://www.openstreetmap.org/?lat=31.086080&lon=-84.984747
 GA91Alt http://www.openstreetmap.org/?lat=31.040470&lon=-84.882533


### PR DESCRIPTION
A comprehensive review of AL/GA border points with corrections made where needed.  Along the Chattahoochie River, points were generally aligned with the western river bank, as the border definition here is the average water mark along the western bank.  North of the river, points were aligned with where signage and pavement changes take place, which was often a different location than where OSM labels the boundary.  Past precedent for some routes along the AL/GA border was to mark at the signage/pavement change (an example being US 411 which was not changed for this update).