### PR TITLE
US 460 BUS (Bedford): Fixing Label Error

### DIFF
--- a/hwy_data/VA/usausb/va.us460busbed.wpt
+++ b/hwy_data/VA/usausb/va.us460busbed.wpt
@@ -2,5 +2,5 @@ US460_W http://www.openstreetmap.org/?lat=37.335676&lon=-79.544288
 VA122Bus_S http://www.openstreetmap.org/?lat=37.335301&lon=-79.526736
 US221Bus_N +US221_N http://www.openstreetmap.org/?lat=37.334457&lon=-79.523495
 VA43_S http://www.openstreetmap.org/?lat=37.333962&lon=-79.521747
-US 221/122 +IndBlvd http://www.openstreetmap.org/?lat=37.326158&lon=-79.503711
+US221/122 +IndBlvd http://www.openstreetmap.org/?lat=37.326158&lon=-79.503711
 US460_E http://www.openstreetmap.org/?lat=37.324791&lon=-79.503025


### PR DESCRIPTION
Showed up in the HB as "US"  and in the WPT Editor as "US +221/122 +IndBlvd". This was intended to be US221/122.

http://forum.travelmapping.net/index.php?topic=2839.0

I'll let Mike know I fixed this via PM on the forum.  -Mark