### PR TITLE
NS4 corridor updates

### DIFF
--- a/hwy_data/NS/cannsc/ns.ns245.wpt
+++ b/hwy_data/NS/cannsc/ns.ns245.wpt
@@ -4,8 +4,10 @@ BarRivRd http://www.openstreetmap.org/?lat=45.668436&lon=-62.337341
 ArbRd http://www.openstreetmap.org/?lat=45.690402&lon=-62.289162
 AriPP http://www.openstreetmap.org/?lat=45.754623&lon=-62.166481
 HigRd http://www.openstreetmap.org/?lat=45.779924&lon=-62.121472
-NS337 http://www.openstreetmap.org/?lat=45.783940&lon=-62.081610
+NS337_W +NS337 http://www.openstreetmap.org/?lat=45.783940&lon=-62.081610
 CloRd http://www.openstreetmap.org/?lat=45.730217&lon=-62.042314
 VinLp http://www.openstreetmap.org/?lat=45.663788&lon=-62.033498
 BriBroRd http://www.openstreetmap.org/?lat=45.631502&lon=-62.013991
-NS4_E http://www.openstreetmap.org/?lat=45.621978&lon=-61.994770
+NS337_E http://www.openstreetmap.org/?lat=45.621978&lon=-61.994770
+JamSt http://www.openstreetmap.org/?lat=45.616586&lon=-61.999032
+NS4_E http://www.openstreetmap.org/?lat=45.614199&lon=-61.998613

--- a/hwy_data/NS/cannsc/ns.ns337.wpt
+++ b/hwy_data/NS/cannsc/ns.ns337.wpt
@@ -1,4 +1,4 @@
-NS245 http://www.openstreetmap.org/?lat=45.783940&lon=-62.081610
+NS245_N +NS245 http://www.openstreetmap.org/?lat=45.783940&lon=-62.081610
 +X746208 http://www.openstreetmap.org/?lat=45.805531&lon=-62.060877
 GleRd http://www.openstreetmap.org/?lat=45.826065&lon=-62.016821
 MarRd_W http://www.openstreetmap.org/?lat=45.868118&lon=-61.971783
@@ -11,4 +11,6 @@ MacKenRd http://www.openstreetmap.org/?lat=45.730896&lon=-61.893895
 FaiRd http://www.openstreetmap.org/?lat=45.710899&lon=-61.911742
 SeaRd http://www.openstreetmap.org/?lat=45.674135&lon=-61.919475
 LanRd http://www.openstreetmap.org/?lat=45.634665&lon=-61.962073
-NS4 http://www.openstreetmap.org/?lat=45.624514&lon=-61.984086
+StAndSt +NS4 http://www.openstreetmap.org/?lat=45.624514&lon=-61.984086
+ChuSt http://www.openstreetmap.org/?lat=45.622621&lon=-61.989301
+NS245_S http://www.openstreetmap.org/?lat=45.621978&lon=-61.994770

--- a/hwy_data/NS/cannsf/ns.ns104.wpt
+++ b/hwy_data/NS/cannsf/ns.ns104.wpt
@@ -43,7 +43,8 @@ NB/NS http://www.openstreetmap.org/?lat=45.856543&lon=-64.263668
 26 http://www.openstreetmap.org/?lat=45.571224&lon=-62.605375
 +X26a http://www.openstreetmap.org/?lat=45.592705&lon=-62.536915
 27 http://www.openstreetmap.org/?lat=45.592705&lon=-62.515921
-*ChuRd http://www.openstreetmap.org/?lat=45.589773&lon=-62.502475
++X27a http://www.openstreetmap.org/?lat=45.592172&lon=-62.508291
+*ChuRd http://www.openstreetmap.org/?lat=45.590225&lon=-62.503279
 *OldNS104_Sut http://www.openstreetmap.org/?lat=45.585122&lon=-62.491844
 +X28 http://www.openstreetmap.org/?lat=45.572708&lon=-62.387872
 29 http://www.openstreetmap.org/?lat=45.594203&lon=-62.266420
@@ -61,6 +62,7 @@ NB/NS http://www.openstreetmap.org/?lat=45.856543&lon=-64.263668
 35B http://www.openstreetmap.org/?lat=45.590417&lon=-61.815243
 36 http://www.openstreetmap.org/?lat=45.590700&lon=-61.789855
 36A http://www.openstreetmap.org/?lat=45.588938&lon=-61.774544
+36B http://www.openstreetmap.org/?lat=45.595639&lon=-61.735866
 37 http://www.openstreetmap.org/?lat=45.614040&lon=-61.627713
 +X37a http://www.openstreetmap.org/?lat=45.658866&lon=-61.551235
 38 http://www.openstreetmap.org/?lat=45.676913&lon=-61.538544

--- a/hwy_data/NS/cannss/ns.suntrlant.wpt
+++ b/hwy_data/NS/cannss/ns.suntrlant.wpt
@@ -1,5 +1,7 @@
 NS104 http://www.openstreetmap.org/?lat=45.592705&lon=-62.515921
-NS4_Sut http://www.openstreetmap.org/?lat=45.587062&lon=-62.497711
++X190718 http://www.openstreetmap.org/?lat=45.591293&lon=-62.514862
+*OldNS104 http://www.openstreetmap.org/?lat=45.589404&lon=-62.501881
+NS4_E http://www.openstreetmap.org/?lat=45.587062&lon=-62.497711
 LamRd http://www.openstreetmap.org/?lat=45.606431&lon=-62.478388
 BarRivRd http://www.openstreetmap.org/?lat=45.668436&lon=-62.337341
 ArbRd http://www.openstreetmap.org/?lat=45.690402&lon=-62.289162
@@ -18,4 +20,4 @@ MacKenRd http://www.openstreetmap.org/?lat=45.730896&lon=-61.893895
 FaiRd http://www.openstreetmap.org/?lat=45.710899&lon=-61.911742
 SeaRd http://www.openstreetmap.org/?lat=45.674135&lon=-61.919475
 LanRd http://www.openstreetmap.org/?lat=45.634665&lon=-61.962073
-NS4_Ant http://www.openstreetmap.org/?lat=45.624514&lon=-61.984086
+StAndSt http://www.openstreetmap.org/?lat=45.624514&lon=-61.984086

--- a/hwy_data/NS/cannst/ns.ns004ant.wpt
+++ b/hwy_data/NS/cannst/ns.ns004ant.wpt
@@ -11,5 +11,4 @@ SouRivRd http://www.openstreetmap.org/?lat=45.604937&lon=-61.948124
 *OldNS104_W http://www.openstreetmap.org/?lat=45.604175&lon=-61.928697
 +x48230-8(14.0) http://www.openstreetmap.org/?lat=45.605580&lon=-61.921256
 OldNS104_E http://www.openstreetmap.org/?lat=45.601506&lon=-61.917909
-NS316 http://www.openstreetmap.org/?lat=45.597314&lon=-61.906811
-NS104(35) http://www.openstreetmap.org/?lat=45.600794&lon=-61.904597
+NS316 +NS104(35) http://www.openstreetmap.org/?lat=45.597314&lon=-61.906811

--- a/hwy_data/NS/cannst/ns.ns004ant.wpt
+++ b/hwy_data/NS/cannst/ns.ns004ant.wpt
@@ -2,15 +2,12 @@ NS104(29A) http://www.openstreetmap.org/?lat=45.587690&lon=-62.198805
 BeaMeaRd http://www.openstreetmap.org/?lat=45.570300&lon=-62.131596
 BriBroRd http://www.openstreetmap.org/?lat=45.587581&lon=-62.088512
 SchRd http://www.openstreetmap.org/?lat=45.600779&lon=-62.054988
-NS104(31) http://www.openstreetmap.org/?lat=45.601548&lon=-62.024496
-UniBlvd_W http://www.openstreetmap.org/?lat=45.614119&lon=-62.005030
-NS7 http://www.openstreetmap.org/?lat=45.616586&lon=-61.999032
-NS245 http://www.openstreetmap.org/?lat=45.621978&lon=-61.994770
-ChuSt http://www.openstreetmap.org/?lat=45.622621&lon=-61.989301
-NS337 http://www.openstreetmap.org/?lat=45.624514&lon=-61.984086
-BeeHillDr http://www.openstreetmap.org/?lat=45.616875&lon=-61.971095
-WilPtRd http://www.openstreetmap.org/?lat=45.616097&lon=-61.963535
-UniBlvd_E +NS104(34) http://www.openstreetmap.org/?lat=45.604937&lon=-61.948124
+NS104(31) http://www.openstreetmap.org/?lat=45.601790&lon=-62.024584
+JamSt http://www.openstreetmap.org/?lat=45.614119&lon=-62.005030
+NS7 http://www.openstreetmap.org/?lat=45.614199&lon=-61.998613
+ChuSt http://www.openstreetmap.org/?lat=45.614219&lon=-61.984935
+BeeHillRd http://www.openstreetmap.org/?lat=45.613438&lon=-61.971040
+SouRivRd http://www.openstreetmap.org/?lat=45.604937&lon=-61.948124
 *OldNS104_W http://www.openstreetmap.org/?lat=45.604175&lon=-61.928697
 +x48230-8(14.0) http://www.openstreetmap.org/?lat=45.605580&lon=-61.921256
 OldNS104_E http://www.openstreetmap.org/?lat=45.601506&lon=-61.917909

--- a/hwy_data/NS/cannst/ns.ns004hav.wpt
+++ b/hwy_data/NS/cannst/ns.ns004hav.wpt
@@ -1,5 +1,6 @@
 NS104(36A) http://www.openstreetmap.org/?lat=45.588938&lon=-61.774544
-SumBayRd http://www.openstreetmap.org/?lat=45.607749&lon=-61.713289
+NS104(36B) http://www.openstreetmap.org/?lat=45.603606&lon=-61.733771
+GorRd http://www.openstreetmap.org/?lat=45.607756&lon=-61.709674
 MyeRd http://www.openstreetmap.org/?lat=45.625376&lon=-61.664943
 NS104(37) http://www.openstreetmap.org/?lat=45.614040&lon=-61.627713
 NS16 http://www.openstreetmap.org/?lat=45.607883&lon=-61.613098

--- a/hwy_data/NS/cannst/ns.ns004ngl.wpt
+++ b/hwy_data/NS/cannst/ns.ns004ngl.wpt
@@ -24,6 +24,8 @@ NS347 http://www.openstreetmap.org/?lat=45.582729&lon=-62.637776
 LorSt http://www.openstreetmap.org/?lat=45.582924&lon=-62.624401
 FraMouRd http://www.openstreetmap.org/?lat=45.599863&lon=-62.572517
 NS104(27) http://www.openstreetmap.org/?lat=45.592705&lon=-62.515921
++X190718 http://www.openstreetmap.org/?lat=45.591293&lon=-62.514862
+*OldNS104 http://www.openstreetmap.org/?lat=45.589404&lon=-62.501881
 NS245 http://www.openstreetmap.org/?lat=45.587062&lon=-62.497711
 +x2 http://www.openstreetmap.org/?lat=45.569997&lon=-62.476677
 PieValRd http://www.openstreetmap.org/?lat=45.577813&lon=-62.422575

--- a/hwy_data/NS/cannst/ns.ns007.wpt
+++ b/hwy_data/NS/cannst/ns.ns007.wpt
@@ -93,5 +93,4 @@ OhioEastRd http://www.openstreetmap.org/?lat=45.550813&lon=-62.050679
 PitFarmRd http://www.openstreetmap.org/?lat=45.580598&lon=-62.023830
 CamKinHill http://www.openstreetmap.org/?lat=45.589373&lon=-62.003700
 NS104 http://www.openstreetmap.org/?lat=45.611465&lon=-61.999218
-UniBlvd http://www.openstreetmap.org/?lat=45.614199&lon=-61.998613
-NS4 http://www.openstreetmap.org/?lat=45.616586&lon=-61.999032
+NS4 http://www.openstreetmap.org/?lat=45.614199&lon=-61.998613

--- a/hwy_data/NS/cantch/ns.tchmai.wpt
+++ b/hwy_data/NS/cantch/ns.tchmai.wpt
@@ -43,7 +43,8 @@ NS104(25) http://www.openstreetmap.org/?lat=45.565011&lon=-62.646004
 NS104(26) http://www.openstreetmap.org/?lat=45.571224&lon=-62.605375
 +X26a http://www.openstreetmap.org/?lat=45.592705&lon=-62.536915
 NS104(27) http://www.openstreetmap.org/?lat=45.592705&lon=-62.515921
-*ChuRd http://www.openstreetmap.org/?lat=45.589773&lon=-62.502475
++X27a http://www.openstreetmap.org/?lat=45.592172&lon=-62.508291
+*ChuRd http://www.openstreetmap.org/?lat=45.590225&lon=-62.503279
 *OldNS104_Sut http://www.openstreetmap.org/?lat=45.585122&lon=-62.491844
 +X28 http://www.openstreetmap.org/?lat=45.572708&lon=-62.387872
 NS104(29) http://www.openstreetmap.org/?lat=45.594203&lon=-62.266420
@@ -61,6 +62,7 @@ NS104(35) http://www.openstreetmap.org/?lat=45.600794&lon=-61.904597
 NS104(35B) http://www.openstreetmap.org/?lat=45.590417&lon=-61.815243
 NS104(36) http://www.openstreetmap.org/?lat=45.590700&lon=-61.789855
 NS104(36A) http://www.openstreetmap.org/?lat=45.588938&lon=-61.774544
+NS104(36B) http://www.openstreetmap.org/?lat=45.595639&lon=-61.735866
 NS104(37) http://www.openstreetmap.org/?lat=45.614040&lon=-61.627713
 +X37a http://www.openstreetmap.org/?lat=45.658866&lon=-61.551235
 NS104(38) http://www.openstreetmap.org/?lat=45.676913&lon=-61.538544

--- a/updates.csv
+++ b/updates.csv
@@ -131,7 +131,7 @@
 2015-08-18;(Canada) New Brunswick;TCH (Main);nb.tchmai;Moved from Madawaska Ave. to new freeway between QC/NB border and exit 1
 2017-12-08;(Canada) Northwest Territories;NT 10;nt.nt010;New route
 2017-12-08;(Canada) Northwest Territories;NT 1;nt.nt001;West end truncated from Wrigley village centre, to Tulita winter road entrance southeast of Wrigley
-2019-09-02;(Canada) Nova Scotia;NS 4 (Antigonish);ns.ns004ant;Removed from James Street, NS 245, NS 337, Saint Andrews Street and South River Road, and relocated onto the pre-2012 alignment of NS 104, directly from James Street to South River Road.
+2019-09-02;(Canada) Nova Scotia;NS 4 (Antigonish);ns.ns004ant;Removed from James Street, NS 245, NS 337, Saint Andrews Street and South River Road, and relocated onto the pre-2012 alignment of NS 104, directly from James Street to South River Road. East end truncated from NS104 Exit 35 to NS 316.
 2019-09-02;(Canada) Nova Scotia;NS 7;ns.ns007;East end truncated from James Street to NS 4.
 2019-09-02;(Canada) Nova Scotia;NS 245;ns.ns245;Extended eastward from NS 227 to NS 4.
 2019-09-02;(Canada) Nova Scotia;NS 337;ns.ns337;Extended southward from Saint Andrews Street to NS 245.

--- a/updates.csv
+++ b/updates.csv
@@ -131,6 +131,10 @@
 2015-08-18;(Canada) New Brunswick;TCH (Main);nb.tchmai;Moved from Madawaska Ave. to new freeway between QC/NB border and exit 1
 2017-12-08;(Canada) Northwest Territories;NT 10;nt.nt010;New route
 2017-12-08;(Canada) Northwest Territories;NT 1;nt.nt001;West end truncated from Wrigley village centre, to Tulita winter road entrance southeast of Wrigley
+2019-09-02;(Canada) Nova Scotia;NS 4 (Antigonish);ns.ns004ant;Removed from James Street, NS 245, NS 337, Saint Andrews Street and South River Road, and relocated onto the pre-2012 alignment of NS 104, directly from James Street to South River Road.
+2019-09-02;(Canada) Nova Scotia;NS 7;ns.ns007;East end truncated from James Street to NS 4.
+2019-09-02;(Canada) Nova Scotia;NS 245;ns.ns245;Extended eastward from NS 227 to NS 4.
+2019-09-02;(Canada) Nova Scotia;NS 337;ns.ns337;Extended southward from Saint Andrews Street to NS 245.
 2016-11-19;(Canada) Nova Scotia;NS 103;ns.ns103;Removed from closed two-lane highway and the surface road through Port Mouton village (now partially NS3), and relocated onto the northwestern Port Mouton bypass between closed intersections labeled *OldNS103_Sum & *OldNS103_PMo
 2016-11-19;(Canada) Nova Scotia;NS 104;ns.ns104;Removed from a closed temporary connector and NS 4, and relocated onto a parallel four-lane divided highway between closed intersections labeled *OldNS104_Ant & *OldNS104_LSR
 2016-11-19;(Canada) Nova Scotia;NS 3 (Liverpool);ns.ns003liv;West end removed from a closed roadway between a point labeled *OldNS3 and the closed former alignment of NS 103, and relocated onto the surface road through Port Mouton village and a new access road to NS 103 Exit 21


### PR DESCRIPTION
* **NS4Ant** relocated completely off its original CHM alignment, onto the original (before Phase 1 Antigonish bypass) NS104.
* **NS7** truncated from James St (old NS4) to new NS4.
* **NS245** extended over old NS4 and the vacated segment of NS7, to new NS4.
* **NS337** extended over old NS4 to NS245.
* **NS104/TCHMai** gets tightened up near the old alignment at `*ChuRd`, and receives new Exit 36B.
* **NS4NGl** gets a `*OldNS104` point, for the former transition to/from `NS NS104 *ChuRd`.
* **NS4Hav** receives new `NS104(36B)` point.