### PR TITLE
MD: I-70 exit changes in Frederick

### DIFF
--- a/hwy_data/MD/usai/md.i070.wpt
+++ b/hwy_data/MD/usai/md.i070.wpt
@@ -27,8 +27,7 @@ PA/MD +0 http://www.openstreetmap.org/?lat=39.722376&lon=-78.184792
 +X09 http://www.openstreetmap.org/?lat=39.406290&lon=-77.468290
 52 http://www.openstreetmap.org/?lat=39.399359&lon=-77.440639
 53 http://www.openstreetmap.org/?lat=39.398464&lon=-77.424860
-*54 http://www.openstreetmap.org/?lat=39.399935&lon=-77.409475
-54A http://www.openstreetmap.org/?lat=39.401366&lon=-77.403681
+54 +54A http://www.openstreetmap.org/?lat=39.401366&lon=-77.403681
 55 http://www.openstreetmap.org/?lat=39.404400&lon=-77.390399
 56 http://www.openstreetmap.org/?lat=39.403803&lon=-77.380625
 +X10 http://www.openstreetmap.org/?lat=39.404897&lon=-77.351217


### PR DESCRIPTION
Per forum discussion, removes I-70 point for long-closed exit 54 (label not in use), and moves its label to current I-70 exit 54 (54A in the HB, label in use and will become alt label). The removal of old *54 point also eliminates an NMP.