### PR TITLE
WI136 AltRouteNames

### DIFF
--- a/hwy_data/WI/usawi/wi.wi136.wpt
+++ b/hwy_data/WI/usawi/wi.wi136.wpt
@@ -8,6 +8,6 @@ CRI http://www.openstreetmap.org/?lat=43.475019&lon=-89.869580
 US12/33 http://www.openstreetmap.org/?lat=43.474722&lon=-89.774780
 WI33_E http://www.openstreetmap.org/?lat=43.474660&lon=-89.768772
 US12Bus http://www.openstreetmap.org/?lat=43.459959&lon=-89.768858
-PoiRocRd http://www.openstreetmap.org/?lat=43.438212&lon=-89.768944
-CRDL +WI123 http://www.openstreetmap.org/?lat=43.438228&lon=-89.743752
-ParkRd http://www.openstreetmap.org/?lat=43.434520&lon=-89.739847
+PoiRocRd +US12 http://www.openstreetmap.org/?lat=43.438212&lon=-89.768944
+CRDL +WI123 +WI159 http://www.openstreetmap.org/?lat=43.438228&lon=-89.743752
+ParkRd CRDI http://www.openstreetmap.org/?lat=43.434520&lon=-89.739847

--- a/hwy_data/_systems/usawi.csv
+++ b/hwy_data/_systems/usawi.csv
@@ -121,7 +121,7 @@ usawi;WI;WI130;;;;wi.wi130;
 usawi;WI;WI131;;;;wi.wi131;
 usawi;WI;WI133;;;;wi.wi133;
 usawi;WI;WI134;;;;wi.wi134;
-usawi;WI;WI136;;;;wi.wi136;
+usawi;WI;WI136;;;;wi.wi136;WI159,WI123
 usawi;WI;WI137;;;;wi.wi137;
 usawi;WI;WI138;;;;wi.wi138;
 usawi;WI;WI139;;;;wi.wi139;


### PR DESCRIPTION
Fixes some broken list lines:
> **bulldog1979.list:** WI WI123 CRDL WI33
**bulldog1979.list:** WI WI159 US12 WI123
**imgoph.list:** WI WI123 CRDL WI159
**imgoph.list:** WI WI159 US12 WI123
**julmac.list:** WI WI123 WI33 CRDI
**keithcavey.list:** WI WI123 CRDL WI159
**keithcavey.list:** WI WI123 WI113_S WI33
**keithcavey.list:** WI WI159 US12 WI123
**sipes23.list:** WI WI123 CRDL WI33
**sipes23.list:** WI WI159 US12 ParkRd

I'd like to get Jeff's approval for this [on the forum](http://forum.travelmapping.net/index.php?topic=3422).