### PR TITLE
US 6: Readded SprSt as Alternate Label for ChuSt

### DIFF
--- a/hwy_data/PA/usaus/pa.us006.wpt
+++ b/hwy_data/PA/usaus/pa.us006.wpt
@@ -206,7 +206,7 @@ BroSt http://www.openstreetmap.org/?lat=41.563049&lon=-75.247231
 PA652 http://www.openstreetmap.org/?lat=41.547155&lon=-75.213583
 +X159812 http://www.openstreetmap.org/?lat=41.509799&lon=-75.202789
 PA590_E http://www.openstreetmap.org/?lat=41.481813&lon=-75.182418
-ChuSt http://www.openstreetmap.org/?lat=41.475323&lon=-75.182708
+ChuSt  +SprSt http://www.openstreetmap.org/?lat=41.475323&lon=-75.182708
 SilkMillDr http://www.openstreetmap.org/?lat=41.472198&lon=-75.173223
 PA590_W http://www.openstreetmap.org/?lat=41.462403&lon=-75.181375
 PA507 http://www.openstreetmap.org/?lat=41.443478&lon=-75.178204


### PR DESCRIPTION
Put SprSt in as alternate label for ChuSt.

This was done while looking at the latest User Data list files and realizing that I broke griffith's with last night's Pull Request (https://github.com/TravelMapping/HighwayData/pull/2759).