### PR TITLE
ME US1: I-495 +-> METpk

### DIFF
--- a/hwy_data/ME/usaus/me.us001.wpt
+++ b/hwy_data/ME/usaus/me.us001.wpt
@@ -58,7 +58,7 @@ I-295(9) http://www.openstreetmap.org/?lat=43.685383&lon=-70.252166
 ME88_S http://www.openstreetmap.org/?lat=43.709517&lon=-70.234566
 DepRd http://www.openstreetmap.org/?lat=43.721808&lon=-70.232597
 BucRd http://www.openstreetmap.org/?lat=43.725987&lon=-70.231690
-I-495 http://www.openstreetmap.org/?lat=43.730205&lon=-70.228987
+METpk +I-495 http://www.openstreetmap.org/?lat=43.730205&lon=-70.228987
 JohRd http://www.openstreetmap.org/?lat=43.740011&lon=-70.220516
 TutRd http://www.openstreetmap.org/?lat=43.770009&lon=-70.201907
 I-295(15) http://www.openstreetmap.org/?lat=43.784852&lon=-70.190320


### PR DESCRIPTION
"Waypoint labels should avoid secret highway designations, i.e., designations travelers will not know about by driving and reading signs."