### PR TITLE
AL point fixes for newly designated routes

### DIFF
--- a/hwy_data/AL/usaus/al.us031.wpt
+++ b/hwy_data/AL/usaus/al.us031.wpt
@@ -143,7 +143,7 @@ CarrBlvd http://www.openstreetmap.org/?lat=33.527166&lon=-86.802528
 I-20/59 +I-20(126A) http://www.openstreetmap.org/?lat=33.528374&lon=-86.804266
 11thAveN http://www.openstreetmap.org/?lat=33.529626&lon=-86.805071
 21stAveN http://www.openstreetmap.org/?lat=33.541399&lon=-86.813021
-FinBlvd http://www.openstreetmap.org/?lat=33.546013&lon=-86.815558
+AL378 http://www.openstreetmap.org/?lat=33.546013&lon=-86.815558
 33rdAveN http://www.openstreetmap.org/?lat=33.554736&lon=-86.819238
 47thAveN http://www.openstreetmap.org/?lat=33.572280&lon=-86.810119
 I-65(266) http://www.openstreetmap.org/?lat=33.585612&lon=-86.805146

--- a/hwy_data/AL/usaus/al.us078.wpt
+++ b/hwy_data/AL/usaus/al.us078.wpt
@@ -39,7 +39,7 @@ PrattHwy http://www.openstreetmap.org/?lat=33.577266&lon=-86.913711
 HefAve http://www.openstreetmap.org/?lat=33.568007&lon=-86.898213
 DanPayDr http://www.openstreetmap.org/?lat=33.547466&lon=-86.878853
 CheAve http://www.openstreetmap.org/?lat=33.540999&lon=-86.871434
-FinBlvd http://www.openstreetmap.org/?lat=33.529840&lon=-86.850615
+AL378 +FinBlvd http://www.openstreetmap.org/?lat=33.529840&lon=-86.850615
 I-20(123) http://www.openstreetmap.org/?lat=33.521013&lon=-86.849391
 8thAveBir +8thAvBir http://www.openstreetmap.org/?lat=33.511808&lon=-86.849198
 US11_S http://www.openstreetmap.org/?lat=33.505341&lon=-86.849118

--- a/hwy_data/AL/usaus/al.us082.wpt
+++ b/hwy_data/AL/usaus/al.us082.wpt
@@ -44,7 +44,7 @@ CR58 http://www.openstreetmap.org/?lat=32.990380&lon=-87.208829
 AL5 http://www.openstreetmap.org/?lat=32.964580&lon=-87.168478
 AL219_N http://www.openstreetmap.org/?lat=32.958612&lon=-87.147723
 AL25/219 +AL25 +AL25_N http://www.openstreetmap.org/?lat=32.957586&lon=-87.135733
-CR20 http://www.openstreetmap.org/?lat=32.938013&lon=-87.066184
+AL382 +CR20 http://www.openstreetmap.org/?lat=32.938013&lon=-87.066184
 CR29Bib http://www.openstreetmap.org/?lat=32.912563&lon=-87.024765
 +x08 http://www.openstreetmap.org/?lat=32.897534&lon=-86.992321
 CR36 http://www.openstreetmap.org/?lat=32.848442&lon=-86.961250

--- a/hwy_data/AL/usaus/al.us084.wpt
+++ b/hwy_data/AL/usaus/al.us084.wpt
@@ -112,7 +112,7 @@ AL92 http://www.openstreetmap.org/?lat=31.242536&lon=-85.635231
 AL123 http://www.openstreetmap.org/?lat=31.242210&lon=-85.629807
 CR9 http://www.openstreetmap.org/?lat=31.242692&lon=-85.570461
 BaySprRd http://www.openstreetmap.org/?lat=31.237802&lon=-85.523994
-BraStaRd http://www.openstreetmap.org/?lat=31.240013&lon=-85.480896
+AL605 http://www.openstreetmap.org/?lat=31.240013&lon=-85.480896
 JohnOdomRd http://www.openstreetmap.org/?lat=31.236298&lon=-85.460383
 FloChaRd http://www.openstreetmap.org/?lat=31.228940&lon=-85.439730
 US231_S http://www.openstreetmap.org/?lat=31.228509&lon=-85.432134

--- a/hwy_data/AL/usaus/al.us231.wpt
+++ b/hwy_data/AL/usaus/al.us231.wpt
@@ -1,4 +1,5 @@
 FL/AL http://www.openstreetmap.org/?lat=30.998304&lon=-85.407661
+AL605_S http://www.openstreetmap.org/?lat=31.003035&lon=-85.407779
 DecRd http://www.openstreetmap.org/?lat=31.034145&lon=-85.406642
 AL109 http://www.openstreetmap.org/?lat=31.107147&lon=-85.405269
 SauRd http://www.openstreetmap.org/?lat=31.160632&lon=-85.402275
@@ -11,6 +12,7 @@ ChocSt http://www.openstreetmap.org/?lat=31.237504&lon=-85.431603
 US84_E http://www.openstreetmap.org/?lat=31.249080&lon=-85.424640
 WestPkwy +WGatePkwy http://www.openstreetmap.org/?lat=31.257211&lon=-85.433384
 NapFieRd http://www.openstreetmap.org/?lat=31.270381&lon=-85.447749
+AL605_N http://www.openstreetmap.org/?lat=31.307462&lon=-85.495868
 AL134 http://www.openstreetmap.org/?lat=31.313746&lon=-85.506206
 CR14New http://www.openstreetmap.org/?lat=31.342701&lon=-85.549920
 CR18 http://www.openstreetmap.org/?lat=31.376416&lon=-85.569715


### PR DESCRIPTION
Point label corrections or additions for three newly signed Alabama state routes:  AL 378, AL 382, and AL 605.