### PR TITLE
CA I-10 and CA 111 updates

### DIFF
--- a/hwy_data/CA/usaca/ca.ca111.wpt
+++ b/hwy_data/CA/usaca/ca.ca111.wpt
@@ -1,5 +1,4 @@
-End http://www.openstreetmap.org/?lat=32.666051&lon=-115.498629
-2ndSt http://www.openstreetmap.org/?lat=32.666655&lon=-115.498667
+2ndSt +End http://www.openstreetmap.org/?lat=32.666655&lon=-115.498667
 CA98 http://www.openstreetmap.org/?lat=32.679068&lon=-115.498699
 CA86_S http://www.openstreetmap.org/?lat=32.730604&lon=-115.500469
 I-8 http://www.openstreetmap.org/?lat=32.773778&lon=-115.501199
@@ -12,14 +11,12 @@ CA78_W http://www.openstreetmap.org/?lat=33.000530&lon=-115.526390
 CRS26 http://www.openstreetmap.org/?lat=33.044469&lon=-115.527484
 CA115 http://www.openstreetmap.org/?lat=33.125743&lon=-115.514245
 MainSt http://www.openstreetmap.org/?lat=33.240193&lon=-115.519115
-+x11 http://www.openstreetmap.org/?lat=33.243038&lon=-115.519180
-+x12 http://www.openstreetmap.org/?lat=33.265492&lon=-115.562611
 DavRd http://www.openstreetmap.org/?lat=33.285198&lon=-115.578902
 NilMarRd http://www.openstreetmap.org/?lat=33.360726&lon=-115.646714
 HotSpaRd http://www.openstreetmap.org/?lat=33.376932&lon=-115.693899
 AveA http://www.openstreetmap.org/?lat=33.357662&lon=-115.733929
 RanRd http://www.openstreetmap.org/?lat=33.368008&lon=-115.770562
-SaltCrkPL http://www.openstreetmap.org/?lat=33.442606&lon=-115.841308
+SaltCrkBea +SaltCrkPL http://www.openstreetmap.org/?lat=33.442606&lon=-115.841308
 BayDr http://www.openstreetmap.org/?lat=33.527254&lon=-115.941494
 ColSt http://www.openstreetmap.org/?lat=33.542544&lon=-116.035098
 GraBlvd http://www.openstreetmap.org/?lat=33.569709&lon=-116.078453

--- a/hwy_data/CA/usaca/ca.ca111pal.wpt
+++ b/hwy_data/CA/usaca/ca.ca111pal.wpt
@@ -2,9 +2,9 @@ PalmSprLim http://www.openstreetmap.org/?lat=33.790597&lon=-116.485956
 CA111Bus_S http://www.openstreetmap.org/?lat=33.793368&lon=-116.495161
 DinShoDr http://www.openstreetmap.org/?lat=33.808551&lon=-116.492929
 RamRd http://www.openstreetmap.org/?lat=33.815831&lon=-116.492983
-VisChi http://www.openstreetmap.org/?lat=33.844879&lon=-116.505783
+VisChi_E +VisChi http://www.openstreetmap.org/?lat=33.844879&lon=-116.505783
 SunWay http://www.openstreetmap.org/?lat=33.844830&lon=-116.528152
 CA111Bus_N http://www.openstreetmap.org/?lat=33.844862&lon=-116.546756
-TraBlvd http://www.openstreetmap.org/?lat=33.858315&lon=-116.557415
+TraRd +TraBlvd http://www.openstreetmap.org/?lat=33.858315&lon=-116.557415
 OveDr http://www.openstreetmap.org/?lat=33.888978&lon=-116.606156
-I-10 http://www.openstreetmap.org/?lat=33.923762&lon=-116.689471
+I-10 http://www.openstreetmap.org/?lat=33.922478&lon=-116.679805

--- a/hwy_data/CA/usai/ca.i010.wpt
+++ b/hwy_data/CA/usai/ca.i010.wpt
@@ -117,8 +117,8 @@
 103 http://www.openstreetmap.org/?lat=33.930978&lon=-116.821731
 104 http://www.openstreetmap.org/?lat=33.921287&lon=-116.806447
 106 http://www.openstreetmap.org/?lat=33.918727&lon=-116.776997
-111 http://www.openstreetmap.org/?lat=33.923762&lon=-116.689471
-112 http://www.openstreetmap.org/?lat=33.922478&lon=-116.679805
+110 http://www.openstreetmap.org/?lat=33.923762&lon=-116.689471
+111 +112 http://www.openstreetmap.org/?lat=33.922478&lon=-116.679805
 114 http://www.openstreetmap.org/?lat=33.923513&lon=-116.644774
 117 http://www.openstreetmap.org/?lat=33.914312&lon=-116.603833
 120 http://www.openstreetmap.org/?lat=33.904651&lon=-116.545334


### PR DESCRIPTION
Updates flagged in usaca peer review, and discussed in that forum thread.

CA I-10 label error fixes are in exit 110-112 range. No Updates entries needed. 110 and 111 are not in use, and 112 becomes an alternate label for 111.