### PR TITLE
WA and ID updates 

### DIFF
--- a/hwy_data/ID/usaid/id.id039.wpt
+++ b/hwy_data/ID/usaid/id.id039.wpt
@@ -1,3 +1,4 @@
+I-86 http://www.openstreetmap.org/?lat=42.792740&lon=-112.828603
 I-86BL_E http://www.openstreetmap.org/?lat=42.790897&lon=-112.835555
 MarRd http://www.openstreetmap.org/?lat=42.794676&lon=-112.848859
 I-86BL_W http://www.openstreetmap.org/?lat=42.785732&lon=-112.859030

--- a/hwy_data/ID/usaus/id.us020.wpt
+++ b/hwy_data/ID/usaus/id.us020.wpt
@@ -103,6 +103,7 @@ SciCenDr +SciCtrDr http://www.openstreetmap.org/?lat=43.514961&lon=-112.040452
 318 +CRA4 http://www.openstreetmap.org/?lat=43.626471&lon=-111.944214
 320 +US20BusRig_W http://www.openstreetmap.org/?lat=43.661451&lon=-111.918851
 *ID48 http://www.openstreetmap.org/?lat=43.670114&lon=-111.912349
++X580981 http://www.openstreetmap.org/?lat=43.678332&lon=-111.906384
 322 +US20BusRig_E http://www.openstreetmap.org/?lat=43.682530&lon=-111.905258
 325 http://www.openstreetmap.org/?lat=43.724622&lon=-111.874895
 328 http://www.openstreetmap.org/?lat=43.761905&lon=-111.844425

--- a/hwy_data/ID/usausb/id.us095sprpay.wpt
+++ b/hwy_data/ID/usausb/id.us095sprpay.wpt
@@ -1,2 +1,0 @@
-US95 http://www.openstreetmap.org/?lat=44.054655&lon=-116.925806
-ID52 http://www.openstreetmap.org/?lat=44.072664&lon=-116.936610

--- a/hwy_data/WA/usawa/wa.wa519.wpt
+++ b/hwy_data/WA/usawa/wa.wa519.wpt
@@ -1,5 +1,0 @@
-I-90 http://www.openstreetmap.org/?lat=47.590305&lon=-122.329191
-AtlSt http://www.openstreetmap.org/?lat=47.590283&lon=-122.334169
-1stAve http://www.openstreetmap.org/?lat=47.596375&lon=-122.334217
-KingSt http://www.openstreetmap.org/?lat=47.598318&lon=-122.335628
-YesWay http://www.openstreetmap.org/?lat=47.601703&lon=-122.336540

--- a/hwy_data/WA/usawa/wa.wa525.wpt
+++ b/hwy_data/WA/usawa/wa.wa525.wpt
@@ -2,7 +2,6 @@ I-5 http://www.openstreetmap.org/?lat=47.831769&lon=-122.262082
 AldMallPkwy +28thAve http://www.openstreetmap.org/?lat=47.839234&lon=-122.272317
 WA99 http://www.openstreetmap.org/?lat=47.869150&lon=-122.277403
 LinWay http://www.openstreetmap.org/?lat=47.873382&lon=-122.276598
-OldMukSpe +106thSt http://www.openstreetmap.org/?lat=47.874943&lon=-122.276266
 BevParkRd http://www.openstreetmap.org/?lat=47.882636&lon=-122.280031
 PaiFieBlvd http://www.openstreetmap.org/?lat=47.910338&lon=-122.293298
 +x10 http://www.openstreetmap.org/?lat=47.917679&lon=-122.299837

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -750,7 +750,6 @@ usausb;NV;US95;Trk;Haw;Hawthorne, NV;nv.us095trkhaw;
 usausb;ID;US95;Bus;Cot;Cottonwood, ID;id.us095buscot;
 usausb;ID;US95;Bus;Cra;Craigmont, ID;id.us095buscra;
 usausb;ID;US95;Bus;Win;Winchester, ID;id.us095buswin;
-usausb;ID;US95;Spr;Pay;Payette, ID;id.us095sprpay;
 usausb;ID;US95;Spr;Wei;Weiser, ID;id.us095sprwei;
 usausb;OR;US95;Spr;Wei;Weiser, ID;or.us095sprwei;
 usausb;TX;US96;Bus;Sil;Silsbee, TX;tx.us096bussil;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -739,7 +739,6 @@ usausb;US95;Trk;Hawthorne, NV;nv.us095trkhaw
 usausb;US95;Bus;Cottonwood, ID;id.us095buscot
 usausb;US95;Bus;Craigmont, ID;id.us095buscra
 usausb;US95;Bus;Winchester, ID;id.us095buswin
-usausb;US95;Spr;Payette, ID;id.us095sprpay
 usausb;US95;Spr;Weiser, ID;id.us095sprwei,or.us095sprwei
 usausb;US96;Bus;Silsbee, TX;tx.us096bussil
 usausb;US96;Bus;Buna, TX;tx.us096busbun

--- a/hwy_data/_systems/usawa.csv
+++ b/hwy_data/_systems/usawa.csv
@@ -156,7 +156,6 @@ usawa;WA;WA513;;;;wa.wa513;
 usawa;WA;WA515;;;;wa.wa515;
 usawa;WA;WA516;;;;wa.wa516;
 usawa;WA;WA518;;;;wa.wa518;
-usawa;WA;WA519;;;;wa.wa519;
 usawa;WA;WA520;;;;wa.wa520;
 usawa;WA;WA522;;;;wa.wa522;
 usawa;WA;WA523;;;;wa.wa523;

--- a/hwy_data/_systems/usawa_con.csv
+++ b/hwy_data/_systems/usawa_con.csv
@@ -156,7 +156,6 @@ usawa;WA513;;;wa.wa513
 usawa;WA515;;;wa.wa515
 usawa;WA516;;;wa.wa516
 usawa;WA518;;;wa.wa518
-usawa;WA519;;;wa.wa519
 usawa;WA520;;;wa.wa520
 usawa;WA522;;;wa.wa522
 usawa;WA523;;;wa.wa523

--- a/updates.csv
+++ b/updates.csv
@@ -2382,6 +2382,8 @@
 2017-03-03;(USA) Hawaii;HI 3800;hi.hi3800;Route added
 2015-12-26;(USA) Hawaii;HI 3000;hi.hi3000;Route added
 2015-11-17;(USA) Hawaii;HI 380;hi.hi380;Route relocated from closed Dairy Rd. segment between waypoints AirAccRd and PakSt_N, onto parts of Airport Access Rd. and Pakaula St.
+2019-08-15;(USA) Idaho;ID 39;id.id039;Route extended at south end from intersection at Poactello Avenue to I-86 at exit 40
+2019-08-15;(USA) Idaho;US 95 Spur (Payette);;Route deleted
 2017-07-09;(USA) Idaho;ID 78;id.id078;Truncated at eastern end from I-84 exit 112 to the junction with I-84 BL (Hammett)
 2017-07-09;(USA) Idaho;I-90BL (Osburn);id.i090blosb;Truncated at eastern end from I-90 exit 60 to the Osburn city limits
 2017-06-09;(USA) Idaho;US 30 Business (Lava Hot Springs);;Route deleted
@@ -3329,6 +3331,8 @@
 2018-01-01;(USA) Virginia;US 15 Alt (Farmville);va.us015altfar;New route
 2018-01-01;(USA) Virginia;VA 167;va.va167;New route
 2018-01-01;(USA) Virginia;VA 154 (Covington);;Route deleted
+2019-08-15;(USA) Washington;WA 519;;Route deleted
+2019-07-27;(USA) Washington;WA 240 Business Loop (Richland);wa.wa240busric;Route added
 2019-02-04;(USA) Washington;WA 99;wa.wa099;Route moved off Alaskan Way Viaduct (now permanently closed) and into new SR 99 tunnel betweeen waypoints AlaWay (AtlSt) and AurAve (BroSt)
 2018-11-04;(USA) Washington;Airport Expressway;wa.airexpy;Route added
 2018-09-01;(USA) Washington;WA 193;wa.wa193;Extended approx. 3 miles west to actual end of route


### PR DESCRIPTION
Updates to WA: remove WA 519 due to lack of signage, remove OldMukSpe +106thSt due to its insignificance and proximity to LinWay waypoint
Updates to ID: Remove US 95 Spur Payette due to lack of signage, add shaping point for US 20 in Rigby, extend ID 39 to I-86.