### PR TITLE
US 322: Added Skelp Level Rd (SkeLevRd)

### DIFF
--- a/hwy_data/PA/usai/pa.i080.wpt
+++ b/hwy_data/PA/usai/pa.i080.wpt
@@ -64,6 +64,7 @@ OH/PA +0 http://www.openstreetmap.org/?lat=41.184734&lon=-80.519158
 +X09A http://www.openstreetmap.org/?lat=40.965285&lon=-77.786164
 158 http://www.openstreetmap.org/?lat=40.955854&lon=-77.769599
 161 http://www.openstreetmap.org/?lat=40.944833&lon=-77.720160
++X(163) http://www.openstreetmap.org/?lat=40.961694&lon=-77.670379
 +X113 http://www.openstreetmap.org/?lat=40.970437&lon=-77.638321
 +X114 http://www.openstreetmap.org/?lat=41.017022&lon=-77.582788
 173 http://www.openstreetmap.org/?lat=41.031127&lon=-77.519207

--- a/hwy_data/PA/usapa/pa.pa026.wpt
+++ b/hwy_data/PA/usapa/pa.pa026.wpt
@@ -118,6 +118,7 @@ I-99(83) http://www.openstreetmap.org/?lat=40.915312&lon=-77.741618
 MusLn http://www.openstreetmap.org/?lat=40.938460&lon=-77.730723
 JacRd_S http://www.openstreetmap.org/?lat=40.940046&lon=-77.728966
 I-80 http://www.openstreetmap.org/?lat=40.944833&lon=-77.720160
++X(I-80)) http://www.openstreetmap.org/?lat=40.967373&lon=-77.674979
 +X5A http://www.openstreetmap.org/?lat=40.974030&lon=-77.657617
 JacRd_N http://www.openstreetmap.org/?lat=40.988337&lon=-77.638275
 +X6 http://www.openstreetmap.org/?lat=40.989819&lon=-77.642484

--- a/hwy_data/PA/usapa/pa.pa031.wpt
+++ b/hwy_data/PA/usapa/pa.pa031.wpt
@@ -20,8 +20,8 @@ ClaRd +ClayPikeRd http://www.openstreetmap.org/?lat=40.121516&lon=-79.405234
 MainSt http://www.openstreetmap.org/?lat=40.112803&lon=-79.390461
 HelSchRd http://www.openstreetmap.org/?lat=40.110716&lon=-79.386003
 *OldPA31_A http://www.openstreetmap.org/?lat=40.109061&lon=-79.383980
-I-70/76 +I-76 http://www.openstreetmap.org/?lat=40.107404&lon=-79.382171
-*OldPA31_B http://www.openstreetmap.org/?lat=40.107466&lon=-79.379104
+I-70/76 +I-76 http://www.openstreetmap.org/?lat=40.107340&lon=-79.382197
+*OldPA31_B http://www.openstreetmap.org/?lat=40.107446&lon=-79.378865
 PA711_N +PA711_W http://www.openstreetmap.org/?lat=40.106888&lon=-79.376226
 PA381/711 http://www.openstreetmap.org/?lat=40.091275&lon=-79.347972
 PA381_N http://www.openstreetmap.org/?lat=40.087897&lon=-79.336387

--- a/hwy_data/PA/usapa/pa.pa072.wpt
+++ b/hwy_data/PA/usapa/pa.pa072.wpt
@@ -3,7 +3,7 @@ PA462 http://www.openstreetmap.org/?lat=40.040308&lon=-76.306119
 PA23 http://www.openstreetmap.org/?lat=40.041937&lon=-76.306443
 US222/272_B http://www.openstreetmap.org/?lat=40.053613&lon=-76.308618
 US222/272_N http://www.openstreetmap.org/?lat=40.053386&lon=-76.310483
-FruPike  +FruPk http://www.openstreetmap.org/?lat=40.056851&lon=-76.311175
+FruPike +FruPk http://www.openstreetmap.org/?lat=40.056851&lon=-76.311175
 US30 http://www.openstreetmap.org/?lat=40.068495&lon=-76.330063
 PA283 http://www.openstreetmap.org/?lat=40.076177&lon=-76.337230
 PA722 http://www.openstreetmap.org/?lat=40.100024&lon=-76.354133
@@ -22,7 +22,7 @@ PA117 +PA117_E http://www.openstreetmap.org/?lat=40.265552&lon=-76.435672
 US322_W http://www.openstreetmap.org/?lat=40.269572&lon=-76.437979
 PA419 http://www.openstreetmap.org/?lat=40.278337&lon=-76.435168
 ZinMillRd http://www.openstreetmap.org/?lat=40.294222&lon=-76.424576
-RocRd http://www.openstreetmap.org/?lat=40.304635&lon=-76.423819
+RocRd http://www.openstreetmap.org/?lat=40.304545&lon=-76.423803
 PA241 http://www.openstreetmap.org/?lat=40.326058&lon=-76.426405
 US422 http://www.openstreetmap.org/?lat=40.337802&lon=-76.426950
 PA343 http://www.openstreetmap.org/?lat=40.349688&lon=-76.428409

--- a/hwy_data/PA/usaus/pa.us220.wpt
+++ b/hwy_data/PA/usaus/pa.us220.wpt
@@ -55,6 +55,7 @@ I-99(83) http://www.openstreetmap.org/?lat=40.915312&lon=-77.741618
 MusLn http://www.openstreetmap.org/?lat=40.938460&lon=-77.730723
 JacRd_S +JacRd http://www.openstreetmap.org/?lat=40.940046&lon=-77.728966
 I-80(161) http://www.openstreetmap.org/?lat=40.944833&lon=-77.720160
++X(I-80(163)) http://www.openstreetmap.org/?lat=40.961694&lon=-77.670379
 +X113 http://www.openstreetmap.org/?lat=40.970437&lon=-77.638321
 +X114 http://www.openstreetmap.org/?lat=41.017022&lon=-77.582788
 I-80(173) http://www.openstreetmap.org/?lat=41.031127&lon=-77.519207
@@ -157,5 +158,5 @@ PineSt http://www.openstreetmap.org/?lat=41.964905&lon=-76.533404
 +X1102 http://www.openstreetmap.org/?lat=41.975044&lon=-76.544243
 +X1102A http://www.openstreetmap.org/?lat=41.983958&lon=-76.546378
 WilRd http://www.openstreetmap.org/?lat=41.988965&lon=-76.548724
-I-86  +NY17 http://www.openstreetmap.org/?lat=41.999255&lon=-76.548719
+I-86 +NY17 http://www.openstreetmap.org/?lat=41.999255&lon=-76.548719
 PA/NY http://www.openstreetmap.org/?lat=42.000046&lon=-76.548829

--- a/hwy_data/PA/usaus/pa.us322.wpt
+++ b/hwy_data/PA/usaus/pa.us322.wpt
@@ -277,6 +277,7 @@ US30Bus_W http://www.openstreetmap.org/?lat=40.005331&lon=-75.705953
 US30Bus_E http://www.openstreetmap.org/?lat=40.006660&lon=-75.703249
 BootRd +US322TrkDow_E http://www.openstreetmap.org/?lat=40.000971&lon=-75.702187
 SugBriRd http://www.openstreetmap.org/?lat=39.968460&lon=-75.675011
+SkeLevRd http://www.openstreetmap.org/?lat=39.969352&lon=-75.669912
 CreRd http://www.openstreetmap.org/?lat=39.967831&lon=-75.657984
 US322BusWes_W http://www.openstreetmap.org/?lat=39.966185&lon=-75.632595
 PotPike http://www.openstreetmap.org/?lat=39.973159&lon=-75.614616


### PR DESCRIPTION
Done to show realignment for new bridge over East Branch Brandywine Creek. (https://www.penndot.gov/regionaloffices/district-6/pages/details.aspx?newsid=5776)

Other Minor Changes:
PA 26: Added Future Connection to I-80 (Exit 163).
PA 31: Relocating I-70/76 Points.
PA 72: Recentered Rocherty Rd (RocRd).
I-80/US 220: Added Future I-80(Exit 163),