### PR TITLE
Quebec Autoroute tweaks

### DIFF
--- a/hwy_data/QC/canqca/qc.a010.wpt
+++ b/hwy_data/QC/canqca/qc.a010.wpt
@@ -36,7 +36,7 @@
 118 http://www.openstreetmap.org/?lat=45.293577&lon=-72.164512
 121 http://www.openstreetmap.org/?lat=45.295268&lon=-72.129021
 123 http://www.openstreetmap.org/?lat=45.299826&lon=-72.099495
-123A http://www.openstreetmap.org/?lat=45.306058&lon=-72.089046
+123A http://www.openstreetmap.org/?lat=45.306059&lon=-72.089045
 128 http://www.openstreetmap.org/?lat=45.326384&lon=-72.060828
 +X07 http://www.openstreetmap.org/?lat=45.359986&lon=-72.058296
 133 http://www.openstreetmap.org/?lat=45.374247&lon=-72.040358

--- a/hwy_data/QC/canqca/qc.a055.wpt
+++ b/hwy_data/QC/canqca/qc.a055.wpt
@@ -11,7 +11,7 @@ ChCur http://www.openstreetmap.org/?lat=45.051301&lon=-72.083187
 33 http://www.openstreetmap.org/?lat=45.286301&lon=-72.118206
 121(10) http://www.openstreetmap.org/?lat=45.295268&lon=-72.129021
 123(10) http://www.openstreetmap.org/?lat=45.299826&lon=-72.099495
-123A(10) http://www.openstreetmap.org/?lat=45.306058&lon=-72.089046
+123A(10) http://www.openstreetmap.org/?lat=45.306059&lon=-72.089045
 128(10) http://www.openstreetmap.org/?lat=45.326384&lon=-72.060828
 +X07 http://www.openstreetmap.org/?lat=45.359986&lon=-72.058296
 133(10) http://www.openstreetmap.org/?lat=45.374247&lon=-72.040358


### PR DESCRIPTION
Reverts to old coordinates for A-10(123A) and corresponding waypoint for A-55. Needed to break false concurrency with QC 112, which is on frontage road rather than A-10/55 mainline.