### PR TITLE
NV I-11 exit renumberings

### DIFF
--- a/hwy_data/NV/usai/nv.i011.wpt
+++ b/hwy_data/NV/usai/nv.i011.wpt
@@ -9,7 +9,7 @@ AZ/NV +NV/AZ http://www.openstreetmap.org/?lat=36.012389&lon=-114.741117
 15A http://www.openstreetmap.org/?lat=35.966259&lon=-114.912540
 15B +15 http://www.openstreetmap.org/?lat=35.969143&lon=-114.913293
 *OldUS93/95 http://www.openstreetmap.org/?lat=35.985420&lon=-114.921311
-56 http://www.openstreetmap.org/?lat=35.995464&lon=-114.934142
-57 http://www.openstreetmap.org/?lat=35.999989&lon=-114.963266
-59 http://www.openstreetmap.org/?lat=36.011816&lon=-114.990029
-61 http://www.openstreetmap.org/?lat=36.033518&lon=-115.014238
+17 +56 http://www.openstreetmap.org/?lat=35.995464&lon=-114.934142
+19 http://www.openstreetmap.org/?lat=35.999989&lon=-114.963266
+20 http://www.openstreetmap.org/?lat=36.011816&lon=-114.990029
+23 +61 http://www.openstreetmap.org/?lat=36.033518&lon=-115.014238

--- a/hwy_data/NV/usaus/nv.us093.wpt
+++ b/hwy_data/NV/usaus/nv.us093.wpt
@@ -9,7 +9,7 @@ I-11(14) +14 +I-11_S http://www.openstreetmap.org/?lat=35.952075&lon=-114.901631
 I-11(15A) http://www.openstreetmap.org/?lat=35.966259&lon=-114.912540
 I-11(15B) +15 http://www.openstreetmap.org/?lat=35.969143&lon=-114.913293
 *OldUS93/95 http://www.openstreetmap.org/?lat=35.985420&lon=-114.921311
-I-11(17) http://www.openstreetmap.org/?lat=35.995464&lon=-114.934142
+I-11(17) +56 http://www.openstreetmap.org/?lat=35.995464&lon=-114.934142
 I-11(19) http://www.openstreetmap.org/?lat=35.999989&lon=-114.963266
 I-11(20) http://www.openstreetmap.org/?lat=36.011816&lon=-114.990029
 I-11(23) +I-11(61) http://www.openstreetmap.org/?lat=36.033518&lon=-115.014238

--- a/hwy_data/NV/usaus/nv.us093.wpt
+++ b/hwy_data/NV/usaus/nv.us093.wpt
@@ -9,10 +9,10 @@ I-11(14) +14 +I-11_S http://www.openstreetmap.org/?lat=35.952075&lon=-114.901631
 I-11(15A) http://www.openstreetmap.org/?lat=35.966259&lon=-114.912540
 I-11(15B) +15 http://www.openstreetmap.org/?lat=35.969143&lon=-114.913293
 *OldUS93/95 http://www.openstreetmap.org/?lat=35.985420&lon=-114.921311
-I-11(56) +56 http://www.openstreetmap.org/?lat=35.995464&lon=-114.934142
-I-11(57) http://www.openstreetmap.org/?lat=35.999989&lon=-114.963266
-I-11(59) http://www.openstreetmap.org/?lat=36.011816&lon=-114.990029
-I-11(61) +61 http://www.openstreetmap.org/?lat=36.033518&lon=-115.014238
+I-11(17) http://www.openstreetmap.org/?lat=35.995464&lon=-114.934142
+I-11(19) http://www.openstreetmap.org/?lat=35.999989&lon=-114.963266
+I-11(20) http://www.openstreetmap.org/?lat=36.011816&lon=-114.990029
+I-11(23) +I-11(61) http://www.openstreetmap.org/?lat=36.033518&lon=-115.014238
 I-515(62) http://www.openstreetmap.org/?lat=36.046011&lon=-115.022650
 I-515(64A) http://www.openstreetmap.org/?lat=36.063740&lon=-115.031791
 I-515(64B) http://www.openstreetmap.org/?lat=36.071545&lon=-115.036597

--- a/hwy_data/NV/usaus/nv.us095.wpt
+++ b/hwy_data/NV/usaus/nv.us095.wpt
@@ -11,14 +11,14 @@ EldValDr http://www.openstreetmap.org/?lat=35.792941&lon=-114.944903
 NV165 http://www.openstreetmap.org/?lat=35.828361&lon=-114.937238
 +X721088 http://www.openstreetmap.org/?lat=35.922698&lon=-114.916692
 SilRd http://www.openstreetmap.org/?lat=35.923115&lon=-114.916853
-14(11) +I-11(14) +14 +I-11_S http://www.openstreetmap.org/?lat=35.952075&lon=-114.901631
-15A(11) +I-11(15A) http://www.openstreetmap.org/?lat=35.966259&lon=-114.912540
-15B(11) +I-11(15B) +15 http://www.openstreetmap.org/?lat=35.969143&lon=-114.913293
+14(11) +I-11_S http://www.openstreetmap.org/?lat=35.952075&lon=-114.901631
+15A(11) http://www.openstreetmap.org/?lat=35.966259&lon=-114.912540
+15B(11) +15 http://www.openstreetmap.org/?lat=35.969143&lon=-114.913293
 *OldUS93/95 http://www.openstreetmap.org/?lat=35.985420&lon=-114.921311
-56(11) +56 http://www.openstreetmap.org/?lat=35.995464&lon=-114.934142
-57(11) http://www.openstreetmap.org/?lat=35.999989&lon=-114.963266
-59(11) http://www.openstreetmap.org/?lat=36.011816&lon=-114.990029
-61(11) +61 http://www.openstreetmap.org/?lat=36.033518&lon=-115.014238
+17(11) +56(11) http://www.openstreetmap.org/?lat=35.995464&lon=-114.934142
+19(11) http://www.openstreetmap.org/?lat=35.999989&lon=-114.963266
+20(11) http://www.openstreetmap.org/?lat=36.011816&lon=-114.990029
+23(11) +61(11) http://www.openstreetmap.org/?lat=36.033518&lon=-115.014238
 62(515) http://www.openstreetmap.org/?lat=36.046011&lon=-115.022650
 64A(515) http://www.openstreetmap.org/?lat=36.063740&lon=-115.031791
 64B(515) http://www.openstreetmap.org/?lat=36.071545&lon=-115.036597


### PR DESCRIPTION
Also affects US 93 and US 95. All labels in use kept as alternate labels. No Updates entry needed.

Datacheck.sh successful.