### PR TITLE
update nci785futrei.wpt to match nc.us029.wpt

### DIFF
--- a/hwy_data/NC/usaif/nc.i785futrei.wpt
+++ b/hwy_data/NC/usaif/nc.i785futrei.wpt
@@ -2,7 +2,7 @@ US29Bus_S http://www.openstreetmap.org/?lat=36.261110&lon=-79.651684
 +y10 http://www.openstreetmap.org/?lat=36.277087&lon=-79.640064
 NC87 http://www.openstreetmap.org/?lat=36.311563&lon=-79.645139
 BarSt http://www.openstreetmap.org/?lat=36.327193&lon=-79.643101
-US158/14 http://www.openstreetmap.org/?lat=36.359867&lon=-79.626664
+US158/14 http://www.openstreetmap.org/?lat=36.360066&lon=-79.627361
 NarGauRd http://www.openstreetmap.org/?lat=36.400940&lon=-79.597836
 US29Bus http://www.openstreetmap.org/?lat=36.434361&lon=-79.572591
 US29Bus_N http://www.openstreetmap.org/?lat=36.456265&lon=-79.543505


### PR DESCRIPTION
NC US29 was updated to realign the intersection of US29 with US158/14, but the same was not done for NC I-785 Future Reidsville -- so the segments BarSt to US158/14 and US158/14 to NarGauRd are not concurrent between the two routes. Reference commit: https://github.com/TravelMapping/HighwayData/commit/50bacb640e15c876d1a5eeea72c93f1ddd3c0512#diff-a026dc22b59eab7dd05e9f329f186636L117