### PR TITLE
US 322 TRUCK (Downingtown) Extension and Other Misc. PA Changes

### DIFF
--- a/hwy_data/PA/usai/pa.i095.wpt
+++ b/hwy_data/PA/usai/pa.i095.wpt
@@ -19,8 +19,9 @@ DE/PA +0 http://www.openstreetmap.org/?lat=39.819068&lon=-75.449595
 20 http://www.openstreetmap.org/?lat=39.933460&lon=-75.145245
 22A +21 http://www.openstreetmap.org/?lat=39.948947&lon=-75.141720
 22 http://www.openstreetmap.org/?lat=39.956514&lon=-75.141056
-23 http://www.openstreetmap.org/?lat=39.972158&lon=-75.122334
-25 http://www.openstreetmap.org/?lat=39.982162&lon=-75.100747
++X02 http://www.openstreetmap.org/?lat=39.965107&lon=-75.137373
+23 http://www.openstreetmap.org/?lat=39.972191&lon=-75.122358
+25 http://www.openstreetmap.org/?lat=39.982162&lon=-75.100718
 25A http://www.openstreetmap.org/?lat=39.988202&lon=-75.088849
 26 http://www.openstreetmap.org/?lat=39.997424&lon=-75.081875
 26A http://www.openstreetmap.org/?lat=40.005222&lon=-75.075650

--- a/hwy_data/PA/usapa/pa.pa003.wpt
+++ b/hwy_data/PA/usapa/pa.pa003.wpt
@@ -4,6 +4,8 @@ US202/322 http://www.openstreetmap.org/?lat=39.967457&lon=-75.581753
 PA352_N http://www.openstreetmap.org/?lat=39.966542&lon=-75.522914
 PA352_S http://www.openstreetmap.org/?lat=39.966376&lon=-75.520500
 PA926 http://www.openstreetmap.org/?lat=39.965033&lon=-75.488734
+DelRd http://www.openstreetmap.org/?lat=39.969420&lon=-75.474862
+SanFlaDr http://www.openstreetmap.org/?lat=39.973254&lon=-75.458806
 PA252AltTrk_S http://www.openstreetmap.org/?lat=39.974660&lon=-75.450231
 PA252 +PA252/252Trk http://www.openstreetmap.org/?lat=39.986806&lon=-75.400760
 BrynMawrAve http://www.openstreetmap.org/?lat=39.985088&lon=-75.392558

--- a/hwy_data/PA/usapa/pa.pa073.wpt
+++ b/hwy_data/PA/usapa/pa.pa073.wpt
@@ -34,6 +34,7 @@ PA363 http://www.openstreetmap.org/?lat=40.201240&lon=-75.346513
 NorWalRd http://www.openstreetmap.org/?lat=40.177970&lon=-75.308484
 US202 http://www.openstreetmap.org/?lat=40.166992&lon=-75.290278
 ButPk http://www.openstreetmap.org/?lat=40.138960&lon=-75.244278
+JosRd http://www.openstreetmap.org/?lat=40.127927&lon=-75.226422
 BetPk_N http://www.openstreetmap.org/?lat=40.122228&lon=-75.217209
 BetPk_S http://www.openstreetmap.org/?lat=40.119649&lon=-75.215650
 PA309 http://www.openstreetmap.org/?lat=40.113071&lon=-75.200990
@@ -44,6 +45,7 @@ WasLn_N http://www.openstreetmap.org/?lat=40.089315&lon=-75.131721
 PA611 http://www.openstreetmap.org/?lat=40.087029&lon=-75.127873
 ChuRd http://www.openstreetmap.org/?lat=40.070172&lon=-75.098556
 PA232 http://www.openstreetmap.org/?lat=40.061255&lon=-75.083509
+CasAve http://www.openstreetmap.org/?lat=40.051199&lon=-75.066099
 US1 http://www.openstreetmap.org/?lat=40.044487&lon=-75.054364
 US13 http://www.openstreetmap.org/?lat=40.036762&lon=-75.040859
 CotAve_E +NewStaRd_E http://www.openstreetmap.org/?lat=40.025671&lon=-75.031635

--- a/hwy_data/PA/usapa/pa.pa100.wpt
+++ b/hwy_data/PA/usapa/pa.pa100.wpt
@@ -1,5 +1,6 @@
 US202 http://www.openstreetmap.org/?lat=39.991079&lon=-75.588984
 PotPk http://www.openstreetmap.org/?lat=40.012652&lon=-75.616364
+MouDr http://www.openstreetmap.org/?lat=40.017819&lon=-75.622249
 US30 http://www.openstreetmap.org/?lat=40.020758&lon=-75.624036
 US30Bus http://www.openstreetmap.org/?lat=40.028146&lon=-75.628290
 ShipRd http://www.openstreetmap.org/?lat=40.049879&lon=-75.635805

--- a/hwy_data/PA/usapa/pa.pa113.wpt
+++ b/hwy_data/PA/usapa/pa.pa113.wpt
@@ -1,5 +1,5 @@
 US30Bus http://www.openstreetmap.org/?lat=40.011408&lon=-75.695441
-US30 http://www.openstreetmap.org/?lat=40.019750&lon=-75.694014
+US30 http://www.openstreetmap.org/?lat=40.019750&lon=-75.694055
 PA100 http://www.openstreetmap.org/?lat=40.056728&lon=-75.657134
 PA401 http://www.openstreetmap.org/?lat=40.078478&lon=-75.634282
 HarHillRd http://www.openstreetmap.org/?lat=40.123741&lon=-75.580616

--- a/hwy_data/PA/usaus/pa.us030.wpt
+++ b/hwy_data/PA/usaus/pa.us030.wpt
@@ -215,7 +215,7 @@ ReeRd http://www.openstreetmap.org/?lat=40.006280&lon=-75.789836
 PA340_E http://www.openstreetmap.org/?lat=40.008016&lon=-75.745454
 US322 http://www.openstreetmap.org/?lat=40.012696&lon=-75.725461
 NorRd http://www.openstreetmap.org/?lat=40.018322&lon=-75.703855
-PA113 http://www.openstreetmap.org/?lat=40.019750&lon=-75.694014
+PA113 http://www.openstreetmap.org/?lat=40.019750&lon=-75.694055
 US30BusDow http://www.openstreetmap.org/?lat=40.019086&lon=-75.675212
 +X113 http://www.openstreetmap.org/?lat=40.013162&lon=-75.646700
 PA100 http://www.openstreetmap.org/?lat=40.020758&lon=-75.624036

--- a/hwy_data/PA/usaus/pa.us030.wpt
+++ b/hwy_data/PA/usaus/pa.us030.wpt
@@ -216,7 +216,7 @@ PA340_E http://www.openstreetmap.org/?lat=40.008016&lon=-75.745454
 US322 http://www.openstreetmap.org/?lat=40.012696&lon=-75.725461
 NorRd http://www.openstreetmap.org/?lat=40.018322&lon=-75.703855
 PA113 http://www.openstreetmap.org/?lat=40.019750&lon=-75.694055
-US30BusDow http://www.openstreetmap.org/?lat=40.019086&lon=-75.675212
+US30BusDow_A  +US30BusDow http://www.openstreetmap.org/?lat=40.019086&lon=-75.675212
 +X113 http://www.openstreetmap.org/?lat=40.013162&lon=-75.646700
 PA100 http://www.openstreetmap.org/?lat=40.020758&lon=-75.624036
 US202 http://www.openstreetmap.org/?lat=40.033026&lon=-75.585157

--- a/hwy_data/PA/usaus/pa.us322.wpt
+++ b/hwy_data/PA/usaus/pa.us322.wpt
@@ -236,6 +236,7 @@ SugBriRd http://www.openstreetmap.org/?lat=39.968460&lon=-75.675011
 CreRd http://www.openstreetmap.org/?lat=39.967831&lon=-75.657984
 US322BusWes_W http://www.openstreetmap.org/?lat=39.966185&lon=-75.632595
 PotPk http://www.openstreetmap.org/?lat=39.973159&lon=-75.614616
+PhoPk http://www.openstreetmap.org/?lat=39.981991&lon=-75.594550
 US202_N http://www.openstreetmap.org/?lat=39.980343&lon=-75.588126
 PaoPk http://www.openstreetmap.org/?lat=39.971054&lon=-75.582998
 PA3 http://www.openstreetmap.org/?lat=39.967457&lon=-75.581753

--- a/hwy_data/PA/usausb/pa.us322trkdow.wpt
+++ b/hwy_data/PA/usausb/pa.us322trkdow.wpt
@@ -1,7 +1,18 @@
 US30Bus/322 http://www.openstreetmap.org/?lat=40.005331&lon=-75.705953
 US322_W http://www.openstreetmap.org/?lat=40.012696&lon=-75.725461
 NorRd http://www.openstreetmap.org/?lat=40.018322&lon=-75.703855
-US30/113 http://www.openstreetmap.org/?lat=40.019750&lon=-75.694014
-US30Bus/113  +PA113 http://www.openstreetmap.org/?lat=40.011408&lon=-75.695441
+US30/113 http://www.openstreetmap.org/?lat=40.019750&lon=-75.694055
+US30Bus/113 +PA113 http://www.openstreetmap.org/?lat=40.011408&lon=-75.695441
 QuaRd +US30Bus_E http://www.openstreetmap.org/?lat=40.018936&lon=-75.675877
-US30 http://www.openstreetmap.org/?lat=40.019086&lon=-75.675212
+US30/30Bus +US30 http://www.openstreetmap.org/?lat=40.019086&lon=-75.675212
++X113 http://www.openstreetmap.org/?lat=40.013162&lon=-75.646700
+US30/100 http://www.openstreetmap.org/?lat=40.020758&lon=-75.624036
+MouDr http://www.openstreetmap.org/?lat=40.017819&lon=-75.622249
+PotPk http://www.openstreetmap.org/?lat=40.012652&lon=-75.616364
+US202/100 http://www.openstreetmap.org/?lat=39.991079&lon=-75.588984
+US322_WesW http://www.openstreetmap.org/?lat=39.980343&lon=-75.588126
+US202/322 http://www.openstreetmap.org/?lat=39.971054&lon=-75.582998
+PA3_E http://www.openstreetmap.org/?lat=39.966016&lon=-75.591763  
+US322Bus/3 http://www.openstreetmap.org/?lat=39.960482&lon=-75.605220
+PA162 http://www.openstreetmap.org/?lat=39.959269&lon=-75.615619
+US322_E http://www.openstreetmap.org/?lat=39.966185&lon=-75.632595

--- a/updates.csv
+++ b/updates.csv
@@ -3460,6 +3460,7 @@
 2017-09-06;(USA) Oregon;OR 99;or.or099;Restored route from I-5 onto Yoncalla-Drain routing.
 2017-09-06;(USA) Oregon;OR 99W;or.or099w;Truncated route from I-5(306) to I-5(294) to reflect signage and prepare for Oregon Highways dataset.
 2017-09-06;(USA) Oregon;OR 126;or.or126;Moved route from Bus 97 to US 97 in Redmond.
+2020-02-16;(USA) Pennsylvania;US 322 Truck (Downingtown);pa.us322trkdow;Extended to US 322/US 322 Business (West Chester) on the northwest side of West Chester via US 30, PA 100, US 202, Paoli Pike, PA 3, and US 322 Business (West Chester).  Note that the part in West Chester is WB only.
 2020-02-14;(USA) Pennsylvania;US 62;pa.us062;Realigned at Allegheny River Bridge and Hunter Station Rd (HunStaRd) between *OldUS62_A and *OldUS62_B. 
 2020-02-14;(USA) Pennsylvania;PA 8 Business (Oil City);pa.pa008busoil;Relocated onto now two-way section of Seneca St between Clifford St (CliSt) and Duncomb St (DunSt) in Oil City.
 2020-01-22;(USA) Pennsylvania;PA 662;pa.pa662;Realigned between *OldPA662_C and MainSt_A as a result of a roundabout recently opened at PA73_W. 


### PR DESCRIPTION
US 322 TRUCK (Downingtown): Extended to US 322/US 322 Business (West Chester) on the northwest side of West Chester via US 30, PA 100, US 202, Paoli Pike, PA 3, and US 322 Business (West Chester).  Note that the part in West Chester is WB only. (http://forum.travelmapping.net/index.php?topic=2779.0)

Other Changes:
I-95: Added +X02.
US 30: Changed US30BusDow Label to US30BusDow_A.  (see [US460BusChr labels on US 460](http://travelmapping.net/hb/index.php?units=miles&u=markkos1992&r=va.us460) for precendent)
US 322: Added Phoenixville Pike (PhoPk).
PA 3: Added Delchester Rd (DelRd) and Sandy Flash Dr (SanFlaDr).
PA 73: Added Joshua Rd (JosRd) (for Fort Washington State Park) and Castor Ave (CasAve).
PA 100: Added Mountainview Dr (MouDr).
