### PR TITLE
fl.us098: forgot to update label

### DIFF
--- a/hwy_data/FL/usaus/fl.us098.wpt
+++ b/hwy_data/FL/usaus/fl.us098.wpt
@@ -160,7 +160,7 @@ US19_S http://www.openstreetmap.org/?lat=28.722650&lon=-82.552747
 FL589 http://www.openstreetmap.org/?lat=28.685129&lon=-82.495190
 BriRd http://www.openstreetmap.org/?lat=28.636758&lon=-82.426072
 CR476 http://www.openstreetmap.org/?lat=28.629239&lon=-82.422832
-US98TrkBro_W http://www.openstreetmap.org/?lat=28.613669&lon=-82.405550
+CR485 +US98TrkBro_W http://www.openstreetmap.org/?lat=28.613669&lon=-82.405550
 FL50A/700 +FL50A_W http://www.openstreetmap.org/?lat=28.555564&lon=-82.397662
 US41_S http://www.openstreetmap.org/?lat=28.555145&lon=-82.394253
 US41_N http://www.openstreetmap.org/?lat=28.555300&lon=-82.381429


### PR DESCRIPTION
Forgot to remove mention of the now removed US-98 Truck (Brooksville).