### PR TITLE
PA Pk to Pike Changes Part 2 

### DIFF
--- a/hwy_data/PA/usapa/pa.pa029pho.wpt
+++ b/hwy_data/PA/usapa/pa.pa029pho.wpt
@@ -1,8 +1,8 @@
 US30 http://www.openstreetmap.org/?lat=40.043920&lon=-75.523745
 US202 http://www.openstreetmap.org/?lat=40.051423&lon=-75.526508
 I-76 http://www.openstreetmap.org/?lat=40.069613&lon=-75.536520
-PhoPk http://www.openstreetmap.org/?lat=40.077454&lon=-75.539052
-PeaPk +PeaPikRd http://www.openstreetmap.org/?lat=40.098116&lon=-75.543221
+PhoPike +PhoPk http://www.openstreetmap.org/?lat=40.077454&lon=-75.539052
+PeaPike +PeaPikRd http://www.openstreetmap.org/?lat=40.098116&lon=-75.543221
 PotRd http://www.openstreetmap.org/?lat=40.113783&lon=-75.522155
 PA23 http://www.openstreetmap.org/?lat=40.123507&lon=-75.512587
 StaSt_S http://www.openstreetmap.org/?lat=40.126231&lon=-75.509892

--- a/hwy_data/PA/usapa/pa.pa031.wpt
+++ b/hwy_data/PA/usapa/pa.pa031.wpt
@@ -2,7 +2,7 @@ PA136 http://www.openstreetmap.org/?lat=40.205116&lon=-79.753433
 MotRd http://www.openstreetmap.org/?lat=40.194536&lon=-79.728743
 I-70 http://www.openstreetmap.org/?lat=40.188576&lon=-79.700985
 WalMillRd http://www.openstreetmap.org/?lat=40.177478&lon=-79.667608
-PitPk http://www.openstreetmap.org/?lat=40.180111&lon=-79.635649
+PitPike http://www.openstreetmap.org/?lat=40.180111&lon=-79.635649
 ButRd http://www.openstreetmap.org/?lat=40.173588&lon=-79.611566
 CenRd http://www.openstreetmap.org/?lat=40.168253&lon=-79.587241
 SchRd http://www.openstreetmap.org/?lat=40.166271&lon=-79.574149

--- a/hwy_data/PA/usapa/pa.pa032.wpt
+++ b/hwy_data/PA/usapa/pa.pa032.wpt
@@ -20,7 +20,7 @@ PA263 http://www.openstreetmap.org/?lat=40.401021&lon=-74.980268
 GreRd http://www.openstreetmap.org/?lat=40.402955&lon=-75.030254
 FleRd http://www.openstreetmap.org/?lat=40.408019&lon=-75.041867
 +X3R http://www.openstreetmap.org/?lat=40.416288&lon=-75.058942
-PoiPlePk http://www.openstreetmap.org/?lat=40.422595&lon=-75.066418
+PoiPlePike http://www.openstreetmap.org/?lat=40.422595&lon=-75.066418
 +X4R http://www.openstreetmap.org/?lat=40.458487&lon=-75.074666
 SmiRd http://www.openstreetmap.org/?lat=40.462628&lon=-75.072675
 DarkHolRd http://www.openstreetmap.org/?lat=40.481326&lon=-75.069387

--- a/hwy_data/PA/usapa/pa.pa041.wpt
+++ b/hwy_data/PA/usapa/pa.pa041.wpt
@@ -1,9 +1,9 @@
 DE/PA http://www.openstreetmap.org/?lat=39.794482&lon=-75.713951
 LimRd http://www.openstreetmap.org/?lat=39.798229&lon=-75.724956
 NewRd http://www.openstreetmap.org/?lat=39.809119&lon=-75.751261
-BalPk http://www.openstreetmap.org/?lat=39.822902&lon=-75.780985
+BalPike http://www.openstreetmap.org/?lat=39.822902&lon=-75.780985
 StaSt http://www.openstreetmap.org/?lat=39.824777&lon=-75.783278
-OldBalPk http://www.openstreetmap.org/?lat=39.834322&lon=-75.793519
+OldBalPike +OldBalPk http://www.openstreetmap.org/?lat=39.834322&lon=-75.793519
 US1 http://www.openstreetmap.org/?lat=39.840332&lon=-75.802928
 PA841 http://www.openstreetmap.org/?lat=39.854098&lon=-75.821304
 WhiRd http://www.openstreetmap.org/?lat=39.865904&lon=-75.858828

--- a/hwy_data/PA/usapa/pa.pa048.wpt
+++ b/hwy_data/PA/usapa/pa.pa048.wpt
@@ -17,5 +17,5 @@ US30 http://www.openstreetmap.org/?lat=40.368001&lon=-79.779812
 PA130 http://www.openstreetmap.org/?lat=40.397675&lon=-79.769341
 HilAve http://www.openstreetmap.org/?lat=40.404718&lon=-79.762233
 HayRd http://www.openstreetmap.org/?lat=40.429846&lon=-79.751277
-NorPk http://www.openstreetmap.org/?lat=40.433986&lon=-79.753256
+NorPike  +NorPk http://www.openstreetmap.org/?lat=40.433986&lon=-79.753256
 US22Bus +US22BusMon http://www.openstreetmap.org/?lat=40.438923&lon=-79.760557

--- a/hwy_data/PA/usapa/pa.pa073.wpt
+++ b/hwy_data/PA/usapa/pa.pa073.wpt
@@ -33,10 +33,10 @@ BusRd http://www.openstreetmap.org/?lat=40.212496&lon=-75.368762
 PA363 http://www.openstreetmap.org/?lat=40.201240&lon=-75.346513
 NorWalRd http://www.openstreetmap.org/?lat=40.177970&lon=-75.308484
 US202 http://www.openstreetmap.org/?lat=40.166992&lon=-75.290278
-ButPk http://www.openstreetmap.org/?lat=40.138960&lon=-75.244278
+ButPike http://www.openstreetmap.org/?lat=40.138972&lon=-75.244264
 JosRd http://www.openstreetmap.org/?lat=40.127927&lon=-75.226422
-BetPk_N http://www.openstreetmap.org/?lat=40.122228&lon=-75.217209
-BetPk_S http://www.openstreetmap.org/?lat=40.119649&lon=-75.215650
+BetPike_N http://www.openstreetmap.org/?lat=40.122228&lon=-75.217209
+BetPike_S http://www.openstreetmap.org/?lat=40.119649&lon=-75.215650
 PA309 http://www.openstreetmap.org/?lat=40.113071&lon=-75.200990
 PapMillRd http://www.openstreetmap.org/?lat=40.106558&lon=-75.189145
 PA152 http://www.openstreetmap.org/?lat=40.093072&lon=-75.161931

--- a/hwy_data/PA/usapa/pa.pa152.wpt
+++ b/hwy_data/PA/usapa/pa.pa152.wpt
@@ -9,7 +9,7 @@ VirDr http://www.openstreetmap.org/?lat=40.142985&lon=-75.167754
 FortWasAve http://www.openstreetmap.org/?lat=40.165670&lon=-75.182450
 NorRd http://www.openstreetmap.org/?lat=40.179084&lon=-75.183126
 PA63 http://www.openstreetmap.org/?lat=40.180791&lon=-75.183169
-ButPk http://www.openstreetmap.org/?lat=40.188406&lon=-75.183220
+ButPike http://www.openstreetmap.org/?lat=40.188406&lon=-75.183220
 PA463 http://www.openstreetmap.org/?lat=40.212099&lon=-75.185899
 LowStaRd_W http://www.openstreetmap.org/?lat=40.236682&lon=-75.191873
 LowStaRd_E http://www.openstreetmap.org/?lat=40.238594&lon=-75.191336
@@ -20,11 +20,11 @@ US202 http://www.openstreetmap.org/?lat=40.267018&lon=-75.199163
 US202Bus_S +StaSt_W +US202_S http://www.openstreetmap.org/?lat=40.284109&lon=-75.209956
 US202Bus_N +StaSt_E +US202_N http://www.openstreetmap.org/?lat=40.285746&lon=-75.207826
 NewGalRd http://www.openstreetmap.org/?lat=40.306328&lon=-75.220331
-HilPk_S http://www.openstreetmap.org/?lat=40.323252&lon=-75.239731
-HilPk_N http://www.openstreetmap.org/?lat=40.330174&lon=-75.237476
+HilPike_S http://www.openstreetmap.org/?lat=40.323252&lon=-75.239731
+HilPike_N http://www.openstreetmap.org/?lat=40.330174&lon=-75.237476
 PA113_N http://www.openstreetmap.org/?lat=40.349015&lon=-75.270145
 PA113_S http://www.openstreetmap.org/?lat=40.347701&lon=-75.271438
 WalSt_W http://www.openstreetmap.org/?lat=40.367382&lon=-75.293614
 MainSt_N +MainSt http://www.openstreetmap.org/?lat=40.356977&lon=-75.306652
-BetPk http://www.openstreetmap.org/?lat=40.345187&lon=-75.303605
+BetPike  +BetPk http://www.openstreetmap.org/?lat=40.345187&lon=-75.303605
 PA309_N http://www.openstreetmap.org/?lat=40.342738&lon=-75.317931

--- a/hwy_data/PA/usapa/pa.pa163.wpt
+++ b/hwy_data/PA/usapa/pa.pa163.wpt
@@ -1,4 +1,4 @@
 MD/PA http://www.openstreetmap.org/?lat=39.721225&lon=-77.768320
-WilPk http://www.openstreetmap.org/?lat=39.721784&lon=-77.768290
+WilPike  +WilPk http://www.openstreetmap.org/?lat=39.721784&lon=-77.768290
 I-81 http://www.openstreetmap.org/?lat=39.721240&lon=-77.732517
 US11 http://www.openstreetmap.org/?lat=39.721396&lon=-77.724141

--- a/hwy_data/PA/usapa/pa.pa213.wpt
+++ b/hwy_data/PA/usapa/pa.pa213.wpt
@@ -1,6 +1,6 @@
 PA532 http://www.openstreetmap.org/?lat=40.154575&lon=-74.999912
 BriRd http://www.openstreetmap.org/?lat=40.163116&lon=-74.984055
-BriPk http://www.openstreetmap.org/?lat=40.173789&lon=-74.967616
+BriPike http://www.openstreetmap.org/?lat=40.173789&lon=-74.967616
 OldLinHwy http://www.openstreetmap.org/?lat=40.174445&lon=-74.930652
 BelAve http://www.openstreetmap.org/?lat=40.176150&lon=-74.920270
 PA413 http://www.openstreetmap.org/?lat=40.176652&lon=-74.917488

--- a/hwy_data/PA/usapa/pa.pa227.wpt
+++ b/hwy_data/PA/usapa/pa.pa227.wpt
@@ -3,7 +3,7 @@ MooRunRd http://www.openstreetmap.org/?lat=41.476679&lon=-79.680002
 GraRd http://www.openstreetmap.org/?lat=41.485559&lon=-79.652394
 EagRockRd http://www.openstreetmap.org/?lat=41.499192&lon=-79.641802
 PitRd http://www.openstreetmap.org/?lat=41.517356&lon=-79.618947
-OldWarPk http://www.openstreetmap.org/?lat=41.529116&lon=-79.610994
+OldWarPike http://www.openstreetmap.org/?lat=41.529116&lon=-79.610994
 MilFarmRd http://www.openstreetmap.org/?lat=41.558853&lon=-79.611032
 BryRd http://www.openstreetmap.org/?lat=41.591515&lon=-79.609895
 PA27_W http://www.openstreetmap.org/?lat=41.596530&lon=-79.592825

--- a/hwy_data/PA/usapa/pa.pa232.wpt
+++ b/hwy_data/PA/usapa/pa.pa232.wpt
@@ -12,7 +12,7 @@ BybRd http://www.openstreetmap.org/?lat=40.149199&lon=-75.058098
 CouLineRd http://www.openstreetmap.org/?lat=40.158029&lon=-75.048881
 PA132 http://www.openstreetmap.org/?lat=40.174484&lon=-75.043839
 BriRd http://www.openstreetmap.org/?lat=40.191373&lon=-75.032418
-BusPk http://www.openstreetmap.org/?lat=40.211081&lon=-75.010915
+BusPike http://www.openstreetmap.org/?lat=40.211081&lon=-75.010915
 PA332 http://www.openstreetmap.org/?lat=40.215318&lon=-75.010531
 WorMillRd http://www.openstreetmap.org/?lat=40.227572&lon=-75.009609
 SacRd http://www.openstreetmap.org/?lat=40.237300&lon=-75.008898

--- a/hwy_data/PA/usapa/pa.pa268.wpt
+++ b/hwy_data/PA/usapa/pa.pa268.wpt
@@ -16,7 +16,7 @@ ArgSt_S http://www.openstreetmap.org/?lat=41.016640&lon=-79.718425
 +X3 http://www.openstreetmap.org/?lat=41.031594&lon=-79.714573
 WasSt http://www.openstreetmap.org/?lat=41.058084&lon=-79.727145
 AnnRd http://www.openstreetmap.org/?lat=41.066165&lon=-79.727156
-ParPk http://www.openstreetmap.org/?lat=41.092559&lon=-79.697182
+ParPike http://www.openstreetmap.org/?lat=41.092559&lon=-79.697182
 JacAve +BluAve http://www.openstreetmap.org/?lat=41.091198&lon=-79.685222
 PA368 http://www.openstreetmap.org/?lat=41.102073&lon=-79.681606
 PA58 http://www.openstreetmap.org/?lat=41.139407&lon=-79.682223

--- a/hwy_data/PA/usapa/pa.pa271.wpt
+++ b/hwy_data/PA/usapa/pa.pa271.wpt
@@ -2,7 +2,7 @@ PA711 http://www.openstreetmap.org/?lat=40.260968&lon=-79.197913
 NatRunRd http://www.openstreetmap.org/?lat=40.254659&lon=-79.169717
 +X0 http://www.openstreetmap.org/?lat=40.275507&lon=-79.088379
 +X0A http://www.openstreetmap.org/?lat=40.272322&lon=-79.072165
-LigPk http://www.openstreetmap.org/?lat=40.290063&lon=-79.017124
+LigPike http://www.openstreetmap.org/?lat=40.290063&lon=-79.017124
 +X0B http://www.openstreetmap.org/?lat=40.303403&lon=-79.008702
 FenLn http://www.openstreetmap.org/?lat=40.303103&lon=-78.989159
 SaiClaRd http://www.openstreetmap.org/?lat=40.314565&lon=-78.968096

--- a/hwy_data/PA/usapa/pa.pa281.wpt
+++ b/hwy_data/PA/usapa/pa.pa281.wpt
@@ -21,7 +21,7 @@ CasSt http://www.openstreetmap.org/?lat=39.901510&lon=-79.268973
 PA653_W http://www.openstreetmap.org/?lat=39.937386&lon=-79.237765
 +X1 http://www.openstreetmap.org/?lat=39.932991&lon=-79.207912
 PA653_E http://www.openstreetmap.org/?lat=39.942279&lon=-79.191773
-MudPk http://www.openstreetmap.org/?lat=39.943083&lon=-79.189198
+MudPike http://www.openstreetmap.org/?lat=39.943083&lon=-79.189198
 CroRd http://www.openstreetmap.org/?lat=39.967922&lon=-79.179843
 IndRd http://www.openstreetmap.org/?lat=39.988498&lon=-79.150730
 ValDr http://www.openstreetmap.org/?lat=40.000155&lon=-79.118892

--- a/hwy_data/PA/usapa/pa.pa305.wpt
+++ b/hwy_data/PA/usapa/pa.pa305.wpt
@@ -1,9 +1,9 @@
 US22 http://www.openstreetmap.org/?lat=40.549850&lon=-78.100157
 MainSt_W http://www.openstreetmap.org/?lat=40.556752&lon=-78.098234
-AlePk http://www.openstreetmap.org/?lat=40.555124&lon=-78.094651
+AlePike http://www.openstreetmap.org/?lat=40.555124&lon=-78.094651
 RivRd http://www.openstreetmap.org/?lat=40.565421&lon=-78.070607
 BarRd http://www.openstreetmap.org/?lat=40.568626&lon=-78.064162
-PetPk http://www.openstreetmap.org/?lat=40.569824&lon=-78.047597
+PetPike http://www.openstreetmap.org/?lat=40.569824&lon=-78.047597
 DiaValRd http://www.openstreetmap.org/?lat=40.579134&lon=-78.043994
 ChiHolRd http://www.openstreetmap.org/?lat=40.585857&lon=-78.027501
 BetRd http://www.openstreetmap.org/?lat=40.611564&lon=-78.006124

--- a/hwy_data/PA/usapa/pa.pa320.wpt
+++ b/hwy_data/PA/usapa/pa.pa320.wpt
@@ -5,7 +5,7 @@ US13 http://www.openstreetmap.org/?lat=39.853733&lon=-75.357936
 22ndSt http://www.openstreetmap.org/?lat=39.866835&lon=-75.362155
 PA252 http://www.openstreetmap.org/?lat=39.879082&lon=-75.361750
 FaiRd http://www.openstreetmap.org/?lat=39.892042&lon=-75.352958
-BalPk http://www.openstreetmap.org/?lat=39.913509&lon=-75.349512
+BalPike  +BalPk http://www.openstreetmap.org/?lat=39.913509&lon=-75.349512
 PA420 http://www.openstreetmap.org/?lat=39.933867&lon=-75.352360
 US1 http://www.openstreetmap.org/?lat=39.938227&lon=-75.350555
 SprRd_A http://www.openstreetmap.org/?lat=39.946704&lon=-75.349165

--- a/hwy_data/PA/usapa/pa.pa352.wpt
+++ b/hwy_data/PA/usapa/pa.pa352.wpt
@@ -11,6 +11,6 @@ PA926 http://www.openstreetmap.org/?lat=39.950422&lon=-75.510466
 PA3_E http://www.openstreetmap.org/?lat=39.966376&lon=-75.520500
 PA3_W http://www.openstreetmap.org/?lat=39.966542&lon=-75.522914
 BootRd http://www.openstreetmap.org/?lat=39.986478&lon=-75.543223
-PaoPk http://www.openstreetmap.org/?lat=39.995108&lon=-75.544422
+PaoPike http://www.openstreetmap.org/?lat=39.995108&lon=-75.544422
 KingRd http://www.openstreetmap.org/?lat=40.026520&lon=-75.550701
 US30 http://www.openstreetmap.org/?lat=40.037382&lon=-75.559874

--- a/hwy_data/PA/usapa/pa.pa363.wpt
+++ b/hwy_data/PA/usapa/pa.pa363.wpt
@@ -1,11 +1,11 @@
 US422 http://www.openstreetmap.org/?lat=40.112587&lon=-75.420343
 EgyRd http://www.openstreetmap.org/?lat=40.130901&lon=-75.401410
 MainSt +MainSt_E http://www.openstreetmap.org/?lat=40.142232&lon=-75.389785
-RidPk_W +MainSt_W http://www.openstreetmap.org/?lat=40.146856&lon=-75.395200
-GerPk http://www.openstreetmap.org/?lat=40.161714&lon=-75.379783
+RidPike_W +MainSt_W http://www.openstreetmap.org/?lat=40.146856&lon=-75.395200
+GerPike http://www.openstreetmap.org/?lat=40.161714&lon=-75.379783
 TowLineRd http://www.openstreetmap.org/?lat=40.180074&lon=-75.362542
 PA73 http://www.openstreetmap.org/?lat=40.201240&lon=-75.346513
 MorRd http://www.openstreetmap.org/?lat=40.213739&lon=-75.330012
-SumPk http://www.openstreetmap.org/?lat=40.229519&lon=-75.314372
+SumPike  +SumPk http://www.openstreetmap.org/?lat=40.229519&lon=-75.314372
 AllRd http://www.openstreetmap.org/?lat=40.241309&lon=-75.302396
 PA63 http://www.openstreetmap.org/?lat=40.248377&lon=-75.295224

--- a/hwy_data/PA/usapa/pa.pa413.wpt
+++ b/hwy_data/PA/usapa/pa.pa413.wpt
@@ -11,7 +11,7 @@ PA513 http://www.openstreetmap.org/?lat=40.159986&lon=-74.912049
 BelAve_N http://www.openstreetmap.org/?lat=40.167638&lon=-74.915782
 PA213 http://www.openstreetmap.org/?lat=40.176652&lon=-74.917488
 WinAve http://www.openstreetmap.org/?lat=40.181644&lon=-74.918891
-BriPk http://www.openstreetmap.org/?lat=40.190488&lon=-74.926600
+BriPike http://www.openstreetmap.org/?lat=40.190488&lon=-74.926600
 PA332_E http://www.openstreetmap.org/?lat=40.216715&lon=-74.931725
 PA532_S http://www.openstreetmap.org/?lat=40.218941&lon=-74.943452
 PA332_W http://www.openstreetmap.org/?lat=40.226527&lon=-74.947743
@@ -25,6 +25,6 @@ PineLn http://www.openstreetmap.org/?lat=40.294830&lon=-75.005220
 PA263 http://www.openstreetmap.org/?lat=40.323520&lon=-75.060568
 US202 http://www.openstreetmap.org/?lat=40.325434&lon=-75.061630
 CSCreRd http://www.openstreetmap.org/?lat=40.359910&lon=-75.087827
-PoiPlePk http://www.openstreetmap.org/?lat=40.372395&lon=-75.108408
+PoiPlePike http://www.openstreetmap.org/?lat=40.372395&lon=-75.108408
 OldEasRd_N http://www.openstreetmap.org/?lat=40.425615&lon=-75.139473
 PA611 http://www.openstreetmap.org/?lat=40.422459&lon=-75.145495

--- a/hwy_data/PA/usapa/pa.pa420.wpt
+++ b/hwy_data/PA/usapa/pa.pa420.wpt
@@ -3,5 +3,5 @@ I-95 http://www.openstreetmap.org/?lat=39.870881&lon=-75.301301
 US13 http://www.openstreetmap.org/?lat=39.882497&lon=-75.306033
 PA420AltTrkRid_S http://www.openstreetmap.org/?lat=39.895841&lon=-75.315219
 PA420AltTrkPro_N http://www.openstreetmap.org/?lat=39.908162&lon=-75.327458
-BalPk http://www.openstreetmap.org/?lat=39.916937&lon=-75.333485
+BalPike  +BalPk http://www.openstreetmap.org/?lat=39.916937&lon=-75.333485
 PA320 http://www.openstreetmap.org/?lat=39.933867&lon=-75.352360

--- a/hwy_data/PA/usapa/pa.pa481.wpt
+++ b/hwy_data/PA/usapa/pa.pa481.wpt
@@ -1,5 +1,5 @@
 US40 http://www.openstreetmap.org/?lat=40.042749&lon=-79.969820
-OldNatPk_W http://www.openstreetmap.org/?lat=40.045528&lon=-79.975689
+OldNatPike_W http://www.openstreetmap.org/?lat=40.045528&lon=-79.975689
 +X2 http://www.openstreetmap.org/?lat=40.047355&lon=-79.969287
 SpurRd http://www.openstreetmap.org/?lat=40.055426&lon=-79.966570
 PikeRunDr http://www.openstreetmap.org/?lat=40.058547&lon=-79.967444

--- a/hwy_data/PA/usapa/pa.pa550.wpt
+++ b/hwy_data/PA/usapa/pa.pa550.wpt
@@ -10,7 +10,7 @@ BecRd http://www.openstreetmap.org/?lat=40.778098&lon=-78.041999
 MeeLn http://www.openstreetmap.org/?lat=40.820161&lon=-77.974973
 AthSt http://www.openstreetmap.org/?lat=40.828411&lon=-77.962621
 SteRd http://www.openstreetmap.org/?lat=40.834061&lon=-77.934710
-JulPk http://www.openstreetmap.org/?lat=40.834611&lon=-77.929746
+JulPike http://www.openstreetmap.org/?lat=40.834611&lon=-77.929746
 BerRd http://www.openstreetmap.org/?lat=40.853579&lon=-77.886275
 FilRd http://www.openstreetmap.org/?lat=40.859077&lon=-77.876372
 RockRd http://www.openstreetmap.org/?lat=40.874858&lon=-77.847254

--- a/hwy_data/PA/usapa/pa.pa563.wpt
+++ b/hwy_data/PA/usapa/pa.pa563.wpt
@@ -4,7 +4,7 @@ WhiMillRd http://www.openstreetmap.org/?lat=40.348515&lon=-75.391547
 AllRd http://www.openstreetmap.org/?lat=40.349674&lon=-75.381331
 CouLineRd http://www.openstreetmap.org/?lat=40.351718&lon=-75.372452
 LawnAve http://www.openstreetmap.org/?lat=40.368038&lon=-75.333386
-BetPk http://www.openstreetmap.org/?lat=40.374334&lon=-75.313648
+BetPike http://www.openstreetmap.org/?lat=40.374334&lon=-75.313648
 TunRd http://www.openstreetmap.org/?lat=40.380797&lon=-75.295441
 PA313_E http://www.openstreetmap.org/?lat=40.407759&lon=-75.260575
 PA313_W http://www.openstreetmap.org/?lat=40.420835&lon=-75.276877

--- a/hwy_data/PA/usapa/pa.pa722.wpt
+++ b/hwy_data/PA/usapa/pa.pa722.wpt
@@ -4,9 +4,10 @@ LemSt +PA741 http://www.openstreetmap.org/?lat=40.099991&lon=-76.355587
 PA72 http://www.openstreetmap.org/?lat=40.100024&lon=-76.354133
 GraRd http://www.openstreetmap.org/?lat=40.104915&lon=-76.342020
 KosRd http://www.openstreetmap.org/?lat=40.107206&lon=-76.337246
-FruPk http://www.openstreetmap.org/?lat=40.105126&lon=-76.332190
+FruPike http://www.openstreetmap.org/?lat=40.105126&lon=-76.332190
 OreRd http://www.openstreetmap.org/?lat=40.104375&lon=-76.309796
 PA501_S http://www.openstreetmap.org/?lat=40.100323&lon=-76.305349
 PA501_N http://www.openstreetmap.org/?lat=40.106363&lon=-76.305451
++X1 http://www.openstreetmap.org/?lat=40.106080&lon=-76.293231
 AirRd http://www.openstreetmap.org/?lat=40.111297&lon=-76.289374
 PA272 http://www.openstreetmap.org/?lat=40.114684&lon=-76.243932

--- a/hwy_data/PA/usapa/pa.pa879.wpt
+++ b/hwy_data/PA/usapa/pa.pa879.wpt
@@ -1,7 +1,7 @@
 US219/729 http://www.openstreetmap.org/?lat=40.964153&lon=-78.609726
 +X0B http://www.openstreetmap.org/?lat=40.969005&lon=-78.603160
 +X0A http://www.openstreetmap.org/?lat=40.970425&lon=-78.555030
-GrePk http://www.openstreetmap.org/?lat=40.976441&lon=-78.549247
+GrePike http://www.openstreetmap.org/?lat=40.976441&lon=-78.549247
 +X0 http://www.openstreetmap.org/?lat=40.979578&lon=-78.536040
 RidAve http://www.openstreetmap.org/?lat=40.978136&lon=-78.532366
 PA453 http://www.openstreetmap.org/?lat=40.975309&lon=-78.525381

--- a/hwy_data/PA/usaus/pa.us011.wpt
+++ b/hwy_data/PA/usaus/pa.us011.wpt
@@ -1,7 +1,7 @@
 MD/PA http://www.openstreetmap.org/?lat=39.721015&lon=-77.724087
 PA163 http://www.openstreetmap.org/?lat=39.721396&lon=-77.724141
 I-81(3) http://www.openstreetmap.org/?lat=39.755966&lon=-77.726984
-WilPk http://www.openstreetmap.org/?lat=39.783390&lon=-77.734663
+WilPike http://www.openstreetmap.org/?lat=39.783390&lon=-77.734663
 PA16 http://www.openstreetmap.org/?lat=39.791111&lon=-77.731190
 KauRd http://www.openstreetmap.org/?lat=39.837117&lon=-77.713530
 FeaRd http://www.openstreetmap.org/?lat=39.856124&lon=-77.708825

--- a/hwy_data/PA/usaus/pa.us013.wpt
+++ b/hwy_data/PA/usaus/pa.us013.wpt
@@ -16,7 +16,7 @@ PA420 http://www.openstreetmap.org/?lat=39.882497&lon=-75.306033
 OakLn http://www.openstreetmap.org/?lat=39.903490&lon=-75.283223
 SprRd http://www.openstreetmap.org/?lat=39.918364&lon=-75.264735
 ChuLn_S +ChuLn http://www.openstreetmap.org/?lat=39.928440&lon=-75.246544
-BalPk_W +BalAve http://www.openstreetmap.org/?lat=39.941102&lon=-75.256130
+BalAve +BalPk_W http://www.openstreetmap.org/?lat=39.941102&lon=-75.256130
 CobCrePkwy http://www.openstreetmap.org/?lat=39.945867&lon=-75.240316
 52ndSt http://www.openstreetmap.org/?lat=39.947784&lon=-75.227436
 UniAve http://www.openstreetmap.org/?lat=39.949591&lon=-75.199675
@@ -52,7 +52,7 @@ US13AltTrk_N http://www.openstreetmap.org/?lat=40.091295&lon=-74.923810
 PA413 http://www.openstreetmap.org/?lat=40.098477&lon=-74.873902
 BathRd +BethRd http://www.openstreetmap.org/?lat=40.102108&lon=-74.863337
 I-95 +I-276 http://www.openstreetmap.org/?lat=40.117477&lon=-74.845935
-BriPk_N http://www.openstreetmap.org/?lat=40.143233&lon=-74.815390
+OldBriPk  +BriPk_N http://www.openstreetmap.org/?lat=40.143233&lon=-74.815390
 MillCreRd http://www.openstreetmap.org/?lat=40.157816&lon=-74.812155
 PenValRd http://www.openstreetmap.org/?lat=40.171528&lon=-74.812458
 TybRd http://www.openstreetmap.org/?lat=40.181343&lon=-74.808939

--- a/hwy_data/PA/usaus/pa.us013.wpt
+++ b/hwy_data/PA/usaus/pa.us013.wpt
@@ -51,8 +51,8 @@ PA132 +StrRd http://www.openstreetmap.org/?lat=40.084144&lon=-74.935201
 US13AltTrk_N http://www.openstreetmap.org/?lat=40.091295&lon=-74.923810
 PA413 http://www.openstreetmap.org/?lat=40.098477&lon=-74.873902
 BathRd +BethRd http://www.openstreetmap.org/?lat=40.102108&lon=-74.863337
-I-95 +I-276 http://www.openstreetmap.org/?lat=40.117477&lon=-74.845935
-OldBriPk  +BriPk_N http://www.openstreetmap.org/?lat=40.143233&lon=-74.815390
+I-95 +I-276 http://www.openstreetmap.org/?lat=40.117305&lon=-74.846174
+OldBriPk +BriPk_N http://www.openstreetmap.org/?lat=40.143233&lon=-74.815390
 MillCreRd http://www.openstreetmap.org/?lat=40.157816&lon=-74.812155
 PenValRd http://www.openstreetmap.org/?lat=40.171528&lon=-74.812458
 TybRd http://www.openstreetmap.org/?lat=40.181343&lon=-74.808939

--- a/hwy_data/PA/usaus/pa.us015.wpt
+++ b/hwy_data/PA/usaus/pa.us015.wpt
@@ -89,13 +89,13 @@ ColJKRd http://www.openstreetmap.org/?lat=41.006328&lon=-76.868084
 PA642 http://www.openstreetmap.org/?lat=41.018937&lon=-76.868798
 NewColRd http://www.openstreetmap.org/?lat=41.041208&lon=-76.871019
 I-80 http://www.openstreetmap.org/?lat=41.052259&lon=-76.871713
-WhiDeerPk http://www.openstreetmap.org/?lat=41.076334&lon=-76.873347
+WhiDeerPike +WhiDeerPk http://www.openstreetmap.org/?lat=41.076334&lon=-76.873347
 PA44 http://www.openstreetmap.org/?lat=41.107659&lon=-76.898568
 BarRd http://www.openstreetmap.org/?lat=41.135341&lon=-76.914124
 PinRd http://www.openstreetmap.org/?lat=41.160414&lon=-76.907344
 PA54 http://www.openstreetmap.org/?lat=41.188253&lon=-76.913733
 +X206 http://www.openstreetmap.org/?lat=41.208582&lon=-76.920905
-*OldMonPk http://www.openstreetmap.org/?lat=41.220192&lon=-76.936092
+*SylDellRd http://www.openstreetmap.org/?lat=41.220192&lon=-76.936092
 +X207 http://www.openstreetmap.org/?lat=41.225974&lon=-76.938157
 PA554 http://www.openstreetmap.org/?lat=41.227008&lon=-76.989218
 PA654 http://www.openstreetmap.org/?lat=41.233792&lon=-76.994247

--- a/hwy_data/PA/usaus/pa.us040.wpt
+++ b/hwy_data/PA/usaus/pa.us040.wpt
@@ -8,7 +8,7 @@ LakeRd http://www.openstreetmap.org/?lat=40.121017&lon=-80.474553
 +X3 http://www.openstreetmap.org/?lat=40.114187&lon=-80.462733
 CunRd http://www.openstreetmap.org/?lat=40.117408&lon=-80.451172
 +X3A http://www.openstreetmap.org/?lat=40.117198&lon=-80.435833
-OldNatPk_A +OldNatPk http://www.openstreetmap.org/?lat=40.115666&lon=-80.428111
+OldNatPike_A +OldNatPk http://www.openstreetmap.org/?lat=40.115666&lon=-80.428111
 PA231_S http://www.openstreetmap.org/?lat=40.116187&lon=-80.415507
 PA231_N http://www.openstreetmap.org/?lat=40.117867&lon=-80.410373
 SunBeaRd http://www.openstreetmap.org/?lat=40.132798&lon=-80.369880
@@ -32,7 +32,7 @@ PA917 http://www.openstreetmap.org/?lat=40.095857&lon=-80.085609
 HicRd http://www.openstreetmap.org/?lat=40.082110&lon=-80.049769
 MaiSt_Bea http://www.openstreetmap.org/?lat=40.065374&lon=-80.023601
 RicRd http://www.openstreetmap.org/?lat=40.053381&lon=-80.002101
-OldNatPk_B http://www.openstreetmap.org/?lat=40.047012&lon=-79.993075
+OldNatPike_B http://www.openstreetmap.org/?lat=40.047012&lon=-79.993075
 RidRd http://www.openstreetmap.org/?lat=40.044136&lon=-79.981775
 PA481 http://www.openstreetmap.org/?lat=40.042749&lon=-79.969820
 MalRd http://www.openstreetmap.org/?lat=40.039826&lon=-79.927254

--- a/hwy_data/PA/usaus/pa.us202.wpt
+++ b/hwy_data/PA/usaus/pa.us202.wpt
@@ -30,11 +30,11 @@ DekSt +DekPk http://www.openstreetmap.org/?lat=40.098600&lon=-75.354618
 PA23 http://www.openstreetmap.org/?lat=40.105815&lon=-75.348962
 MainSt http://www.openstreetmap.org/?lat=40.114987&lon=-75.345633
 JohHwy http://www.openstreetmap.org/?lat=40.131945&lon=-75.328585
-GerPk http://www.openstreetmap.org/?lat=40.141771&lon=-75.312535
+GerPike +GerPk http://www.openstreetmap.org/?lat=40.141769&lon=-75.312561
 SweRd_C http://www.openstreetmap.org/?lat=40.152174&lon=-75.305126
 PA73 http://www.openstreetmap.org/?lat=40.166992&lon=-75.290278
 US202AltTrk_S http://www.openstreetmap.org/?lat=40.179492&lon=-75.277848
-SumPk http://www.openstreetmap.org/?lat=40.202074&lon=-75.255395
+SumPike http://www.openstreetmap.org/?lat=40.202074&lon=-75.255395
 US202Bus http://www.openstreetmap.org/?lat=40.217184&lon=-75.246896
 PA63 http://www.openstreetmap.org/?lat=40.218682&lon=-75.245455
 PA309 http://www.openstreetmap.org/?lat=40.231850&lon=-75.238229

--- a/hwy_data/PA/usaus/pa.us219.wpt
+++ b/hwy_data/PA/usaus/pa.us219.wpt
@@ -8,7 +8,7 @@ US219BusMey_S http://www.openstreetmap.org/?lat=39.798019&lon=-79.036768
 US219BusMey_N +PA653 http://www.openstreetmap.org/?lat=39.838188&lon=-79.041202
 +X08 http://www.openstreetmap.org/?lat=39.861216&lon=-79.036033
 +X09 http://www.openstreetmap.org/?lat=39.878199&lon=-79.046113
-MudPk http://www.openstreetmap.org/?lat=39.934781&lon=-79.048618
+MudPike http://www.openstreetmap.org/?lat=39.934781&lon=-79.048618
 BerPlaRd +CinRd http://www.openstreetmap.org/?lat=39.983658&lon=-79.041902
 +X13 http://www.openstreetmap.org/?lat=40.010645&lon=-79.033480
 PA281 http://www.openstreetmap.org/?lat=40.027796&lon=-79.047977
@@ -88,7 +88,7 @@ OldGraRd_A http://www.openstreetmap.org/?lat=40.949797&lon=-78.614109
 PA729/879 http://www.openstreetmap.org/?lat=40.964153&lon=-78.609726
 WalRd http://www.openstreetmap.org/?lat=40.966818&lon=-78.616356
 BilRocRd http://www.openstreetmap.org/?lat=40.993176&lon=-78.629078
-GrePk http://www.openstreetmap.org/?lat=41.021284&lon=-78.646005
+GrePike http://www.openstreetmap.org/?lat=41.021284&lon=-78.646005
 SchOrcRd http://www.openstreetmap.org/?lat=41.035914&lon=-78.696911
 BruRd_A http://www.openstreetmap.org/?lat=41.050131&lon=-78.705516
 US322_E http://www.openstreetmap.org/?lat=41.053877&lon=-78.716832

--- a/hwy_data/PA/usausb/pa.us022busmon.wpt
+++ b/hwy_data/PA/usausb/pa.us022busmon.wpt
@@ -2,6 +2,6 @@ US22_W http://www.openstreetmap.org/?lat=40.440774&lon=-79.834642
 PA791 http://www.openstreetmap.org/?lat=40.438239&lon=-79.830480
 RodiRd http://www.openstreetmap.org/?lat=40.433623&lon=-79.820730
 EntDr +DonDr http://www.openstreetmap.org/?lat=40.434180&lon=-79.794525
-NorPk http://www.openstreetmap.org/?lat=40.437577&lon=-79.777745
+NorPike http://www.openstreetmap.org/?lat=40.437577&lon=-79.777745
 PA48 http://www.openstreetmap.org/?lat=40.438923&lon=-79.760557
 US22_E http://www.openstreetmap.org/?lat=40.438845&lon=-79.756689

--- a/hwy_data/PA/usausb/pa.us209busstr.wpt
+++ b/hwy_data/PA/usausb/pa.us209busstr.wpt
@@ -1,6 +1,6 @@
 US209_S http://www.openstreetmap.org/?lat=40.927856&lon=-75.316601
 NeoRd http://www.openstreetmap.org/?lat=40.935765&lon=-75.313857
-EasBelPk http://www.openstreetmap.org/?lat=40.957521&lon=-75.293569
+EasBelPike http://www.openstreetmap.org/?lat=40.957521&lon=-75.293569
 PA33 http://www.openstreetmap.org/?lat=40.961331&lon=-75.284098
 PolkValRd http://www.openstreetmap.org/?lat=40.973562&lon=-75.253845
 ShaSchRd http://www.openstreetmap.org/?lat=40.975233&lon=-75.245423


### PR DESCRIPTION
Other Notes:
US 13: Relocated I-95 point to intersection replacing trumpet interchange.
US 15:  *OldMonPk was actually Sylvan Dell Rd (SylDellRd).  (https://www.northcentralpa.com/news/permanent-closure-of-section-of-sylvan-dell-road-in-armstrong/article_33ecd864-01eb-54a0-8e8a-e0aef686da77.html)
PA 722: Added +X1.