### PR TITLE
usafl: remove unused 'alt' labels

### DIFF
--- a/hwy_data/FL/usai/fl.i004.wpt
+++ b/hwy_data/FL/usai/fl.i004.wpt
@@ -55,7 +55,7 @@ GraDr http://www.openstreetmap.org/?lat=28.473527&lon=-81.455888
 81B http://www.openstreetmap.org/?lat=28.520175&lon=-81.386257
 82 http://www.openstreetmap.org/?lat=28.529592&lon=-81.386228
 82A http://www.openstreetmap.org/?lat=28.535249&lon=-81.383272
-82B +82C http://www.openstreetmap.org/?lat=28.536152&lon=-81.382875
+82B http://www.openstreetmap.org/?lat=28.536152&lon=-81.382875
 83 http://www.openstreetmap.org/?lat=28.538348&lon=-81.382274
 83A http://www.openstreetmap.org/?lat=28.549392&lon=-81.382591
 83B http://www.openstreetmap.org/?lat=28.553060&lon=-81.382357

--- a/hwy_data/FL/usai/fl.i095.wpt
+++ b/hwy_data/FL/usai/fl.i095.wpt
@@ -9,7 +9,7 @@ US1 +0 http://www.openstreetmap.org/?lat=25.749548&lon=-80.211313
 4 http://www.openstreetmap.org/?lat=25.812474&lon=-80.206021
 6A http://www.openstreetmap.org/?lat=25.832347&lon=-80.205895
 6B http://www.openstreetmap.org/?lat=25.837880&lon=-80.206048
-7 +7A http://www.openstreetmap.org/?lat=25.847956&lon=-80.207708
+7 http://www.openstreetmap.org/?lat=25.847956&lon=-80.207708
 8A http://www.openstreetmap.org/?lat=25.861893&lon=-80.208266
 8B http://www.openstreetmap.org/?lat=25.869254&lon=-80.208494
 9 http://www.openstreetmap.org/?lat=25.883787&lon=-80.209041
@@ -36,7 +36,7 @@ US1 +0 http://www.openstreetmap.org/?lat=25.749548&lon=-80.211313
 29 http://www.openstreetmap.org/?lat=26.136540&lon=-80.169358
 31 http://www.openstreetmap.org/?lat=26.165983&lon=-80.160024
 32 http://www.openstreetmap.org/?lat=26.188316&lon=-80.151948
-33A +32A http://www.openstreetmap.org/?lat=26.199590&lon=-80.148185
+33A http://www.openstreetmap.org/?lat=26.199590&lon=-80.148185
 33 http://www.openstreetmap.org/?lat=26.203569&lon=-80.143957
 36 http://www.openstreetmap.org/?lat=26.231500&lon=-80.136458
 38 http://www.openstreetmap.org/?lat=26.260507&lon=-80.133156
@@ -46,7 +46,7 @@ US1 +0 http://www.openstreetmap.org/?lat=25.749548&lon=-80.211313
 44 http://www.openstreetmap.org/?lat=26.350743&lon=-80.117988
 45 http://www.openstreetmap.org/?lat=26.368309&lon=-80.118452
 48A http://www.openstreetmap.org/?lat=26.390764&lon=-80.098722
-48B +48 http://www.openstreetmap.org/?lat=26.394479&lon=-80.093229
+48B http://www.openstreetmap.org/?lat=26.394479&lon=-80.093229
 50 http://www.openstreetmap.org/?lat=26.420794&lon=-80.089975
 51 http://www.openstreetmap.org/?lat=26.439509&lon=-80.089047
 52 http://www.openstreetmap.org/?lat=26.461629&lon=-80.088559
@@ -156,14 +156,14 @@ US1 +0 http://www.openstreetmap.org/?lat=25.749548&lon=-80.211313
 348 http://www.openstreetmap.org/?lat=30.306397&lon=-81.644812
 349 http://www.openstreetmap.org/?lat=30.310037&lon=-81.647730
 +X022(I95) http://www.openstreetmap.org/?lat=30.313668&lon=-81.652177
-350A +350 http://www.openstreetmap.org/?lat=30.314050&lon=-81.658429
+350A http://www.openstreetmap.org/?lat=30.314050&lon=-81.658429
 350B http://www.openstreetmap.org/?lat=30.313966&lon=-81.662160
 351A http://www.openstreetmap.org/?lat=30.317953&lon=-81.679286
 351B http://www.openstreetmap.org/?lat=30.320947&lon=-81.682373
 352A http://www.openstreetmap.org/?lat=30.323564&lon=-81.680627
 352B http://www.openstreetmap.org/?lat=30.329861&lon=-81.675475
 352C http://www.openstreetmap.org/?lat=30.331824&lon=-81.673329
-353B +353A http://www.openstreetmap.org/?lat=30.334586&lon=-81.670545
+353B http://www.openstreetmap.org/?lat=30.334586&lon=-81.670545
 353C http://www.openstreetmap.org/?lat=30.336361&lon=-81.669311
 353D http://www.openstreetmap.org/?lat=30.347320&lon=-81.668310
 354 http://www.openstreetmap.org/?lat=30.356055&lon=-81.668557
@@ -171,7 +171,7 @@ US1 +0 http://www.openstreetmap.org/?lat=25.749548&lon=-80.211313
 356 http://www.openstreetmap.org/?lat=30.382640&lon=-81.672693
 357 http://www.openstreetmap.org/?lat=30.392443&lon=-81.667940
 358 http://www.openstreetmap.org/?lat=30.408519&lon=-81.657442
-ClaRd +359 http://www.openstreetmap.org/?lat=30.414064&lon=-81.657096
+ClaRd http://www.openstreetmap.org/?lat=30.414064&lon=-81.657096
 360 http://www.openstreetmap.org/?lat=30.430023&lon=-81.656144
 362 http://www.openstreetmap.org/?lat=30.459749&lon=-81.649379
 363 http://www.openstreetmap.org/?lat=30.481565&lon=-81.643680

--- a/hwy_data/FL/usai/fl.i110.wpt
+++ b/hwy_data/FL/usai/fl.i110.wpt
@@ -4,4 +4,4 @@
 4 http://www.openstreetmap.org/?lat=30.451994&lon=-87.221669
 5 http://www.openstreetmap.org/?lat=30.472187&lon=-87.228377
 5A http://www.openstreetmap.org/?lat=30.481366&lon=-87.230453
-6 +999 +I-10 http://www.openstreetmap.org/?lat=30.503469&lon=-87.230217
+6 +I-10 +999 http://www.openstreetmap.org/?lat=30.503469&lon=-87.230217

--- a/hwy_data/FL/usai/fl.i175.wpt
+++ b/hwy_data/FL/usai/fl.i175.wpt
@@ -1,4 +1,4 @@
 I-275 +0 http://www.openstreetmap.org/?lat=27.766535&lon=-82.658420
-MLKJrSt +MLKJrStS +9thSt http://www.openstreetmap.org/?lat=27.766025&lon=-82.646630
+MLKJrSt +MLKJrStS http://www.openstreetmap.org/?lat=27.766025&lon=-82.646630
 6thSt http://www.openstreetmap.org/?lat=27.766051&lon=-82.641700
 FL687 http://www.openstreetmap.org/?lat=27.765900&lon=-82.638447

--- a/hwy_data/FL/usai/fl.i275.wpt
+++ b/hwy_data/FL/usai/fl.i275.wpt
@@ -27,8 +27,8 @@ NSkyPier http://www.openstreetmap.org/?lat=27.649857&lon=-82.675394
 39B http://www.openstreetmap.org/?lat=27.947744&lon=-82.531284
 40A http://www.openstreetmap.org/?lat=27.950277&lon=-82.524168
 40B http://www.openstreetmap.org/?lat=27.950720&lon=-82.513922
-41A +41 http://www.openstreetmap.org/?lat=27.955046&lon=-82.505602
-41B +41C http://www.openstreetmap.org/?lat=27.955866&lon=-82.501472
+41A http://www.openstreetmap.org/?lat=27.955046&lon=-82.505602
+41B http://www.openstreetmap.org/?lat=27.955866&lon=-82.501472
 42 http://www.openstreetmap.org/?lat=27.955875&lon=-82.483919
 44 http://www.openstreetmap.org/?lat=27.956501&lon=-82.463438
 44A http://www.openstreetmap.org/?lat=27.956612&lon=-82.460214

--- a/hwy_data/FL/usai/fl.i295.wpt
+++ b/hwy_data/FL/usai/fl.i295.wpt
@@ -31,7 +31,7 @@ NewBerRd http://www.openstreetmap.org/?lat=30.402537&lon=-81.564453
 51 http://www.openstreetmap.org/?lat=30.286969&lon=-81.521725
 52 http://www.openstreetmap.org/?lat=30.268533&lon=-81.520481
 53 http://www.openstreetmap.org/?lat=30.252960&lon=-81.516216
-54 +55 http://www.openstreetmap.org/?lat=30.235996&lon=-81.514172
+54 http://www.openstreetmap.org/?lat=30.235996&lon=-81.514172
 56 http://www.openstreetmap.org/?lat=30.215940&lon=-81.513971
 58 http://www.openstreetmap.org/?lat=30.180469&lon=-81.513609
 60 http://www.openstreetmap.org/?lat=30.167343&lon=-81.540565

--- a/hwy_data/FL/usai/fl.i375.wpt
+++ b/hwy_data/FL/usai/fl.i375.wpt
@@ -1,5 +1,5 @@
 I-275 +0 http://www.openstreetmap.org/?lat=27.776450&lon=-82.659344
 +X000(I375) http://www.openstreetmap.org/?lat=27.777250&lon=-82.653130
 10thSt http://www.openstreetmap.org/?lat=27.776666&lon=-82.647676
-8thSt +8thStN http://www.openstreetmap.org/?lat=27.777378&lon=-82.644632
+8thSt http://www.openstreetmap.org/?lat=27.777378&lon=-82.644632
 US19Alt +7thSt http://www.openstreetmap.org/?lat=27.777032&lon=-82.642550

--- a/hwy_data/FL/usasf/fl.fltpkmia.wpt
+++ b/hwy_data/FL/usasf/fl.fltpkmia.wpt
@@ -2,5 +2,5 @@ FL826 +0X http://www.openstreetmap.org/?lat=25.929907&lon=-80.210543
 I-95/826 +0XA http://www.openstreetmap.org/?lat=25.932267&lon=-80.213043
 +X000(FL91) http://www.openstreetmap.org/?lat=25.945634&lon=-80.225907
 2X http://www.openstreetmap.org/?lat=25.959525&lon=-80.229260
-FL852 +4XA http://www.openstreetmap.org/?lat=25.972287&lon=-80.229662
+FL852 http://www.openstreetmap.org/?lat=25.972287&lon=-80.229662
 4X http://www.openstreetmap.org/?lat=25.973521&lon=-80.229737

--- a/hwy_data/FL/usaus/fl.us001.wpt
+++ b/hwy_data/FL/usaus/fl.us001.wpt
@@ -1,5 +1,5 @@
 FleSt http://www.openstreetmap.org/?lat=24.555296&lon=-81.804030
-TruAve_W +TruAve http://www.openstreetmap.org/?lat=24.550390&lon=-81.800385
+TruAve_W http://www.openstreetmap.org/?lat=24.550390&lon=-81.800385
 WhiSt http://www.openstreetmap.org/?lat=24.556140&lon=-81.791223
 1stSt +CR5A http://www.openstreetmap.org/?lat=24.559712&lon=-81.783670
 KenDr http://www.openstreetmap.org/?lat=24.568006&lon=-81.769339
@@ -7,30 +7,30 @@ KenDr http://www.openstreetmap.org/?lat=24.568006&lon=-81.769339
 FLA1A_Key http://www.openstreetmap.org/?lat=24.569900&lon=-81.752524
 MacAve http://www.openstreetmap.org/?lat=24.572909&lon=-81.742680
 +X001(US1) http://www.openstreetmap.org/?lat=24.579417&lon=-81.707900
-NASKeyWest +SarAve http://www.openstreetmap.org/?lat=24.588266&lon=-81.690905
-RocDr +MidAve_E http://www.openstreetmap.org/?lat=24.589873&lon=-81.673360
+NASKeyWest http://www.openstreetmap.org/?lat=24.588266&lon=-81.690905
+RocDr http://www.openstreetmap.org/?lat=24.589873&lon=-81.673360
 BocaChiRd +CR941 http://www.openstreetmap.org/?lat=24.599304&lon=-81.651828
-SugBlvd +CR939A http://www.openstreetmap.org/?lat=24.645491&lon=-81.566148
+SugBlvd http://www.openstreetmap.org/?lat=24.645491&lon=-81.566148
 StaRd939B http://www.openstreetmap.org/?lat=24.660315&lon=-81.521430
 BliRd http://www.openstreetmap.org/?lat=24.666487&lon=-81.499621
-EShoDr +CR942 http://www.openstreetmap.org/?lat=24.661112&lon=-81.439859
+EShoDr http://www.openstreetmap.org/?lat=24.661112&lon=-81.439859
 KeyDeerBlvd +CR940_N http://www.openstreetmap.org/?lat=24.669594&lon=-81.356340
 +X002(US1) http://www.openstreetmap.org/?lat=24.668960&lon=-81.343063
-LongBeaRd +CR940_S http://www.openstreetmap.org/?lat=24.648670&lon=-81.331969
-BahHonSP +BHKeyPark http://www.openstreetmap.org/?lat=24.660403&lon=-81.273648
+LongBeaRd http://www.openstreetmap.org/?lat=24.648670&lon=-81.331969
+BahHonSP http://www.openstreetmap.org/?lat=24.660403&lon=-81.273648
 VetMemPark http://www.openstreetmap.org/?lat=24.681157&lon=-81.231371
 +X003(US1) http://www.openstreetmap.org/?lat=24.701910&lon=-81.158034
-20thSt +CR931_W http://www.openstreetmap.org/?lat=24.708728&lon=-81.104982
-SomBeaRd +CR931_E http://www.openstreetmap.org/?lat=24.716194&lon=-81.075700
-95thSt +95thStOce http://www.openstreetmap.org/?lat=24.725764&lon=-81.047465
+20thSt http://www.openstreetmap.org/?lat=24.708728&lon=-81.104982
+SomBeaRd http://www.openstreetmap.org/?lat=24.716194&lon=-81.075700
+95thSt http://www.openstreetmap.org/?lat=24.725764&lon=-81.047465
 +X004(US1) http://www.openstreetmap.org/?lat=24.743177&lon=-80.991648
 DuckKeyDr http://www.openstreetmap.org/?lat=24.779967&lon=-80.915396
 LongKeySP +LKeySRArea http://www.openstreetmap.org/?lat=24.816814&lon=-80.823981
 GulfShoBlvd http://www.openstreetmap.org/?lat=24.839767&lon=-80.792239
 +X005(US1) http://www.openstreetmap.org/?lat=24.836089&lon=-80.763760
 GulDr http://www.openstreetmap.org/?lat=24.855719&lon=-80.729843
-CR905_IslS +CR905_IslW http://www.openstreetmap.org/?lat=24.904158&lon=-80.651284
-CR905_IslN +CR905_IslE http://www.openstreetmap.org/?lat=24.935095&lon=-80.615514
+CR905_IslS http://www.openstreetmap.org/?lat=24.904158&lon=-80.651284
+CR905_IslN http://www.openstreetmap.org/?lat=24.935095&lon=-80.615514
 +X006(US1) http://www.openstreetmap.org/?lat=24.946890&lon=-80.601583
 +X007(US1) http://www.openstreetmap.org/?lat=24.960985&lon=-80.566848
 RoyPoiBlvd http://www.openstreetmap.org/?lat=24.996628&lon=-80.538433
@@ -55,7 +55,7 @@ FL998 +312thSt http://www.openstreetmap.org/?lat=25.477244&lon=-80.465061
 216thSt +SW216thSt http://www.openstreetmap.org/?lat=25.566250&lon=-80.381663
 211thSt http://www.openstreetmap.org/?lat=25.571704&lon=-80.376320
 FL989 http://www.openstreetmap.org/?lat=25.575725&lon=-80.372404
-200thSt +CarBlvd http://www.openstreetmap.org/?lat=25.579710&lon=-80.368501
+200thSt http://www.openstreetmap.org/?lat=25.579710&lon=-80.368501
 FLTpk(12A) +FL821(12A) http://www.openstreetmap.org/?lat=25.582148&lon=-80.366165
 FL994 http://www.openstreetmap.org/?lat=25.596121&lon=-80.355326
 184thSt http://www.openstreetmap.org/?lat=25.598610&lon=-80.354186
@@ -101,7 +101,7 @@ FL856 http://www.openstreetmap.org/?lat=25.955094&lon=-80.146827
 FL858 http://www.openstreetmap.org/?lat=25.985662&lon=-80.142367
 FL824 http://www.openstreetmap.org/?lat=25.996737&lon=-80.142689
 FL820 http://www.openstreetmap.org/?lat=26.011512&lon=-80.143054
-TaftSt +TafSt http://www.openstreetmap.org/?lat=26.026245&lon=-80.143257
+TaftSt http://www.openstreetmap.org/?lat=26.026245&lon=-80.143257
 FL822 http://www.openstreetmap.org/?lat=26.033593&lon=-80.143306
 WDixHwy http://www.openstreetmap.org/?lat=26.041023&lon=-80.143359
 FL848 http://www.openstreetmap.org/?lat=26.048754&lon=-80.143536
@@ -120,20 +120,20 @@ FL838_W http://www.openstreetmap.org/?lat=26.137048&lon=-80.136324
 FL838_E http://www.openstreetmap.org/?lat=26.137400&lon=-80.121167
 FL816 http://www.openstreetmap.org/?lat=26.167193&lon=-80.116867
 FL870 http://www.openstreetmap.org/?lat=26.189600&lon=-80.114888
-NE62ndSt +BayDr http://www.openstreetmap.org/?lat=26.204147&lon=-80.108633
+NE62ndSt http://www.openstreetmap.org/?lat=26.204147&lon=-80.108633
 AtlBlvd http://www.openstreetmap.org/?lat=26.231761&lon=-80.102815
 FL844 http://www.openstreetmap.org/?lat=26.250069&lon=-80.101013
 CopRd http://www.openstreetmap.org/?lat=26.258854&lon=-80.099773
 FL834 http://www.openstreetmap.org/?lat=26.275479&lon=-80.097440
 10thSt http://www.openstreetmap.org/?lat=26.305063&lon=-80.092890
 FL810 http://www.openstreetmap.org/?lat=26.318000&lon=-80.090761
-RoyPalmWay +18thSt http://www.openstreetmap.org/?lat=26.330210&lon=-80.090823
+RoyPalmWay http://www.openstreetmap.org/?lat=26.330210&lon=-80.090823
 CamReal http://www.openstreetmap.org/?lat=26.340944&lon=-80.086193
 PalParkRd +FL798 http://www.openstreetmap.org/?lat=26.350500&lon=-80.086400
 FL808 http://www.openstreetmap.org/?lat=26.361772&lon=-80.082369
 FL800 http://www.openstreetmap.org/?lat=26.386060&lon=-80.076521
 FL794 http://www.openstreetmap.org/?lat=26.394633&lon=-80.076570
-LinBlvd +CR782 http://www.openstreetmap.org/?lat=26.439754&lon=-80.071243
+LinBlvd http://www.openstreetmap.org/?lat=26.439754&lon=-80.071243
 FL806 http://www.openstreetmap.org/?lat=26.461660&lon=-80.067541
 WooRd http://www.openstreetmap.org/?lat=26.514554&lon=-80.058990
 FL804_E http://www.openstreetmap.org/?lat=26.527117&lon=-80.058092
@@ -141,7 +141,7 @@ FL804_W http://www.openstreetmap.org/?lat=26.528900&lon=-80.058132
 GatBlvd http://www.openstreetmap.org/?lat=26.549081&lon=-80.056000
 HypRd http://www.openstreetmap.org/?lat=26.571976&lon=-80.053596
 OceAve http://www.openstreetmap.org/?lat=26.584418&lon=-80.051936
-LanRd +CR812 http://www.openstreetmap.org/?lat=26.586745&lon=-80.051982
+LanRd http://www.openstreetmap.org/?lat=26.586745&lon=-80.051982
 FL5 http://www.openstreetmap.org/?lat=26.592161&lon=-80.052419
 12thAve http://www.openstreetmap.org/?lat=26.601349&lon=-80.057266
 6thAve http://www.openstreetmap.org/?lat=26.608587&lon=-80.057604
@@ -156,11 +156,11 @@ FL704_W http://www.openstreetmap.org/?lat=26.705976&lon=-80.055166
 BanBlvd http://www.openstreetmap.org/?lat=26.714415&lon=-80.054927
 +X011(US1) http://www.openstreetmap.org/?lat=26.718134&lon=-80.054814
 FLA1A_For http://www.openstreetmap.org/?lat=26.718447&lon=-80.053400
-PBLakBlvd +PBeaLBlvd http://www.openstreetmap.org/?lat=26.724437&lon=-80.053213
+PBLakBlvd http://www.openstreetmap.org/?lat=26.724437&lon=-80.053213
 DixHwy_N +PoiDr http://www.openstreetmap.org/?lat=26.735900&lon=-80.052845
-BroAve_S +25thSt http://www.openstreetmap.org/?lat=26.735995&lon=-80.056847
+BroAve_S http://www.openstreetmap.org/?lat=26.735995&lon=-80.056847
 36thSt http://www.openstreetmap.org/?lat=26.745845&lon=-80.056544
-45thSt +CR702 http://www.openstreetmap.org/?lat=26.752868&lon=-80.056161
+45thSt http://www.openstreetmap.org/?lat=26.752868&lon=-80.056161
 FL708/A1A http://www.openstreetmap.org/?lat=26.783404&lon=-80.054800
 FL850 http://www.openstreetmap.org/?lat=26.807389&lon=-80.055876
 FL786/A1A http://www.openstreetmap.org/?lat=26.844134&lon=-80.061280
@@ -174,9 +174,9 @@ TeqDr http://www.openstreetmap.org/?lat=26.959300&lon=-80.084745
 CRA1A http://www.openstreetmap.org/?lat=27.045637&lon=-80.119922
 CR708 http://www.openstreetmap.org/?lat=27.059458&lon=-80.136638
 OspSt http://www.openstreetmap.org/?lat=27.098860&lon=-80.159310
-CoveRd +CovRd http://www.openstreetmap.org/?lat=27.133924&lon=-80.206777
+CoveRd http://www.openstreetmap.org/?lat=27.133924&lon=-80.206777
 FL714 http://www.openstreetmap.org/?lat=27.177925&lon=-80.236773
-DixCutRd +CutRd http://www.openstreetmap.org/?lat=27.186839&lon=-80.245592
+DixCutRd http://www.openstreetmap.org/?lat=27.186839&lon=-80.245592
 FL76 http://www.openstreetmap.org/?lat=27.191100&lon=-80.253056
 DixHwy http://www.openstreetmap.org/?lat=27.212532&lon=-80.259979
 WriBlvd http://www.openstreetmap.org/?lat=27.215893&lon=-80.261116
@@ -204,19 +204,19 @@ FL656 http://www.openstreetmap.org/?lat=27.632552&lon=-80.389184
 FL60 http://www.openstreetmap.org/?lat=27.638424&lon=-80.389152
 21stSt_E http://www.openstreetmap.org/?lat=27.639833&lon=-80.389109
 21stSt_W http://www.openstreetmap.org/?lat=27.639752&lon=-80.397378
-OldDixHwy +CR5A_N http://www.openstreetmap.org/?lat=27.663200&lon=-80.404657
-53rdSt +CR603 +CR603_N http://www.openstreetmap.org/?lat=27.689575&lon=-80.412498
+OldDixHwy http://www.openstreetmap.org/?lat=27.663200&lon=-80.404657
+53rdSt +CR603 http://www.openstreetmap.org/?lat=27.689575&lon=-80.412498
 CR508 http://www.openstreetmap.org/?lat=27.719010&lon=-80.420987
 FL510 http://www.openstreetmap.org/?lat=27.748522&lon=-80.435575
 CR512 http://www.openstreetmap.org/?lat=27.810398&lon=-80.466946
-RosRd +CR505 http://www.openstreetmap.org/?lat=27.841071&lon=-80.486886
+RosRd http://www.openstreetmap.org/?lat=27.841071&lon=-80.486886
 MicRd http://www.openstreetmap.org/?lat=27.880337&lon=-80.501244
 ValRd http://www.openstreetmap.org/?lat=27.963843&lon=-80.541700
 FL514 http://www.openstreetmap.org/?lat=28.004391&lon=-80.563747
-PalmBayRd +CR516 http://www.openstreetmap.org/?lat=28.036434&lon=-80.582362
+PalmBayRd http://www.openstreetmap.org/?lat=28.036434&lon=-80.582362
 US192 http://www.openstreetmap.org/?lat=28.079913&lon=-80.603524
 FL508 http://www.openstreetmap.org/?lat=28.093832&lon=-80.610200
-BabSt +CR507 http://www.openstreetmap.org/?lat=28.116100&lon=-80.623134
+BabSt http://www.openstreetmap.org/?lat=28.116100&lon=-80.623134
 SarRd http://www.openstreetmap.org/?lat=28.121617&lon=-80.630945
 FL518 http://www.openstreetmap.org/?lat=28.129004&lon=-80.630285
 ParDr http://www.openstreetmap.org/?lat=28.157548&lon=-80.641341
@@ -236,7 +236,7 @@ FL405_N http://www.openstreetmap.org/?lat=28.607985&lon=-80.808000
 FL406 http://www.openstreetmap.org/?lat=28.615381&lon=-80.807909
 NorAve http://www.openstreetmap.org/?lat=28.621036&lon=-80.819831
 FL46 http://www.openstreetmap.org/?lat=28.665600&lon=-80.844963
-DeePkwy +StuRd http://www.openstreetmap.org/?lat=28.781076&lon=-80.882083
+DeePkwy http://www.openstreetmap.org/?lat=28.781076&lon=-80.882083
 +X013(US1) http://www.openstreetmap.org/?lat=28.797410&lon=-80.880935
 KenPkwy +FL3 +CR3 http://www.openstreetmap.org/?lat=28.833668&lon=-80.841769
 CR4164 http://www.openstreetmap.org/?lat=28.864113&lon=-80.851422
@@ -277,7 +277,7 @@ CasDr +WCasDr http://www.openstreetmap.org/?lat=29.899073&lon=-81.319784
 SanCarAve http://www.openstreetmap.org/?lat=29.908954&lon=-81.321694
 FL16 +FL16/1BusStA_N http://www.openstreetmap.org/?lat=29.916822&lon=-81.324610
 US1BusStA_N http://www.openstreetmap.org/?lat=29.923464&lon=-81.325100
-CR16A +LewSpdwy http://www.openstreetmap.org/?lat=29.940358&lon=-81.335014
+CR16A http://www.openstreetmap.org/?lat=29.940358&lon=-81.335014
 IntGolfPkwy +IntGolPky http://www.openstreetmap.org/?lat=30.013000&lon=-81.392526
 CR210_W http://www.openstreetmap.org/?lat=30.080751&lon=-81.454619
 CR210_E http://www.openstreetmap.org/?lat=30.087678&lon=-81.461611
@@ -288,7 +288,7 @@ StAugRd http://www.openstreetmap.org/?lat=30.143427&lon=-81.518150
 I-295(60) +FL9A +FL9A(60) http://www.openstreetmap.org/?lat=30.167343&lon=-81.540565
 FL115 http://www.openstreetmap.org/?lat=30.178661&lon=-81.552005
 I-95(339) http://www.openstreetmap.org/?lat=30.184773&lon=-81.558131
-ShadRd +ShaRd http://www.openstreetmap.org/?lat=30.196500&lon=-81.569865
+ShadRd http://www.openstreetmap.org/?lat=30.196500&lon=-81.569865
 SunRd http://www.openstreetmap.org/?lat=30.206247&lon=-81.576965
 FL152 http://www.openstreetmap.org/?lat=30.220740&lon=-81.585752
 FL202 http://www.openstreetmap.org/?lat=30.244185&lon=-81.600252
@@ -310,7 +310,7 @@ US17/23 http://www.openstreetmap.org/?lat=30.332495&lon=-81.655492
 8thSt http://www.openstreetmap.org/?lat=30.345748&lon=-81.653982
 US17/1Alt +US17/1Alt_N http://www.openstreetmap.org/?lat=30.356400&lon=-81.653926
 PeaSt http://www.openstreetmap.org/?lat=30.356356&lon=-81.658486
-Blvd +BouSt http://www.openstreetmap.org/?lat=30.356319&lon=-81.661310
+Blvd http://www.openstreetmap.org/?lat=30.356319&lon=-81.661310
 I-95(354) http://www.openstreetmap.org/?lat=30.356055&lon=-81.668557
 MyrAve http://www.openstreetmap.org/?lat=30.355608&lon=-81.675906
 CanSt http://www.openstreetmap.org/?lat=30.356800&lon=-81.697115
@@ -322,7 +322,7 @@ RatRd http://www.openstreetmap.org/?lat=30.510737&lon=-81.793208
 FL115_Cal +FL115_S http://www.openstreetmap.org/?lat=30.560173&lon=-81.825461
 US301/A1A http://www.openstreetmap.org/?lat=30.563680&lon=-81.829769
 CR115 +CR115_N http://www.openstreetmap.org/?lat=30.571046&lon=-81.835468
-MusRd +MusWhiRd http://www.openstreetmap.org/?lat=30.589524&lon=-81.829779
+MusRd http://www.openstreetmap.org/?lat=30.589524&lon=-81.829779
 SauRd http://www.openstreetmap.org/?lat=30.629641&lon=-81.852066
 CR108 http://www.openstreetmap.org/?lat=30.690944&lon=-81.917737
 CR121 http://www.openstreetmap.org/?lat=30.774141&lon=-81.978545

--- a/hwy_data/FL/usaus/fl.us017.wpt
+++ b/hwy_data/FL/usaus/fl.us017.wpt
@@ -5,7 +5,7 @@ MarWay http://www.openstreetmap.org/?lat=26.941679&lon=-82.032396
 I-75 +I-75(164) http://www.openstreetmap.org/?lat=26.940593&lon=-82.019028
 CR74 http://www.openstreetmap.org/?lat=26.948106&lon=-82.001108
 CR764 http://www.openstreetmap.org/?lat=26.971095&lon=-81.960808
-CR761 +CR769 http://www.openstreetmap.org/?lat=27.067853&lon=-81.958201
+CR761 http://www.openstreetmap.org/?lat=27.067853&lon=-81.958201
 +X00B(US17) http://www.openstreetmap.org/?lat=27.081705&lon=-81.956522
 CR760 http://www.openstreetmap.org/?lat=27.159527&lon=-81.883458
 FL70 http://www.openstreetmap.org/?lat=27.215146&lon=-81.859539
@@ -21,7 +21,7 @@ FL636 http://www.openstreetmap.org/?lat=27.547703&lon=-81.811109
 FL62 http://www.openstreetmap.org/?lat=27.594920&lon=-81.822087
 TorRd http://www.openstreetmap.org/?lat=27.613129&lon=-81.826419
 CR664 +CR664_W http://www.openstreetmap.org/?lat=27.638324&lon=-81.823897
-CouLineRd +CR664_E http://www.openstreetmap.org/?lat=27.646203&lon=-81.822685
+CouLineRd http://www.openstreetmap.org/?lat=27.646203&lon=-81.822685
 +X00C(US17) http://www.openstreetmap.org/?lat=27.677667&lon=-81.821450
 +X00D(US17) http://www.openstreetmap.org/?lat=27.685476&lon=-81.813582
 SandMouRd http://www.openstreetmap.org/?lat=27.722486&lon=-81.801775
@@ -32,7 +32,7 @@ CR640 http://www.openstreetmap.org/?lat=27.820549&lon=-81.821647
 MainSt +OldFL60 http://www.openstreetmap.org/?lat=27.896842&lon=-81.828720
 US98_N +US98_W http://www.openstreetmap.org/?lat=27.903958&lon=-81.830370
 ErnSmiBlvd http://www.openstreetmap.org/?lat=27.923884&lon=-81.821639
-SpiLakeRd +SpiLakRd http://www.openstreetmap.org/?lat=27.955970&lon=-81.783407
+SpiLakeRd http://www.openstreetmap.org/?lat=27.955970&lon=-81.783407
 FL540_W http://www.openstreetmap.org/?lat=27.986668&lon=-81.747400
 CR655 +FL655 http://www.openstreetmap.org/?lat=27.994792&lon=-81.738067
 FL540_E http://www.openstreetmap.org/?lat=28.004014&lon=-81.730927
@@ -41,11 +41,11 @@ FL544 http://www.openstreetmap.org/?lat=28.044000&lon=-81.735012
 US92_W http://www.openstreetmap.org/?lat=28.075665&lon=-81.732732
 +X002(US17) http://www.openstreetmap.org/?lat=28.077423&lon=-81.730294
 CR557 http://www.openstreetmap.org/?lat=28.093184&lon=-81.730122
-ExpStaRd +LeeJacRd http://www.openstreetmap.org/?lat=28.098973&lon=-81.712899
+ExpStaRd http://www.openstreetmap.org/?lat=28.098973&lon=-81.712899
 FleCutRd http://www.openstreetmap.org/?lat=28.107226&lon=-81.677529
 US27 http://www.openstreetmap.org/?lat=28.106568&lon=-81.642910
 FL17 http://www.openstreetmap.org/?lat=28.106679&lon=-81.623327
-HinAve_E +HinAve http://www.openstreetmap.org/?lat=28.106710&lon=-81.618024
+HinAve_E http://www.openstreetmap.org/?lat=28.106710&lon=-81.618024
 CR580 http://www.openstreetmap.org/?lat=28.114011&lon=-81.618000
 BatRd http://www.openstreetmap.org/?lat=28.135833&lon=-81.613124
 CR547 http://www.openstreetmap.org/?lat=28.159393&lon=-81.603130
@@ -62,7 +62,7 @@ US192_W http://www.openstreetmap.org/?lat=28.304515&lon=-81.416000
 US192/441 +US192/441_S http://www.openstreetmap.org/?lat=28.304456&lon=-81.403692
 CarSt http://www.openstreetmap.org/?lat=28.326239&lon=-81.403724
 CR522 http://www.openstreetmap.org/?lat=28.337258&lon=-81.403743
-TownCenBlvd +TowCenBlvd http://www.openstreetmap.org/?lat=28.367797&lon=-81.404475
+TownCenBlvd http://www.openstreetmap.org/?lat=28.367797&lon=-81.404475
 FL417(11) http://www.openstreetmap.org/?lat=28.372607&lon=-81.404491
 CenFloPky http://www.openstreetmap.org/?lat=28.407395&lon=-81.404625
 ConDr http://www.openstreetmap.org/?lat=28.428223&lon=-81.404730
@@ -81,7 +81,7 @@ PriSt http://www.openstreetmap.org/?lat=28.570340&lon=-81.364446
 FL527_N http://www.openstreetmap.org/?lat=28.586000&lon=-81.364888
 FL426 http://www.openstreetmap.org/?lat=28.593106&lon=-81.365052
 FL423 +US17/92Trk_S http://www.openstreetmap.org/?lat=28.605946&lon=-81.365215
-LakeAve +CR438A http://www.openstreetmap.org/?lat=28.618569&lon=-81.365511
+LakeAve http://www.openstreetmap.org/?lat=28.618569&lon=-81.365511
 FL414 +FL414/17Trk http://www.openstreetmap.org/?lat=28.637210&lon=-81.358853
 FL436 http://www.openstreetmap.org/?lat=28.660664&lon=-81.341620
 FL434 http://www.openstreetmap.org/?lat=28.697900&lon=-81.327147
@@ -113,7 +113,7 @@ FL40 http://www.openstreetmap.org/?lat=29.187344&lon=-81.421013
 +X005(US17) http://www.openstreetmap.org/?lat=29.217045&lon=-81.458248
 WasAve http://www.openstreetmap.org/?lat=29.245260&lon=-81.463191
 CR305 http://www.openstreetmap.org/?lat=29.317036&lon=-81.492814
-OldHwy17 +OldUS17Hwy http://www.openstreetmap.org/?lat=29.372510&lon=-81.509146
+OldHwy17 http://www.openstreetmap.org/?lat=29.372510&lon=-81.509146
 CR308 http://www.openstreetmap.org/?lat=29.437537&lon=-81.510618
 +X006(US17) http://www.openstreetmap.org/?lat=29.449809&lon=-81.512278
 UniAve http://www.openstreetmap.org/?lat=29.474989&lon=-81.536764
@@ -134,9 +134,9 @@ CR216 http://www.openstreetmap.org/?lat=29.686641&lon=-81.662367
 +X011(US17) http://www.openstreetmap.org/?lat=29.704348&lon=-81.663828
 CR209_S http://www.openstreetmap.org/?lat=29.715659&lon=-81.657826
 +X012(US17) http://www.openstreetmap.org/?lat=29.742838&lon=-81.643009
-CR209_N +PalBluRd http://www.openstreetmap.org/?lat=29.774221&lon=-81.639571
+CR209_N http://www.openstreetmap.org/?lat=29.774221&lon=-81.639571
 +X013(US17) http://www.openstreetmap.org/?lat=29.811038&lon=-81.659607
-CR214_W +CR214 http://www.openstreetmap.org/?lat=29.838783&lon=-81.661731
+CR214_W http://www.openstreetmap.org/?lat=29.838783&lon=-81.661731
 CR214_E http://www.openstreetmap.org/?lat=29.853297&lon=-81.662691
 CroRd http://www.openstreetmap.org/?lat=29.882455&lon=-81.665309
 CR15A http://www.openstreetmap.org/?lat=29.933922&lon=-81.688440
@@ -144,7 +144,7 @@ CR209S +CR209 http://www.openstreetmap.org/?lat=29.960886&lon=-81.670955
 FL16_E http://www.openstreetmap.org/?lat=29.983247&lon=-81.675965
 FL16_W http://www.openstreetmap.org/?lat=29.991948&lon=-81.678972
 CR315 http://www.openstreetmap.org/?lat=30.023896&lon=-81.706221
-CR220/15A +CR220 http://www.openstreetmap.org/?lat=30.102305&lon=-81.705655
+CR220/15A http://www.openstreetmap.org/?lat=30.102305&lon=-81.705655
 FL224 http://www.openstreetmap.org/?lat=30.165912&lon=-81.701068
 I-295(10) http://www.openstreetmap.org/?lat=30.191600&lon=-81.705379
 YorAve http://www.openstreetmap.org/?lat=30.225992&lon=-81.700462
@@ -161,7 +161,7 @@ I-10/95 +I-95(351B) http://www.openstreetmap.org/?lat=30.320947&lon=-81.682373
 I-95(352A) http://www.openstreetmap.org/?lat=30.323564&lon=-81.680627
 I-95(352B) http://www.openstreetmap.org/?lat=30.329861&lon=-81.675475
 I-95(352C) http://www.openstreetmap.org/?lat=30.331824&lon=-81.673329
-I-95(353B) +I-95(353A) http://www.openstreetmap.org/?lat=30.334586&lon=-81.670545
+I-95(353B) http://www.openstreetmap.org/?lat=30.334586&lon=-81.670545
 I-95(353C) +I-95(353) http://www.openstreetmap.org/?lat=30.336361&lon=-81.669311
 BroSt http://www.openstreetmap.org/?lat=30.334183&lon=-81.663461
 US1/23 +US1/23_S http://www.openstreetmap.org/?lat=30.332495&lon=-81.655492
@@ -175,7 +175,7 @@ ClaRd http://www.openstreetmap.org/?lat=30.414034&lon=-81.650289
 FL104 http://www.openstreetmap.org/?lat=30.430132&lon=-81.644830
 I-295(36) +FL9A(36) http://www.openstreetmap.org/?lat=30.457400&lon=-81.635904
 AirCenDr http://www.openstreetmap.org/?lat=30.475590&lon=-81.629882
-MaxLegPkwy +DuvRd http://www.openstreetmap.org/?lat=30.490448&lon=-81.624953
+MaxLegPkwy http://www.openstreetmap.org/?lat=30.490448&lon=-81.624953
 PecParRd http://www.openstreetmap.org/?lat=30.517782&lon=-81.622614
 +X014(US17) http://www.openstreetmap.org/?lat=30.557623&lon=-81.620328
 +X015(US17) http://www.openstreetmap.org/?lat=30.588633&lon=-81.600029

--- a/hwy_data/FL/usaus/fl.us019.wpt
+++ b/hwy_data/FL/usaus/fl.us019.wpt
@@ -1,5 +1,5 @@
 US41 http://www.openstreetmap.org/?lat=27.550610&lon=-82.563404
-61stSt +PalRd http://www.openstreetmap.org/?lat=27.564900&lon=-82.565158
+61stSt http://www.openstreetmap.org/?lat=27.564900&lon=-82.565158
 I-275(5) http://www.openstreetmap.org/?lat=27.581755&lon=-82.579414
 SSkyPier http://www.openstreetmap.org/?lat=27.583810&lon=-82.613306
 +X000(I275) http://www.openstreetmap.org/?lat=27.607653&lon=-82.646280
@@ -12,7 +12,7 @@ CR138 +22ndAveS http://www.openstreetmap.org/?lat=27.748356&lon=-82.679332
 5thAve +5thAveS http://www.openstreetmap.org/?lat=27.766471&lon=-82.679436
 US19Alt_S http://www.openstreetmap.org/?lat=27.777305&lon=-82.679417
 22ndAveN http://www.openstreetmap.org/?lat=27.791867&lon=-82.679500
-CR184 +38thAveN http://www.openstreetmap.org/?lat=27.806478&lon=-82.679549
+CR184 http://www.openstreetmap.org/?lat=27.806478&lon=-82.679549
 CR202 http://www.openstreetmap.org/?lat=27.821068&lon=-82.679549
 HaiRd +CR691 http://www.openstreetmap.org/?lat=27.834618&lon=-82.680863
 FL694 http://www.openstreetmap.org/?lat=27.839612&lon=-82.684023
@@ -40,7 +40,7 @@ CR816 http://www.openstreetmap.org/?lat=28.093600&lon=-82.739590
 CR582 +FL582 http://www.openstreetmap.org/?lat=28.146216&lon=-82.740352
 US19Alt_N http://www.openstreetmap.org/?lat=28.182352&lon=-82.740250
 FL54 http://www.openstreetmap.org/?lat=28.216973&lon=-82.737337
-MainSt +MaiSt http://www.openstreetmap.org/?lat=28.250151&lon=-82.727764
+MainSt http://www.openstreetmap.org/?lat=28.250151&lon=-82.727764
 BelAve http://www.openstreetmap.org/?lat=28.266427&lon=-82.727501
 CR524 http://www.openstreetmap.org/?lat=28.280491&lon=-82.717320
 CR77 http://www.openstreetmap.org/?lat=28.306308&lon=-82.701699
@@ -71,12 +71,12 @@ FL345 http://www.openstreetmap.org/?lat=29.474781&lon=-82.859624
 US27Alt_S http://www.openstreetmap.org/?lat=29.486180&lon=-82.859675
 US129 http://www.openstreetmap.org/?lat=29.487581&lon=-82.860062
 FL320 http://www.openstreetmap.org/?lat=29.496537&lon=-82.868232
-CR55A_Lev +CR55A http://www.openstreetmap.org/?lat=29.588171&lon=-82.923281
+CR55A_Lev http://www.openstreetmap.org/?lat=29.588171&lon=-82.923281
 FL26 http://www.openstreetmap.org/?lat=29.590884&lon=-82.926336
 +X004(US19) http://www.openstreetmap.org/?lat=29.590895&lon=-82.941831
 +X005(US19) http://www.openstreetmap.org/?lat=29.583578&lon=-82.952470
 FL349 http://www.openstreetmap.org/?lat=29.601561&lon=-82.981944
-CR55A_Dix +55AHwy http://www.openstreetmap.org/?lat=29.610061&lon=-83.084206
+CR55A_Dix http://www.openstreetmap.org/?lat=29.610061&lon=-83.084206
 CR351_N http://www.openstreetmap.org/?lat=29.633518&lon=-83.123240
 CR351_S http://www.openstreetmap.org/?lat=29.634469&lon=-83.124871
 CR358 http://www.openstreetmap.org/?lat=29.653727&lon=-83.175578
@@ -88,15 +88,15 @@ FL51 http://www.openstreetmap.org/?lat=29.777939&lon=-83.325977
 +X008(US19) http://www.openstreetmap.org/?lat=29.816151&lon=-83.348132
 FishCreRd http://www.openstreetmap.org/?lat=29.886011&lon=-83.412390
 +X009(US19) http://www.openstreetmap.org/?lat=29.946963&lon=-83.452696
-JoshEzeRd +JoshEze http://www.openstreetmap.org/?lat=29.984388&lon=-83.493605
-CR356_S +RedPadRd http://www.openstreetmap.org/?lat=30.018018&lon=-83.528227
+JoshEzeRd http://www.openstreetmap.org/?lat=29.984388&lon=-83.493605
+CR356_S http://www.openstreetmap.org/?lat=30.018018&lon=-83.528227
 CR361 http://www.openstreetmap.org/?lat=30.051651&lon=-83.551733
 CR30_Tay http://www.openstreetmap.org/?lat=30.068186&lon=-83.559410
 US221 http://www.openstreetmap.org/?lat=30.098354&lon=-83.583389
 ChuSt http://www.openstreetmap.org/?lat=30.105361&lon=-83.589107
 US27/98 +US27/98_W http://www.openstreetmap.org/?lat=30.111605&lon=-83.589215
 MainSt_Per http://www.openstreetmap.org/?lat=30.117970&lon=-83.589467
-CR356_N +CR356 http://www.openstreetmap.org/?lat=30.124171&lon=-83.594300
+CR356_N http://www.openstreetmap.org/?lat=30.124171&lon=-83.594300
 US221Trk_N http://www.openstreetmap.org/?lat=30.146296&lon=-83.611488
 BoydRd http://www.openstreetmap.org/?lat=30.180061&lon=-83.637698
 PleGroRd http://www.openstreetmap.org/?lat=30.290580&lon=-83.736634
@@ -108,5 +108,5 @@ AttRd http://www.openstreetmap.org/?lat=30.456356&lon=-83.893361
 I-10 +I-10(225) http://www.openstreetmap.org/?lat=30.475525&lon=-83.889681
 CR259 http://www.openstreetmap.org/?lat=30.522046&lon=-83.873368
 US90 http://www.openstreetmap.org/?lat=30.545134&lon=-83.870152
-CR149/259 +CR149 http://www.openstreetmap.org/?lat=30.561679&lon=-83.870160
+CR149/259 http://www.openstreetmap.org/?lat=30.561679&lon=-83.870160
 FL/GA http://www.openstreetmap.org/?lat=30.665805&lon=-83.879727

--- a/hwy_data/FL/usaus/fl.us023.wpt
+++ b/hwy_data/FL/usaus/fl.us023.wpt
@@ -12,7 +12,7 @@ RatRd http://www.openstreetmap.org/?lat=30.510737&lon=-81.793208
 FL115_Cal +FL115_S http://www.openstreetmap.org/?lat=30.560173&lon=-81.825461
 US301/A1A +US301/A1A_S http://www.openstreetmap.org/?lat=30.563680&lon=-81.829769
 CR115 +CR115_N http://www.openstreetmap.org/?lat=30.571046&lon=-81.835468
-MusRd +MusWhiRd http://www.openstreetmap.org/?lat=30.589524&lon=-81.829779
+MusRd http://www.openstreetmap.org/?lat=30.589524&lon=-81.829779
 SauRd http://www.openstreetmap.org/?lat=30.629641&lon=-81.852066
 CR108 http://www.openstreetmap.org/?lat=30.690944&lon=-81.917737
 CR121 http://www.openstreetmap.org/?lat=30.774141&lon=-81.978545

--- a/hwy_data/FL/usaus/fl.us027.wpt
+++ b/hwy_data/FL/usaus/fl.us027.wpt
@@ -15,7 +15,7 @@ FL823 http://www.openstreetmap.org/?lat=25.829648&lon=-80.289792
 FL826 http://www.openstreetmap.org/?lat=25.854110&lon=-80.322517
 FL932 http://www.openstreetmap.org/?lat=25.867220&lon=-80.340067
 HiaGarBlvd http://www.openstreetmap.org/?lat=25.879270&lon=-80.356400
-138thStExt +138thSt http://www.openstreetmap.org/?lat=25.896052&lon=-80.379091
+138thStExt http://www.openstreetmap.org/?lat=25.896052&lon=-80.379091
 FLTpk(35) +FL821T http://www.openstreetmap.org/?lat=25.900736&lon=-80.385391
 +X000(US27) http://www.openstreetmap.org/?lat=25.934071&lon=-80.429621
 FL997 http://www.openstreetmap.org/?lat=25.950612&lon=-80.430828
@@ -26,7 +26,7 @@ GriRd +OldFL818 http://www.openstreetmap.org/?lat=26.059657&lon=-80.434000
 RecRd http://www.openstreetmap.org/?lat=26.130267&lon=-80.438727
 I-75(23) http://www.openstreetmap.org/?lat=26.144500&lon=-80.441822
 +X002(US27) http://www.openstreetmap.org/?lat=26.236017&lon=-80.461900
-HolLandWMA +DeemCity http://www.openstreetmap.org/?lat=26.336254&lon=-80.538937
+HolLandWMA http://www.openstreetmap.org/?lat=26.336254&lon=-80.538937
 +X003(US27) http://www.openstreetmap.org/?lat=26.557591&lon=-80.710437
 OkeRd http://www.openstreetmap.org/?lat=26.580873&lon=-80.710877
 CR827 http://www.openstreetmap.org/?lat=26.609968&lon=-80.711650
@@ -58,7 +58,7 @@ SunNLBlvd http://www.openstreetmap.org/?lat=27.234548&lon=-81.330277
 CR29 http://www.openstreetmap.org/?lat=27.266911&lon=-81.347821
 CR17A/621 +CR621 http://www.openstreetmap.org/?lat=27.297145&lon=-81.358470
 LagRd http://www.openstreetmap.org/?lat=27.313910&lon=-81.359704
-CR17_Hig +CR17_Lak http://www.openstreetmap.org/?lat=27.333993&lon=-81.384712
+CR17_Hig http://www.openstreetmap.org/?lat=27.333993&lon=-81.384712
 LakeFraRd http://www.openstreetmap.org/?lat=27.354871&lon=-81.388977
 LakeJosDr http://www.openstreetmap.org/?lat=27.391066&lon=-81.414000
 US98_S +US98_E http://www.openstreetmap.org/?lat=27.429090&lon=-81.418042
@@ -101,7 +101,7 @@ FL50 http://www.openstreetmap.org/?lat=28.547236&lon=-81.741800
 CROld50 http://www.openstreetmap.org/?lat=28.575649&lon=-81.748302
 CR561_S http://www.openstreetmap.org/?lat=28.590377&lon=-81.752030
 CR561_N http://www.openstreetmap.org/?lat=28.620467&lon=-81.760045
-WilLakePkwy +LibRd http://www.openstreetmap.org/?lat=28.635391&lon=-81.780649
+WilLakePkwy http://www.openstreetmap.org/?lat=28.635391&lon=-81.780649
 FL19 http://www.openstreetmap.org/?lat=28.642476&lon=-81.806696
 FLTpk(285) +FLTpke(285) http://www.openstreetmap.org/?lat=28.642987&lon=-81.809223
 CR565 http://www.openstreetmap.org/?lat=28.657263&lon=-81.846565
@@ -118,14 +118,14 @@ EagNestRd http://www.openstreetmap.org/?lat=28.887075&lon=-81.906306
 CR466 http://www.openstreetmap.org/?lat=28.917725&lon=-81.922707
 CR25 http://www.openstreetmap.org/?lat=28.923850&lon=-81.924486
 CR42 http://www.openstreetmap.org/?lat=28.982000&lon=-81.987373
-92ndLp +132ndStRd http://www.openstreetmap.org/?lat=29.030690&lon=-82.023035
+92ndLp http://www.openstreetmap.org/?lat=29.030690&lon=-82.023035
 CR25A http://www.openstreetmap.org/?lat=29.051093&lon=-82.037948
 BasRd http://www.openstreetmap.org/?lat=29.053956&lon=-82.040749
 US301_S http://www.openstreetmap.org/?lat=29.058245&lon=-82.050016
 FL25 http://www.openstreetmap.org/?lat=29.058861&lon=-82.053017
 110thSt http://www.openstreetmap.org/?lat=29.062472&lon=-82.066412
 CR467 http://www.openstreetmap.org/?lat=29.084320&lon=-82.078884
-92ndPlRd +92ndPlaRd http://www.openstreetmap.org/?lat=29.088033&lon=-82.081003
+92ndPlRd http://www.openstreetmap.org/?lat=29.088033&lon=-82.081003
 CR328 http://www.openstreetmap.org/?lat=29.106281&lon=-82.091555
 CR464A http://www.openstreetmap.org/?lat=29.147481&lon=-82.115309
 FL464 http://www.openstreetmap.org/?lat=29.171646&lon=-82.140183
@@ -156,7 +156,7 @@ CR232 http://www.openstreetmap.org/?lat=29.727434&lon=-82.607145
 +X014(US27) http://www.openstreetmap.org/?lat=29.804194&lon=-82.608433
 CR340 http://www.openstreetmap.org/?lat=29.819288&lon=-82.601609
 US41_N http://www.openstreetmap.org/?lat=29.826970&lon=-82.596900
-MapSt +BadRd http://www.openstreetmap.org/?lat=29.845246&lon=-82.634445
+MapSt http://www.openstreetmap.org/?lat=29.845246&lon=-82.634445
 CR138 http://www.openstreetmap.org/?lat=29.853283&lon=-82.641301
 +X015(US27) http://www.openstreetmap.org/?lat=29.868122&lon=-82.649696
 CR778 http://www.openstreetmap.org/?lat=29.885460&lon=-82.668922
@@ -166,10 +166,10 @@ US129_S http://www.openstreetmap.org/?lat=29.952408&lon=-82.860507
 US129_N http://www.openstreetmap.org/?lat=29.955794&lon=-82.927618
 FL349 http://www.openstreetmap.org/?lat=29.950131&lon=-82.948896
 CR416 http://www.openstreetmap.org/?lat=30.013159&lon=-83.037023
-CR354/405 +CR354 http://www.openstreetmap.org/?lat=30.053427&lon=-83.096109
+CR354/405 http://www.openstreetmap.org/?lat=30.053427&lon=-83.096109
 FL51 http://www.openstreetmap.org/?lat=30.053055&lon=-83.175300
 +X016(US27) http://www.openstreetmap.org/?lat=30.125558&lon=-83.272258
-CR53/534 +CR53 http://www.openstreetmap.org/?lat=30.129200&lon=-83.292573
+CR53/534 http://www.openstreetmap.org/?lat=30.129200&lon=-83.292573
 CR348 http://www.openstreetmap.org/?lat=30.129238&lon=-83.339463
 +X017(US27) http://www.openstreetmap.org/?lat=30.129233&lon=-83.363539
 JamBeaRd http://www.openstreetmap.org/?lat=30.114496&lon=-83.414297
@@ -179,7 +179,7 @@ CR30 http://www.openstreetmap.org/?lat=30.081642&lon=-83.520421
 US221 http://www.openstreetmap.org/?lat=30.111550&lon=-83.582101
 US19/98 +US19/98_S http://www.openstreetmap.org/?lat=30.111605&lon=-83.589215
 MainSt_Per http://www.openstreetmap.org/?lat=30.117970&lon=-83.589467
-CR356_N +CR356 http://www.openstreetmap.org/?lat=30.124171&lon=-83.594300
+CR356_N http://www.openstreetmap.org/?lat=30.124171&lon=-83.594300
 US221Trk_N http://www.openstreetmap.org/?lat=30.146296&lon=-83.611488
 BoydRd http://www.openstreetmap.org/?lat=30.180061&lon=-83.637698
 PleGroRd http://www.openstreetmap.org/?lat=30.290580&lon=-83.736634
@@ -188,7 +188,7 @@ CR257B http://www.openstreetmap.org/?lat=30.378137&lon=-83.813882
 US19_N http://www.openstreetmap.org/?lat=30.411015&lon=-83.911318
 FL59 http://www.openstreetmap.org/?lat=30.404642&lon=-84.020959
 +X019(US27) http://www.openstreetmap.org/?lat=30.402348&lon=-84.051536
-CR1543/2195 +CR1543 http://www.openstreetmap.org/?lat=30.422409&lon=-84.118643
+CR1543/2195 http://www.openstreetmap.org/?lat=30.422409&lon=-84.118643
 US319 http://www.openstreetmap.org/?lat=30.427371&lon=-84.226776
 CR373 http://www.openstreetmap.org/?lat=30.432223&lon=-84.249516
 FL265 http://www.openstreetmap.org/?lat=30.436903&lon=-84.261813
@@ -208,7 +208,7 @@ FL159 http://www.openstreetmap.org/?lat=30.614504&lon=-84.421542
 12thAve http://www.openstreetmap.org/?lat=30.618589&lon=-84.415652
 FL12 http://www.openstreetmap.org/?lat=30.623958&lon=-84.415311
 CR159A http://www.openstreetmap.org/?lat=30.653048&lon=-84.416070
-PeaFarmRd +PeaRd http://www.openstreetmap.org/?lat=30.665189&lon=-84.409131
+PeaFarmRd http://www.openstreetmap.org/?lat=30.665189&lon=-84.409131
 +X021(US27) http://www.openstreetmap.org/?lat=30.677035&lon=-84.386008
-CR157 +DorCalRd http://www.openstreetmap.org/?lat=30.688133&lon=-84.380474
+CR157 http://www.openstreetmap.org/?lat=30.688133&lon=-84.380474
 FL/GA http://www.openstreetmap.org/?lat=30.690008&lon=-84.380890

--- a/hwy_data/FL/usaus/fl.us041.wpt
+++ b/hwy_data/FL/usaus/fl.us041.wpt
@@ -30,10 +30,10 @@ FL997 http://www.openstreetmap.org/?lat=25.760977&lon=-80.481336
 GatPark http://www.openstreetmap.org/?lat=25.760951&lon=-80.581313
 ShaVal +ShaVLRd http://www.openstreetmap.org/?lat=25.761885&lon=-80.766436
 LoopRd_E +CR94_W http://www.openstreetmap.org/?lat=25.762011&lon=-80.827366
-DCTTAir +DCTAirp http://www.openstreetmap.org/?lat=25.845950&lon=-80.925143
+DCTTAir http://www.openstreetmap.org/?lat=25.845950&lon=-80.925143
 OasVisCen http://www.openstreetmap.org/?lat=25.856723&lon=-81.032109
 LoopRd_W +CR94_E http://www.openstreetmap.org/?lat=25.863681&lon=-81.100570
-BurLakeCam +BurRd http://www.openstreetmap.org/?lat=25.876851&lon=-81.229949
+BurLakeCam http://www.openstreetmap.org/?lat=25.876851&lon=-81.229949
 CR839 http://www.openstreetmap.org/?lat=25.887744&lon=-81.262557
 BassLakeRd http://www.openstreetmap.org/?lat=25.901164&lon=-81.294531
 CR841 http://www.openstreetmap.org/?lat=25.901488&lon=-81.310748
@@ -68,7 +68,7 @@ CR78A http://www.openstreetmap.org/?lat=26.667259&lon=-81.889845
 FL78 http://www.openstreetmap.org/?lat=26.682140&lon=-81.901582
 LitRd http://www.openstreetmap.org/?lat=26.696840&lon=-81.900716
 US41BusFor_N http://www.openstreetmap.org/?lat=26.712525&lon=-81.902462
-DelPraBlvd +CR867A http://www.openstreetmap.org/?lat=26.725393&lon=-81.906627
+DelPraBlvd http://www.openstreetmap.org/?lat=26.725393&lon=-81.906627
 ZemRd http://www.openstreetmap.org/?lat=26.799433&lon=-81.950165
 CR762 http://www.openstreetmap.org/?lat=26.858148&lon=-81.988089
 CR765 http://www.openstreetmap.org/?lat=26.891225&lon=-82.023542
@@ -81,8 +81,8 @@ ChaBlvd http://www.openstreetmap.org/?lat=27.019833&lon=-82.186484
 SumBlvd http://www.openstreetmap.org/?lat=27.038140&lon=-82.219727
 PanAmeBlvd http://www.openstreetmap.org/?lat=27.045445&lon=-82.243668
 DeMirAve http://www.openstreetmap.org/?lat=27.048293&lon=-82.281514
-RivRd +FL777 +CR777 http://www.openstreetmap.org/?lat=27.041740&lon=-82.300156
-WVilPkwy +VilPkwy http://www.openstreetmap.org/?lat=27.049404&lon=-82.320648
+RivRd +FL777 http://www.openstreetmap.org/?lat=27.041740&lon=-82.300156
+WVilPkwy http://www.openstreetmap.org/?lat=27.049404&lon=-82.320648
 JacBlvd http://www.openstreetmap.org/?lat=27.049810&lon=-82.397536
 FL776_W http://www.openstreetmap.org/?lat=27.050111&lon=-82.406269
 US41BusVen_S http://www.openstreetmap.org/?lat=27.074541&lon=-82.425056
@@ -121,7 +121,7 @@ PinPoiRd http://www.openstreetmap.org/?lat=27.633895&lon=-82.539707
 FL674 http://www.openstreetmap.org/?lat=27.713145&lon=-82.434127
 19thAve http://www.openstreetmap.org/?lat=27.735176&lon=-82.430758
 ApoBeaBlvd http://www.openstreetmap.org/?lat=27.768782&lon=-82.392021
-BigBendRd +CR672 http://www.openstreetmap.org/?lat=27.792529&lon=-82.384388
+BigBendRd http://www.openstreetmap.org/?lat=27.792529&lon=-82.384388
 GibDr http://www.openstreetmap.org/?lat=27.849770&lon=-82.381719
 OldUSHwy41A http://www.openstreetmap.org/?lat=27.891922&lon=-82.401259
 US41BusTam_S http://www.openstreetmap.org/?lat=27.923023&lon=-82.401892
@@ -136,7 +136,7 @@ US92_E http://www.openstreetmap.org/?lat=27.996085&lon=-82.414083
 22ndSt http://www.openstreetmap.org/?lat=27.996088&lon=-82.434741
 US92_W http://www.openstreetmap.org/?lat=27.996064&lon=-82.451140
 SliAve http://www.openstreetmap.org/?lat=28.010680&lon=-82.451274
-BirdSt +BirSt http://www.openstreetmap.org/?lat=28.022596&lon=-82.451263
+BirdSt http://www.openstreetmap.org/?lat=28.022596&lon=-82.451263
 FL580 http://www.openstreetmap.org/?lat=28.032859&lon=-82.451274
 FL582 http://www.openstreetmap.org/?lat=28.054572&lon=-82.451124
 FL579 http://www.openstreetmap.org/?lat=28.069256&lon=-82.451153
@@ -201,7 +201,7 @@ US27_N http://www.openstreetmap.org/?lat=29.826970&lon=-82.596900
 US441_S http://www.openstreetmap.org/?lat=29.830004&lon=-82.595150
 +X008(US41) http://www.openstreetmap.org/?lat=29.846893&lon=-82.607580
 CR778 http://www.openstreetmap.org/?lat=29.887081&lon=-82.609133
-CR18_W +CR18 http://www.openstreetmap.org/?lat=29.936899&lon=-82.608250
+CR18_W http://www.openstreetmap.org/?lat=29.936899&lon=-82.608250
 CR18_E http://www.openstreetmap.org/?lat=29.952218&lon=-82.605289
 I-75(414) http://www.openstreetmap.org/?lat=29.999832&lon=-82.597400
 FL238 http://www.openstreetmap.org/?lat=30.003760&lon=-82.597369
@@ -215,7 +215,7 @@ FL47 http://www.openstreetmap.org/?lat=30.168662&lon=-82.640957
 FL10A http://www.openstreetmap.org/?lat=30.183456&lon=-82.639343
 US90/441 +US90 http://www.openstreetmap.org/?lat=30.189363&lon=-82.639471
 LongSt http://www.openstreetmap.org/?lat=30.199719&lon=-82.639978
-US441/100A +US441Trk_N http://www.openstreetmap.org/?lat=30.203101&lon=-82.643420
+US441/100A http://www.openstreetmap.org/?lat=30.203101&lon=-82.643420
 CR25A http://www.openstreetmap.org/?lat=30.242292&lon=-82.672607
 I-10 +I-10(301) http://www.openstreetmap.org/?lat=30.245117&lon=-82.674608
 CR246 http://www.openstreetmap.org/?lat=30.312681&lon=-82.714262
@@ -224,7 +224,7 @@ FL136 http://www.openstreetmap.org/?lat=30.329794&lon=-82.758991
 +X012(US41) http://www.openstreetmap.org/?lat=30.341112&lon=-82.761565
 CR132 http://www.openstreetmap.org/?lat=30.400242&lon=-82.835181
 US129_S http://www.openstreetmap.org/?lat=30.488596&lon=-82.930223
-CR6 +CR6_E http://www.openstreetmap.org/?lat=30.518006&lon=-82.945761
+CR6 http://www.openstreetmap.org/?lat=30.518006&lon=-82.945761
 US129_N http://www.openstreetmap.org/?lat=30.524455&lon=-82.961921
 86thBlvd http://www.openstreetmap.org/?lat=30.523826&lon=-83.023086
 FL6_W http://www.openstreetmap.org/?lat=30.529831&lon=-83.042023

--- a/hwy_data/FL/usaus/fl.us090.wpt
+++ b/hwy_data/FL/usaus/fl.us090.wpt
@@ -37,7 +37,7 @@ DeaBriRd http://www.openstreetmap.org/?lat=30.658957&lon=-86.880433
 +X003(US90) http://www.openstreetmap.org/?lat=30.675171&lon=-86.855174
 CR189_S +CR189 http://www.openstreetmap.org/?lat=30.714025&lon=-86.749704
 +X004(US90) http://www.openstreetmap.org/?lat=30.723530&lon=-86.726182
-CR189_N +GalCut http://www.openstreetmap.org/?lat=30.724208&lon=-86.707765
+CR189_N http://www.openstreetmap.org/?lat=30.724208&lon=-86.707765
 WilBluRd http://www.openstreetmap.org/?lat=30.721572&lon=-86.675391
 +X004A(US90) http://www.openstreetmap.org/?lat=30.728123&lon=-86.659362
 FL4 http://www.openstreetmap.org/?lat=30.750713&lon=-86.636942
@@ -49,7 +49,7 @@ CR393 http://www.openstreetmap.org/?lat=30.751748&lon=-86.436023
 FL285 http://www.openstreetmap.org/?lat=30.736925&lon=-86.348575
 CR1087 http://www.openstreetmap.org/?lat=30.743396&lon=-86.313658
 +X006(US90) http://www.openstreetmap.org/?lat=30.751700&lon=-86.282512
-KinLakeRd +KingLakeRd http://www.openstreetmap.org/?lat=30.744600&lon=-86.206946
+KinLakeRd http://www.openstreetmap.org/?lat=30.744600&lon=-86.206946
 US331_N http://www.openstreetmap.org/?lat=30.734087&lon=-86.148632
 US331_S http://www.openstreetmap.org/?lat=30.721881&lon=-86.120437
 FL83 http://www.openstreetmap.org/?lat=30.721388&lon=-86.115365
@@ -57,7 +57,7 @@ CR183_N http://www.openstreetmap.org/?lat=30.727141&lon=-86.071454
 CR183_S http://www.openstreetmap.org/?lat=30.720343&lon=-86.045362
 +X007(US90) http://www.openstreetmap.org/?lat=30.718844&lon=-86.020943
 FL81 http://www.openstreetmap.org/?lat=30.726555&lon=-85.937730
-CR179A/181 +CR181 http://www.openstreetmap.org/?lat=30.772242&lon=-85.850161
+CR179A/181 http://www.openstreetmap.org/?lat=30.772242&lon=-85.850161
 +X008(US90) http://www.openstreetmap.org/?lat=30.778207&lon=-85.836053
 CR279 http://www.openstreetmap.org/?lat=30.774052&lon=-85.812100
 CR179 http://www.openstreetmap.org/?lat=30.776633&lon=-85.804435
@@ -81,7 +81,7 @@ CR271 http://www.openstreetmap.org/?lat=30.709485&lon=-84.932342
 CR286 http://www.openstreetmap.org/?lat=30.710631&lon=-84.925395
 ACIDr http://www.openstreetmap.org/?lat=30.708431&lon=-84.897897
 +X008A(US90) http://www.openstreetmap.org/?lat=30.698016&lon=-84.868988
-MainSt +CR269 http://www.openstreetmap.org/?lat=30.705006&lon=-84.843370
+MainSt http://www.openstreetmap.org/?lat=30.705006&lon=-84.843370
 CR269A http://www.openstreetmap.org/?lat=30.702919&lon=-84.791660
 CR379B http://www.openstreetmap.org/?lat=30.691678&lon=-84.733102
 +X009(US90) http://www.openstreetmap.org/?lat=30.688310&lon=-84.721874
@@ -101,7 +101,7 @@ CR1583 http://www.openstreetmap.org/?lat=30.459206&lon=-84.386668
 FL263 http://www.openstreetmap.org/?lat=30.458868&lon=-84.360989
 FL20 http://www.openstreetmap.org/?lat=30.456179&lon=-84.344881
 WhiDr http://www.openstreetmap.org/?lat=30.447064&lon=-84.326162
-StaDr +BrySt http://www.openstreetmap.org/?lat=30.449051&lon=-84.306716
+StaDr http://www.openstreetmap.org/?lat=30.449051&lon=-84.306716
 MacSt +CR157 http://www.openstreetmap.org/?lat=30.444685&lon=-84.288491
 US27 http://www.openstreetmap.org/?lat=30.444700&lon=-84.280677
 CR1555 http://www.openstreetmap.org/?lat=30.444705&lon=-84.272167
@@ -129,10 +129,10 @@ FL53_N http://www.openstreetmap.org/?lat=30.469400&lon=-83.414910
 FL53/145 +FL53_S http://www.openstreetmap.org/?lat=30.469420&lon=-83.410032
 FL6 http://www.openstreetmap.org/?lat=30.469216&lon=-83.375582
 CR255 http://www.openstreetmap.org/?lat=30.419800&lon=-83.300276
-MyrSt +CR141 http://www.openstreetmap.org/?lat=30.400228&lon=-83.208561
+MyrSt http://www.openstreetmap.org/?lat=30.400228&lon=-83.208561
 CR132 http://www.openstreetmap.org/?lat=30.377432&lon=-83.165831
 I-10(275) http://www.openstreetmap.org/?lat=30.343463&lon=-83.090337
-76thSt +MitRd http://www.openstreetmap.org/?lat=30.313325&lon=-83.023539
+76thSt http://www.openstreetmap.org/?lat=30.313325&lon=-83.023539
 US129 http://www.openstreetmap.org/?lat=30.296142&lon=-82.984393
 CR49 http://www.openstreetmap.org/?lat=30.283659&lon=-82.954180
 CR417 http://www.openstreetmap.org/?lat=30.253382&lon=-82.897344
@@ -143,12 +143,12 @@ PinRd http://www.openstreetmap.org/?lat=30.184592&lon=-82.709697
 I-75 +I-75(427) http://www.openstreetmap.org/?lat=30.179929&lon=-82.688600
 FL247 http://www.openstreetmap.org/?lat=30.178879&lon=-82.666932
 FL10A_W http://www.openstreetmap.org/?lat=30.187367&lon=-82.651383
-EadSt +DuvSt http://www.openstreetmap.org/?lat=30.188985&lon=-82.649538
+EadSt http://www.openstreetmap.org/?lat=30.188985&lon=-82.649538
 US41/441 +US41 http://www.openstreetmap.org/?lat=30.189363&lon=-82.639471
 US441_S +US441 http://www.openstreetmap.org/?lat=30.189340&lon=-82.637148
 FL100 +FL100_S http://www.openstreetmap.org/?lat=30.186428&lon=-82.603873
 FL10A_E +US90Trk_E http://www.openstreetmap.org/?lat=30.186433&lon=-82.597039
-TimDr +TimAve http://www.openstreetmap.org/?lat=30.188427&lon=-82.566370
+TimDr http://www.openstreetmap.org/?lat=30.188427&lon=-82.566370
 CR231 http://www.openstreetmap.org/?lat=30.204390&lon=-82.428845
 I-10(324) http://www.openstreetmap.org/?lat=30.238923&lon=-82.303830
 CR127/229 +CR229 http://www.openstreetmap.org/?lat=30.250233&lon=-82.271279
@@ -174,7 +174,7 @@ FL228_E http://www.openstreetmap.org/?lat=30.327226&lon=-81.657018
 BaySt +OldUS17_S http://www.openstreetmap.org/?lat=30.326073&lon=-81.657348
 IndDr http://www.openstreetmap.org/?lat=30.325136&lon=-81.657973
 RivBlvd http://www.openstreetmap.org/?lat=30.318546&lon=-81.658939
-FL5/13 +FL13 http://www.openstreetmap.org/?lat=30.316307&lon=-81.659035
+FL5/13 http://www.openstreetmap.org/?lat=30.316307&lon=-81.659035
 I-95(350A) +I-95(350) http://www.openstreetmap.org/?lat=30.314050&lon=-81.658429
 +X022(I95) http://www.openstreetmap.org/?lat=30.313668&lon=-81.652177
 I-95(349) http://www.openstreetmap.org/?lat=30.310037&lon=-81.647730
@@ -184,7 +184,7 @@ US1Alt http://www.openstreetmap.org/?lat=30.296230&lon=-81.614500
 FL109 http://www.openstreetmap.org/?lat=30.292548&lon=-81.601969
 HartExpy http://www.openstreetmap.org/?lat=30.288935&lon=-81.581986
 US90AltJac_E http://www.openstreetmap.org/?lat=30.286589&lon=-81.559171
-StJohRd +StJohBRd http://www.openstreetmap.org/?lat=30.286920&lon=-81.525692
+StJohRd http://www.openstreetmap.org/?lat=30.286920&lon=-81.525692
 I-295 +FL9A(51) http://www.openstreetmap.org/?lat=30.286969&lon=-81.521725
 KerBlvd http://www.openstreetmap.org/?lat=30.287344&lon=-81.488981
 HodBlvd http://www.openstreetmap.org/?lat=30.287678&lon=-81.458908

--- a/hwy_data/FL/usaus/fl.us092.wpt
+++ b/hwy_data/FL/usaus/fl.us092.wpt
@@ -4,7 +4,7 @@ US19Alt +FL595 http://www.openstreetmap.org/?lat=27.776956&lon=-82.637776
 38thAve http://www.openstreetmap.org/?lat=27.806700&lon=-82.638589
 54thAve http://www.openstreetmap.org/?lat=27.821220&lon=-82.638651
 FL687/694 +FL694 +FL694/687 http://www.openstreetmap.org/?lat=27.864617&lon=-82.638828
-WesBlvd +CR587 +WShoBlvd http://www.openstreetmap.org/?lat=27.893431&lon=-82.526821
+WesBlvd +CR587 http://www.openstreetmap.org/?lat=27.893431&lon=-82.526821
 FL618 +FL618T http://www.openstreetmap.org/?lat=27.893706&lon=-82.507909
 FL573 http://www.openstreetmap.org/?lat=27.893706&lon=-82.506329
 FL618(1B) http://www.openstreetmap.org/?lat=27.896128&lon=-82.506300
@@ -31,7 +31,7 @@ McIRd http://www.openstreetmap.org/?lat=28.016000&lon=-82.244650
 BraForRd http://www.openstreetmap.org/?lat=28.020936&lon=-82.187079
 FL566 http://www.openstreetmap.org/?lat=28.018954&lon=-82.144054
 FL39 +FL39A http://www.openstreetmap.org/?lat=28.017249&lon=-82.137973
-FL574_E +FL574Pla http://www.openstreetmap.org/?lat=28.016307&lon=-82.135318
+FL574_E http://www.openstreetmap.org/?lat=28.016307&lon=-82.135318
 WheSt http://www.openstreetmap.org/?lat=28.016785&lon=-82.125276
 ColSt +FL39_S http://www.openstreetmap.org/?lat=28.017074&lon=-82.123629
 FL553 http://www.openstreetmap.org/?lat=28.018755&lon=-82.104963
@@ -77,7 +77,7 @@ US192_W http://www.openstreetmap.org/?lat=28.304515&lon=-81.416000
 US192/441 +US192/441_S http://www.openstreetmap.org/?lat=28.304456&lon=-81.403692
 CarSt http://www.openstreetmap.org/?lat=28.326239&lon=-81.403724
 CR522 http://www.openstreetmap.org/?lat=28.337258&lon=-81.403743
-TownCenBlvd +TowCenBlvd http://www.openstreetmap.org/?lat=28.367797&lon=-81.404475
+TownCenBlvd http://www.openstreetmap.org/?lat=28.367797&lon=-81.404475
 FL417(11) http://www.openstreetmap.org/?lat=28.372607&lon=-81.404491
 CenFloPky http://www.openstreetmap.org/?lat=28.407395&lon=-81.404625
 ConDr http://www.openstreetmap.org/?lat=28.428223&lon=-81.404730
@@ -96,7 +96,7 @@ PriSt http://www.openstreetmap.org/?lat=28.570340&lon=-81.364446
 FL527_N http://www.openstreetmap.org/?lat=28.586000&lon=-81.364888
 FL426 http://www.openstreetmap.org/?lat=28.593106&lon=-81.365052
 FL423 http://www.openstreetmap.org/?lat=28.605946&lon=-81.365215
-LakeAve +CR438A http://www.openstreetmap.org/?lat=28.618569&lon=-81.365511
+LakeAve http://www.openstreetmap.org/?lat=28.618569&lon=-81.365511
 FL414 +FL414/17Trk http://www.openstreetmap.org/?lat=28.637210&lon=-81.358853
 FL436 http://www.openstreetmap.org/?lat=28.660664&lon=-81.341620
 FL434 http://www.openstreetmap.org/?lat=28.697900&lon=-81.327147

--- a/hwy_data/FL/usaus/fl.us098.wpt
+++ b/hwy_data/FL/usaus/fl.us098.wpt
@@ -10,7 +10,7 @@ FL294 http://www.openstreetmap.org/?lat=30.407300&lon=-87.273315
 CR453 http://www.openstreetmap.org/?lat=30.412253&lon=-87.250870
 US98BusPen_W http://www.openstreetmap.org/?lat=30.411874&lon=-87.241726
 US90_W http://www.openstreetmap.org/?lat=30.420679&lon=-87.241270
-ASt +CoySt http://www.openstreetmap.org/?lat=30.419988&lon=-87.225582
+ASt http://www.openstreetmap.org/?lat=30.419988&lon=-87.225582
 US29 http://www.openstreetmap.org/?lat=30.421320&lon=-87.217348
 I-110 +I-110(2) http://www.openstreetmap.org/?lat=30.421864&lon=-87.214148
 FL291 http://www.openstreetmap.org/?lat=30.422300&lon=-87.211441
@@ -51,7 +51,7 @@ FroBeaRd +FL30_E +CR30Bay http://www.openstreetmap.org/?lat=30.264852&lon=-85.97
 WildHerWay http://www.openstreetmap.org/?lat=30.261342&lon=-85.956017
 WisLn http://www.openstreetmap.org/?lat=30.250594&lon=-85.933369
 FL79 http://www.openstreetmap.org/?lat=30.230036&lon=-85.887790
-RicJacBlvd +BecRd http://www.openstreetmap.org/?lat=30.196082&lon=-85.811964
+RicJacBlvd http://www.openstreetmap.org/?lat=30.196082&lon=-85.811964
 FL30 +OldUS98Alt_E +FL30_W http://www.openstreetmap.org/?lat=30.188200&lon=-85.764138
 CR3031 http://www.openstreetmap.org/?lat=30.188614&lon=-85.760940
 SunHarRd http://www.openstreetmap.org/?lat=30.185090&lon=-85.730937
@@ -87,17 +87,17 @@ CR30A http://www.openstreetmap.org/?lat=29.776526&lon=-85.279666
 CR30 http://www.openstreetmap.org/?lat=29.720623&lon=-85.107055
 CR385_App http://www.openstreetmap.org/?lat=29.725486&lon=-85.082250
 +X013A(US98) http://www.openstreetmap.org/?lat=29.718317&lon=-85.060701
-24thAve +25thAve http://www.openstreetmap.org/?lat=29.714007&lon=-85.003066
+24thAve http://www.openstreetmap.org/?lat=29.714007&lon=-85.003066
 CR384 http://www.openstreetmap.org/?lat=29.721932&lon=-84.990535
-MarSt_W +MarSt http://www.openstreetmap.org/?lat=29.727739&lon=-84.984752
+MarSt_W http://www.openstreetmap.org/?lat=29.727739&lon=-84.984752
 +X014(US98) http://www.openstreetmap.org/?lat=29.723683&lon=-84.980991
 US319_End http://www.openstreetmap.org/?lat=29.725985&lon=-84.971606
 FL300 http://www.openstreetmap.org/?lat=29.736186&lon=-84.887983
 FL65 http://www.openstreetmap.org/?lat=29.757550&lon=-84.833229
 +X014A(US98) http://www.openstreetmap.org/?lat=29.769178&lon=-84.798446
 HerRd http://www.openstreetmap.org/?lat=29.802723&lon=-84.738337
-GulfBeaDr +GulfBeaRd http://www.openstreetmap.org/?lat=29.833185&lon=-84.684538
-11thSt +10thSt http://www.openstreetmap.org/?lat=29.852772&lon=-84.674774
+GulfBeaDr http://www.openstreetmap.org/?lat=29.833185&lon=-84.684538
+11thSt http://www.openstreetmap.org/?lat=29.852772&lon=-84.674774
 TalSt +CR67 http://www.openstreetmap.org/?lat=29.851090&lon=-84.664775
 GulfAve http://www.openstreetmap.org/?lat=29.850769&lon=-84.642746
 US319_N http://www.openstreetmap.org/?lat=29.918963&lon=-84.520150
@@ -122,7 +122,7 @@ FL59 http://www.openstreetmap.org/?lat=30.189570&lon=-84.049627
 +X020(US98) http://www.openstreetmap.org/?lat=30.160523&lon=-84.001631
 AucLanRd http://www.openstreetmap.org/?lat=30.144877&lon=-83.970115
 CR14 http://www.openstreetmap.org/?lat=30.141101&lon=-83.900506
-CabGroRd +CagGroRd http://www.openstreetmap.org/?lat=30.141249&lon=-83.770403
+CabGroRd http://www.openstreetmap.org/?lat=30.141249&lon=-83.770403
 +X021(US98) http://www.openstreetmap.org/?lat=30.084060&lon=-83.664032
 CR356_W +CR356 http://www.openstreetmap.org/?lat=30.087295&lon=-83.653389
 US19/27 +US19/27_N http://www.openstreetmap.org/?lat=30.111605&lon=-83.589215
@@ -130,8 +130,8 @@ ChuSt http://www.openstreetmap.org/?lat=30.105361&lon=-83.589107
 US221 http://www.openstreetmap.org/?lat=30.098354&lon=-83.583389
 CR30_Tay http://www.openstreetmap.org/?lat=30.068186&lon=-83.559410
 CR361 http://www.openstreetmap.org/?lat=30.051651&lon=-83.551733
-CR356_S +RedPadRd http://www.openstreetmap.org/?lat=30.018018&lon=-83.528227
-JoshEzeRd +JoshEze http://www.openstreetmap.org/?lat=29.984388&lon=-83.493605
+CR356_S http://www.openstreetmap.org/?lat=30.018018&lon=-83.528227
+JoshEzeRd http://www.openstreetmap.org/?lat=29.984388&lon=-83.493605
 +X009(US19) http://www.openstreetmap.org/?lat=29.946963&lon=-83.452696
 FishCreRd http://www.openstreetmap.org/?lat=29.886011&lon=-83.412390
 +X008(US19) http://www.openstreetmap.org/?lat=29.816151&lon=-83.348132
@@ -143,12 +143,12 @@ CR358_E http://www.openstreetmap.org/?lat=29.707456&lon=-83.292238
 CR358 http://www.openstreetmap.org/?lat=29.653727&lon=-83.175578
 CR351_S http://www.openstreetmap.org/?lat=29.634469&lon=-83.124871
 CR351_N http://www.openstreetmap.org/?lat=29.633518&lon=-83.123240
-CR55A_Dix +55AHwy http://www.openstreetmap.org/?lat=29.610061&lon=-83.084206
+CR55A_Dix http://www.openstreetmap.org/?lat=29.610061&lon=-83.084206
 FL349 http://www.openstreetmap.org/?lat=29.601561&lon=-82.981944
 +X005(US19) http://www.openstreetmap.org/?lat=29.583578&lon=-82.952470
 +X004(US19) http://www.openstreetmap.org/?lat=29.590895&lon=-82.941831
 FL26 http://www.openstreetmap.org/?lat=29.590884&lon=-82.926336
-CR55A_Lev +CR55A http://www.openstreetmap.org/?lat=29.588171&lon=-82.923281
+CR55A_Lev http://www.openstreetmap.org/?lat=29.588171&lon=-82.923281
 FL320 http://www.openstreetmap.org/?lat=29.496537&lon=-82.868232
 US129 http://www.openstreetmap.org/?lat=29.487581&lon=-82.860062
 US27Alt_S http://www.openstreetmap.org/?lat=29.486180&lon=-82.859675
@@ -195,7 +195,7 @@ CR35Alt http://www.openstreetmap.org/?lat=28.300385&lon=-82.149405
 CR54 http://www.openstreetmap.org/?lat=28.259294&lon=-82.075768
 FL471 http://www.openstreetmap.org/?lat=28.247982&lon=-82.055576
 RocRd http://www.openstreetmap.org/?lat=28.192913&lon=-82.000880
-CR35A +WSocLoopRd +SocLoopRd http://www.openstreetmap.org/?lat=28.164799&lon=-81.974605
+CR35A +WSocLoopRd http://www.openstreetmap.org/?lat=28.164799&lon=-81.974605
 MarRd http://www.openstreetmap.org/?lat=28.128051&lon=-81.973597
 I-4 +I-4(32) http://www.openstreetmap.org/?lat=28.085157&lon=-81.970335
 TucSt http://www.openstreetmap.org/?lat=28.073386&lon=-81.958646
@@ -236,7 +236,7 @@ FL17Seb_S http://www.openstreetmap.org/?lat=27.471334&lon=-81.442852
 US27_S http://www.openstreetmap.org/?lat=27.429090&lon=-81.418042
 CR17_N http://www.openstreetmap.org/?lat=27.428266&lon=-81.412642
 CR17_S http://www.openstreetmap.org/?lat=27.427121&lon=-81.403131
-HayTayBlvd +AirRd http://www.openstreetmap.org/?lat=27.434389&lon=-81.366463
+HayTayBlvd http://www.openstreetmap.org/?lat=27.434389&lon=-81.366463
 +X024(US98) http://www.openstreetmap.org/?lat=27.433670&lon=-81.318923
 +X025(US98) http://www.openstreetmap.org/?lat=27.450781&lon=-81.281018
 +X026(US98) http://www.openstreetmap.org/?lat=27.450352&lon=-81.266953
@@ -276,7 +276,7 @@ CR880 http://www.openstreetmap.org/?lat=26.687218&lon=-80.387564
 SemPraWhiRd http://www.openstreetmap.org/?lat=26.683633&lon=-80.309967
 ForHillBlvd http://www.openstreetmap.org/?lat=26.681700&lon=-80.247051
 US441_S http://www.openstreetmap.org/?lat=26.680609&lon=-80.202330
-FLTpk +PikeRd +PreRd http://www.openstreetmap.org/?lat=26.679310&lon=-80.166399
+FLTpk +PreRd http://www.openstreetmap.org/?lat=26.679310&lon=-80.166399
 JogRd http://www.openstreetmap.org/?lat=26.678850&lon=-80.145207
 HavRd http://www.openstreetmap.org/?lat=26.678294&lon=-80.120384
 FL809 http://www.openstreetmap.org/?lat=26.678087&lon=-80.112197

--- a/hwy_data/FL/usaus/fl.us129.wpt
+++ b/hwy_data/FL/usaus/fl.us129.wpt
@@ -16,16 +16,16 @@ CR349 http://www.openstreetmap.org/?lat=30.038323&lon=-82.940412
 +X000(US129) http://www.openstreetmap.org/?lat=30.150156&lon=-82.949352
 CR252_E http://www.openstreetmap.org/?lat=30.162804&lon=-82.964764
 CR252_W http://www.openstreetmap.org/?lat=30.174125&lon=-82.979583
-117thRd +CraLn http://www.openstreetmap.org/?lat=30.182218&lon=-82.986882
+117thRd http://www.openstreetmap.org/?lat=30.182218&lon=-82.986882
 FL51 http://www.openstreetmap.org/?lat=30.290121&lon=-82.987719
 US90 http://www.openstreetmap.org/?lat=30.296142&lon=-82.984393
 I-10 +I-10(283) http://www.openstreetmap.org/?lat=30.330627&lon=-82.962584
 CR136A http://www.openstreetmap.org/?lat=30.352949&lon=-82.946375
 CR132_W http://www.openstreetmap.org/?lat=30.384623&lon=-82.938253
-CR132_E +CR132 http://www.openstreetmap.org/?lat=30.408001&lon=-82.933930
+CR132_E http://www.openstreetmap.org/?lat=30.408001&lon=-82.933930
 I-75 +I-75(451) http://www.openstreetmap.org/?lat=30.448731&lon=-82.933018
 US41_S http://www.openstreetmap.org/?lat=30.488596&lon=-82.930223
-CR6 +CR6_E http://www.openstreetmap.org/?lat=30.518006&lon=-82.945761
+CR6 http://www.openstreetmap.org/?lat=30.518006&lon=-82.945761
 US41_N http://www.openstreetmap.org/?lat=30.524455&lon=-82.961921
 CR150 http://www.openstreetmap.org/?lat=30.596340&lon=-83.010791
 FL/GA http://www.openstreetmap.org/?lat=30.617450&lon=-83.023510

--- a/hwy_data/FL/usaus/fl.us192.wpt
+++ b/hwy_data/FL/usaus/fl.us192.wpt
@@ -1,5 +1,5 @@
 US27 http://www.openstreetmap.org/?lat=28.346955&lon=-81.673648
-CR545_N +AvaRd http://www.openstreetmap.org/?lat=28.346825&lon=-81.648234
+CR545_N http://www.openstreetmap.org/?lat=28.346825&lon=-81.648234
 FL429 http://www.openstreetmap.org/?lat=28.346993&lon=-81.616045
 BlaLakeRd http://www.openstreetmap.org/?lat=28.346514&lon=-81.605448
 CR545_S +NOldLWRd +CR545 http://www.openstreetmap.org/?lat=28.332999&lon=-81.587482

--- a/hwy_data/FL/usaus/fl.us221.wpt
+++ b/hwy_data/FL/usaus/fl.us221.wpt
@@ -1,6 +1,6 @@
 US19/98 http://www.openstreetmap.org/?lat=30.098354&lon=-83.583389
 US27 http://www.openstreetmap.org/?lat=30.111550&lon=-83.582101
-GreSt +CR356 http://www.openstreetmap.org/?lat=30.117118&lon=-83.582085
+GreSt http://www.openstreetmap.org/?lat=30.117118&lon=-83.582085
 AshSt http://www.openstreetmap.org/?lat=30.128240&lon=-83.582584
 US221Trk_N http://www.openstreetmap.org/?lat=30.146512&lon=-83.588944
 PisRd http://www.openstreetmap.org/?lat=30.164836&lon=-83.595306

--- a/hwy_data/FL/usaus/fl.us231.wpt
+++ b/hwy_data/FL/usaus/fl.us231.wpt
@@ -6,13 +6,13 @@ FL368 http://www.openstreetmap.org/?lat=30.189372&lon=-85.640981
 FL389 http://www.openstreetmap.org/?lat=30.200783&lon=-85.624880
 FL390 http://www.openstreetmap.org/?lat=30.233352&lon=-85.578952
 CR2293/2315 +CR2315 http://www.openstreetmap.org/?lat=30.248759&lon=-85.557151
-CamRd +CamFloRd http://www.openstreetmap.org/?lat=30.310780&lon=-85.469542
+CamRd http://www.openstreetmap.org/?lat=30.310780&lon=-85.469542
 VealRd http://www.openstreetmap.org/?lat=30.334440&lon=-85.443482
 CR388 http://www.openstreetmap.org/?lat=30.366755&lon=-85.438292
 FL20 http://www.openstreetmap.org/?lat=30.435622&lon=-85.427322
 +X000(US231) http://www.openstreetmap.org/?lat=30.523771&lon=-85.406733
 CR167 http://www.openstreetmap.org/?lat=30.534334&lon=-85.394347
-LakRd +FreRd http://www.openstreetmap.org/?lat=30.579156&lon=-85.387732
+LakRd http://www.openstreetmap.org/?lat=30.579156&lon=-85.387732
 +X001(US231) http://www.openstreetmap.org/?lat=30.584600&lon=-85.394840
 +X002(US231) http://www.openstreetmap.org/?lat=30.644510&lon=-85.400113
 ShoRd http://www.openstreetmap.org/?lat=30.655930&lon=-85.393665

--- a/hwy_data/FL/usaus/fl.us301.wpt
+++ b/hwy_data/FL/usaus/fl.us301.wpt
@@ -6,7 +6,7 @@ WhiAve http://www.openstreetmap.org/?lat=27.418150&lon=-82.532875
 FL70 +FL70_S http://www.openstreetmap.org/?lat=27.447355&lon=-82.530372
 44thAve http://www.openstreetmap.org/?lat=27.461774&lon=-82.530359
 38thAve http://www.openstreetmap.org/?lat=27.465627&lon=-82.531813
-15thSt +FL70_N +FL70Bra http://www.openstreetmap.org/?lat=27.475339&lon=-82.546616
+15thSt +FL70_N http://www.openstreetmap.org/?lat=27.475339&lon=-82.546616
 +X000(US301) http://www.openstreetmap.org/?lat=27.481464&lon=-82.562208
 US41_S http://www.openstreetmap.org/?lat=27.485288&lon=-82.562959
 FL64 http://www.openstreetmap.org/?lat=27.494527&lon=-82.563010
@@ -64,15 +64,15 @@ CR656 http://www.openstreetmap.org/?lat=28.581107&lon=-82.152618
 CR673 http://www.openstreetmap.org/?lat=28.611587&lon=-82.137686
 CR48/476 http://www.openstreetmap.org/?lat=28.657618&lon=-82.115046
 FL48 http://www.openstreetmap.org/?lat=28.664891&lon=-82.112613
-FloSt +CR48 +CR48_S http://www.openstreetmap.org/?lat=28.664884&lon=-82.110550
-CR476_E +CR476 http://www.openstreetmap.org/?lat=28.665034&lon=-82.106814
+FloSt +CR48 http://www.openstreetmap.org/?lat=28.664884&lon=-82.110550
+CR476_E http://www.openstreetmap.org/?lat=28.665034&lon=-82.106814
 CR532C http://www.openstreetmap.org/?lat=28.707151&lon=-82.103995
 CR528 http://www.openstreetmap.org/?lat=28.734121&lon=-82.069775
 CR470_W http://www.openstreetmap.org/?lat=28.748865&lon=-82.062472
 FL471 http://www.openstreetmap.org/?lat=28.753309&lon=-82.060329
 CR470_E http://www.openstreetmap.org/?lat=28.756476&lon=-82.060726
 WarmSprAve_W +ComSt http://www.openstreetmap.org/?lat=28.799856&lon=-82.070521
-WarmSprAve_E +CR468 http://www.openstreetmap.org/?lat=28.800048&lon=-82.048543
+WarmSprAve_E http://www.openstreetmap.org/?lat=28.800048&lon=-82.048543
 FLTpk http://www.openstreetmap.org/?lat=28.837094&lon=-82.045467
 FL44 http://www.openstreetmap.org/?lat=28.847200&lon=-82.045440
 OldWireRd http://www.openstreetmap.org/?lat=28.870876&lon=-82.037106
@@ -126,7 +126,7 @@ FordRd http://www.openstreetmap.org/?lat=30.435271&lon=-81.921535
 CraRd http://www.openstreetmap.org/?lat=30.513253&lon=-81.874360
 US1/23_S http://www.openstreetmap.org/?lat=30.563680&lon=-81.829769
 CR115 +CR115_N http://www.openstreetmap.org/?lat=30.571046&lon=-81.835468
-MusRd +MusWhiRd http://www.openstreetmap.org/?lat=30.589524&lon=-81.829779
+MusRd http://www.openstreetmap.org/?lat=30.589524&lon=-81.829779
 SauRd http://www.openstreetmap.org/?lat=30.629641&lon=-81.852066
 CR108 http://www.openstreetmap.org/?lat=30.690944&lon=-81.917737
 CR121 http://www.openstreetmap.org/?lat=30.774141&lon=-81.978545

--- a/hwy_data/FL/usaus/fl.us319.wpt
+++ b/hwy_data/FL/usaus/fl.us319.wpt
@@ -1,10 +1,10 @@
 US98_W http://www.openstreetmap.org/?lat=29.725985&lon=-84.971606
-FL300 +IslDr http://www.openstreetmap.org/?lat=29.736186&lon=-84.887983
+FL300 http://www.openstreetmap.org/?lat=29.736186&lon=-84.887983
 FL65 http://www.openstreetmap.org/?lat=29.757550&lon=-84.833229
 +X014A(US98) http://www.openstreetmap.org/?lat=29.769178&lon=-84.798446
 HerRd http://www.openstreetmap.org/?lat=29.802723&lon=-84.738337
-GulfBeaDr +GulfBeaRd http://www.openstreetmap.org/?lat=29.833185&lon=-84.684538
-11thSt +10thSt http://www.openstreetmap.org/?lat=29.852772&lon=-84.674774
+GulfBeaDr http://www.openstreetmap.org/?lat=29.833185&lon=-84.684538
+11thSt http://www.openstreetmap.org/?lat=29.852772&lon=-84.674774
 TalSt +CR67 http://www.openstreetmap.org/?lat=29.851090&lon=-84.664775
 GulfAve http://www.openstreetmap.org/?lat=29.850769&lon=-84.642746
 US98_E http://www.openstreetmap.org/?lat=29.918963&lon=-84.520150
@@ -12,7 +12,7 @@ US98_E http://www.openstreetmap.org/?lat=29.918963&lon=-84.520150
 +X001(US319) http://www.openstreetmap.org/?lat=29.955883&lon=-84.505334
 +X002(US319) http://www.openstreetmap.org/?lat=29.971656&lon=-84.498682
 CR299 http://www.openstreetmap.org/?lat=30.002382&lon=-84.503939
-RoseSt +FL375/377 +CR375 http://www.openstreetmap.org/?lat=30.060844&lon=-84.488672
+RoseSt http://www.openstreetmap.org/?lat=30.060844&lon=-84.488672
 US98_MedW +US98Med_W http://www.openstreetmap.org/?lat=30.083837&lon=-84.387639
 OldCraHwy_S +US98Med_E http://www.openstreetmap.org/?lat=30.104816&lon=-84.380273
 US98_MedE http://www.openstreetmap.org/?lat=30.107118&lon=-84.378766
@@ -29,15 +29,15 @@ FL363 http://www.openstreetmap.org/?lat=30.375749&lon=-84.270222
 +X004(US319) http://www.openstreetmap.org/?lat=30.376559&lon=-84.239843
 CR259 http://www.openstreetmap.org/?lat=30.381244&lon=-84.236735
 BlaStoRd http://www.openstreetmap.org/?lat=30.402528&lon=-84.234903
-OraAve +MonRd http://www.openstreetmap.org/?lat=30.410860&lon=-84.234930
-OldSARd +CR2196 http://www.openstreetmap.org/?lat=30.420742&lon=-84.229045
+OraAve http://www.openstreetmap.org/?lat=30.410860&lon=-84.234930
+OldSARd http://www.openstreetmap.org/?lat=30.420742&lon=-84.229045
 US27 http://www.openstreetmap.org/?lat=30.427371&lon=-84.226776
-ParkAve +ParAve http://www.openstreetmap.org/?lat=30.441355&lon=-84.226561
+ParkAve http://www.openstreetmap.org/?lat=30.441355&lon=-84.226561
 US90 http://www.openstreetmap.org/?lat=30.460075&lon=-84.227990
 CR0347/146 http://www.openstreetmap.org/?lat=30.469635&lon=-84.230901
 CR151 http://www.openstreetmap.org/?lat=30.478300&lon=-84.236665
 RayDieRd http://www.openstreetmap.org/?lat=30.500349&lon=-84.247568
-I-10 +I-10(203A) http://www.openstreetmap.org/?lat=30.501837&lon=-84.248067
+I-10 http://www.openstreetmap.org/?lat=30.501837&lon=-84.248067
 FL160 http://www.openstreetmap.org/?lat=30.505165&lon=-84.249303
 FL61 +FL61Tal_S http://www.openstreetmap.org/?lat=30.506491&lon=-84.250116
 KilWay http://www.openstreetmap.org/?lat=30.512571&lon=-84.244473

--- a/hwy_data/FL/usaus/fl.us331.wpt
+++ b/hwy_data/FL/usaus/fl.us331.wpt
@@ -4,7 +4,7 @@ CR3280 http://www.openstreetmap.org/?lat=30.444370&lon=-86.138649
 FL20 +FL20_E http://www.openstreetmap.org/?lat=30.491125&lon=-86.121266
 +X001(US331) http://www.openstreetmap.org/?lat=30.520430&lon=-86.108758
 CR883 http://www.openstreetmap.org/?lat=30.551923&lon=-86.106285
-EglSiteC6 +CR282 http://www.openstreetmap.org/?lat=30.592050&lon=-86.109805
+EglSiteC6 http://www.openstreetmap.org/?lat=30.592050&lon=-86.109805
 I-10 +I-10(85) http://www.openstreetmap.org/?lat=30.692146&lon=-86.122521
 CR280 http://www.openstreetmap.org/?lat=30.705850&lon=-86.122647
 US90_E http://www.openstreetmap.org/?lat=30.721881&lon=-86.120437
@@ -12,8 +12,8 @@ US90_W http://www.openstreetmap.org/?lat=30.734087&lon=-86.148632
 SunRd http://www.openstreetmap.org/?lat=30.776515&lon=-86.160817
 CR1084 +CR185 http://www.openstreetmap.org/?lat=30.822050&lon=-86.216251
 +X002(US331) http://www.openstreetmap.org/?lat=30.825740&lon=-86.228036
-CR2_E +CR2A_E http://www.openstreetmap.org/?lat=30.851063&lon=-86.244229
-CR2A +CR2A_W http://www.openstreetmap.org/?lat=30.852892&lon=-86.245433
+CR2_E http://www.openstreetmap.org/?lat=30.851063&lon=-86.244229
+CR2A http://www.openstreetmap.org/?lat=30.852892&lon=-86.245433
 CR2_W +CR2 http://www.openstreetmap.org/?lat=30.889900&lon=-86.279714
 CR285 http://www.openstreetmap.org/?lat=30.947477&lon=-86.285484
 CR147 http://www.openstreetmap.org/?lat=30.969765&lon=-86.301900

--- a/hwy_data/FL/usaus/fl.us441.wpt
+++ b/hwy_data/FL/usaus/fl.us441.wpt
@@ -40,7 +40,7 @@ FL816 http://www.openstreetmap.org/?lat=26.164786&lon=-80.203100
 FL870 http://www.openstreetmap.org/?lat=26.186633&lon=-80.203658
 McNRd http://www.openstreetmap.org/?lat=26.207393&lon=-80.204020
 FL814 http://www.openstreetmap.org/?lat=26.235418&lon=-80.204800
-CocCrePkwy +FL912 http://www.openstreetmap.org/?lat=26.244474&lon=-80.201413
+CocCrePkwy http://www.openstreetmap.org/?lat=26.244474&lon=-80.201413
 FL834 http://www.openstreetmap.org/?lat=26.274147&lon=-80.201791
 FL869 http://www.openstreetmap.org/?lat=26.300025&lon=-80.202373
 FL810 http://www.openstreetmap.org/?lat=26.317536&lon=-80.202553
@@ -128,10 +128,10 @@ HiaRd http://www.openstreetmap.org/?lat=28.654340&lon=-81.470044
 FL436 http://www.openstreetmap.org/?lat=28.672956&lon=-81.496826
 CR435 http://www.openstreetmap.org/?lat=28.673104&lon=-81.509470
 FL451 http://www.openstreetmap.org/?lat=28.682834&lon=-81.527101
-PlySorRd +CR437_N http://www.openstreetmap.org/?lat=28.693413&lon=-81.556631
-CR437 +CR437_S http://www.openstreetmap.org/?lat=28.694408&lon=-81.558748
+PlySorRd http://www.openstreetmap.org/?lat=28.693413&lon=-81.556631
+CR437 http://www.openstreetmap.org/?lat=28.694408&lon=-81.558748
 SR429ConRd +FL429ConRd http://www.openstreetmap.org/?lat=28.696460&lon=-81.562806
-YotRd +ChuDr http://www.openstreetmap.org/?lat=28.710378&lon=-81.582987
+YotRd http://www.openstreetmap.org/?lat=28.710378&lon=-81.582987
 CR448 http://www.openstreetmap.org/?lat=28.748954&lon=-81.620031
 CR500A http://www.openstreetmap.org/?lat=28.776786&lon=-81.624389
 FL46 http://www.openstreetmap.org/?lat=28.796889&lon=-81.625167
@@ -152,14 +152,14 @@ EagNestRd http://www.openstreetmap.org/?lat=28.887075&lon=-81.906306
 CR466 http://www.openstreetmap.org/?lat=28.917725&lon=-81.922707
 CR25 http://www.openstreetmap.org/?lat=28.923850&lon=-81.924486
 CR42 http://www.openstreetmap.org/?lat=28.982000&lon=-81.987373
-92ndLp +132ndStRd http://www.openstreetmap.org/?lat=29.030690&lon=-82.023035
+92ndLp http://www.openstreetmap.org/?lat=29.030690&lon=-82.023035
 CR25A http://www.openstreetmap.org/?lat=29.051093&lon=-82.037948
 BasRd http://www.openstreetmap.org/?lat=29.053956&lon=-82.040749
 US301_S http://www.openstreetmap.org/?lat=29.058245&lon=-82.050016
 FL25 http://www.openstreetmap.org/?lat=29.058861&lon=-82.053017
 110thSt http://www.openstreetmap.org/?lat=29.062472&lon=-82.066412
 CR467 http://www.openstreetmap.org/?lat=29.084320&lon=-82.078884
-92ndPlRd +92ndPlaRd http://www.openstreetmap.org/?lat=29.088033&lon=-82.081003
+92ndPlRd http://www.openstreetmap.org/?lat=29.088033&lon=-82.081003
 CR328 http://www.openstreetmap.org/?lat=29.106281&lon=-82.091555
 CR464A http://www.openstreetmap.org/?lat=29.147481&lon=-82.115309
 FL464 http://www.openstreetmap.org/?lat=29.171646&lon=-82.140183
@@ -172,7 +172,7 @@ CR318 http://www.openstreetmap.org/?lat=29.410430&lon=-82.212364
 CR320 http://www.openstreetmap.org/?lat=29.448807&lon=-82.222449
 219thStRd http://www.openstreetmap.org/?lat=29.467783&lon=-82.223200
 CR346 http://www.openstreetmap.org/?lat=29.505044&lon=-82.267454
-CR234_E +CR234_N http://www.openstreetmap.org/?lat=29.511204&lon=-82.279454
+CR234_E http://www.openstreetmap.org/?lat=29.511204&lon=-82.279454
 CR234_W +CR234_S http://www.openstreetmap.org/?lat=29.513895&lon=-82.290146
 +X010(US441) http://www.openstreetmap.org/?lat=29.565427&lon=-82.333000
 FL331 http://www.openstreetmap.org/?lat=29.614809&lon=-82.340775
@@ -184,7 +184,7 @@ FL120 http://www.openstreetmap.org/?lat=29.673954&lon=-82.339139
 FL222 http://www.openstreetmap.org/?lat=29.688500&lon=-82.339010
 FL20_E http://www.openstreetmap.org/?lat=29.699414&lon=-82.339327
 FL121 http://www.openstreetmap.org/?lat=29.711757&lon=-82.353698
-59thTer +NW59Ter http://www.openstreetmap.org/?lat=29.764177&lon=-82.407779
+59thTer http://www.openstreetmap.org/?lat=29.764177&lon=-82.407779
 CR237 http://www.openstreetmap.org/?lat=29.768475&lon=-82.421351
 FL235 http://www.openstreetmap.org/?lat=29.793692&lon=-82.494262
 I-75(399) http://www.openstreetmap.org/?lat=29.801699&lon=-82.513922
@@ -192,7 +192,7 @@ FL20_W http://www.openstreetmap.org/?lat=29.823437&lon=-82.588415
 US41_S http://www.openstreetmap.org/?lat=29.830004&lon=-82.595150
 +X008(US41) http://www.openstreetmap.org/?lat=29.846893&lon=-82.607580
 CR778 http://www.openstreetmap.org/?lat=29.887081&lon=-82.609133
-CR18_W +CR18 http://www.openstreetmap.org/?lat=29.936899&lon=-82.608250
+CR18_W http://www.openstreetmap.org/?lat=29.936899&lon=-82.608250
 CR18_E http://www.openstreetmap.org/?lat=29.952218&lon=-82.605289
 I-75(414) http://www.openstreetmap.org/?lat=29.999832&lon=-82.597400
 FL238 http://www.openstreetmap.org/?lat=30.003760&lon=-82.597369
@@ -206,7 +206,7 @@ US90_E +US90 http://www.openstreetmap.org/?lat=30.189340&lon=-82.637148
 US41/90 http://www.openstreetmap.org/?lat=30.189363&lon=-82.639471
 LongSt http://www.openstreetmap.org/?lat=30.199719&lon=-82.639978
 US41/100A http://www.openstreetmap.org/?lat=30.203101&lon=-82.643420
-CR100A +US441TrkLak_N http://www.openstreetmap.org/?lat=30.203412&lon=-82.637347
+CR100A http://www.openstreetmap.org/?lat=30.203412&lon=-82.637347
 CR25A_Lak http://www.openstreetmap.org/?lat=30.209295&lon=-82.637492
 I-10 +I-10(303) http://www.openstreetmap.org/?lat=30.241646&lon=-82.638449
 CR246 http://www.openstreetmap.org/?lat=30.316636&lon=-82.630271

--- a/hwy_data/FL/usausb/fl.us001bussta.wpt
+++ b/hwy_data/FL/usausb/fl.us001bussta.wpt
@@ -4,7 +4,7 @@ CorSt http://www.openstreetmap.org/?lat=29.892200&lon=-81.313934
 FLA1A_S http://www.openstreetmap.org/?lat=29.892767&lon=-81.310962
 OraSt http://www.openstreetmap.org/?lat=29.897820&lon=-81.313200
 CasDr http://www.openstreetmap.org/?lat=29.899508&lon=-81.314570
-SanCarAve +SanCAve http://www.openstreetmap.org/?lat=29.909056&lon=-81.320230
+SanCarAve http://www.openstreetmap.org/?lat=29.909056&lon=-81.320230
 FLA1A_N http://www.openstreetmap.org/?lat=29.909481&lon=-81.320362
-FL16 +FL16_End http://www.openstreetmap.org/?lat=29.917187&lon=-81.322732
+FL16 http://www.openstreetmap.org/?lat=29.917187&lon=-81.322732
 US1_N http://www.openstreetmap.org/?lat=29.923464&lon=-81.325100

--- a/hwy_data/FL/usausb/fl.us019altstp.wpt
+++ b/hwy_data/FL/usausb/fl.us019altstp.wpt
@@ -26,9 +26,9 @@ FL686 http://www.openstreetmap.org/?lat=27.916700&lon=-82.787771
 BelRd http://www.openstreetmap.org/?lat=27.938889&lon=-82.787387
 FL60_E http://www.openstreetmap.org/?lat=27.960848&lon=-82.787612
 FL60_W http://www.openstreetmap.org/?lat=27.961431&lon=-82.795860
-CleSt +OldFL60 http://www.openstreetmap.org/?lat=27.965636&lon=-82.795906
+CleSt http://www.openstreetmap.org/?lat=27.965636&lon=-82.795906
 FL590 http://www.openstreetmap.org/?lat=27.968168&lon=-82.795925
-FtHarAve +OldUS19Alt http://www.openstreetmap.org/?lat=27.983881&lon=-82.796016
+FtHarAve http://www.openstreetmap.org/?lat=27.983881&lon=-82.796016
 CR576 http://www.openstreetmap.org/?lat=27.990304&lon=-82.795627
 MarPla http://www.openstreetmap.org/?lat=28.012390&lon=-82.791220
 MainSt http://www.openstreetmap.org/?lat=28.012092&lon=-82.789769
@@ -37,10 +37,10 @@ BueVisDr http://www.openstreetmap.org/?lat=28.032784&lon=-82.788345
 FL586 http://www.openstreetmap.org/?lat=28.049488&lon=-82.780327
 CR752 http://www.openstreetmap.org/?lat=28.068243&lon=-82.769121
 CR776 http://www.openstreetmap.org/?lat=28.078969&lon=-82.767260
-CR816 +AldRd http://www.openstreetmap.org/?lat=28.093562&lon=-82.772552
+CR816 http://www.openstreetmap.org/?lat=28.093562&lon=-82.772552
 +X002(US19A) http://www.openstreetmap.org/?lat=28.109670&lon=-82.768600
 CR880 http://www.openstreetmap.org/?lat=28.122889&lon=-82.760895
-TarAve +FL582 http://www.openstreetmap.org/?lat=28.146223&lon=-82.756652
+TarAve http://www.openstreetmap.org/?lat=28.146223&lon=-82.756652
 RaiRd http://www.openstreetmap.org/?lat=28.163673&lon=-82.756885
 AncBlvd http://www.openstreetmap.org/?lat=28.172786&lon=-82.750188
 US19_N http://www.openstreetmap.org/?lat=28.182352&lon=-82.740250

--- a/hwy_data/FL/usausb/fl.us027altper.wpt
+++ b/hwy_data/FL/usausb/fl.us027altper.wpt
@@ -8,12 +8,12 @@ FL345 http://www.openstreetmap.org/?lat=29.475545&lon=-82.845025
 US19/98_S http://www.openstreetmap.org/?lat=29.486180&lon=-82.859675
 US129 http://www.openstreetmap.org/?lat=29.487581&lon=-82.860062
 FL320 http://www.openstreetmap.org/?lat=29.496537&lon=-82.868232
-CR55A_Lev +CR55A http://www.openstreetmap.org/?lat=29.588171&lon=-82.923281
+CR55A_Lev http://www.openstreetmap.org/?lat=29.588171&lon=-82.923281
 FL26 http://www.openstreetmap.org/?lat=29.590884&lon=-82.926336
 +X004(US19) http://www.openstreetmap.org/?lat=29.590895&lon=-82.941831
 +X005(US19) http://www.openstreetmap.org/?lat=29.583578&lon=-82.952470
 FL349 http://www.openstreetmap.org/?lat=29.601561&lon=-82.981944
-CR55A_Dix +55AHwy http://www.openstreetmap.org/?lat=29.610061&lon=-83.084206
+CR55A_Dix http://www.openstreetmap.org/?lat=29.610061&lon=-83.084206
 CR351_N http://www.openstreetmap.org/?lat=29.633518&lon=-83.123240
 CR351_S http://www.openstreetmap.org/?lat=29.634469&lon=-83.124871
 CR358 http://www.openstreetmap.org/?lat=29.653727&lon=-83.175578
@@ -25,8 +25,8 @@ FL51 http://www.openstreetmap.org/?lat=29.777939&lon=-83.325977
 +X008(US19) http://www.openstreetmap.org/?lat=29.816151&lon=-83.348132
 FishCreRd http://www.openstreetmap.org/?lat=29.886011&lon=-83.412390
 +X009(US19) http://www.openstreetmap.org/?lat=29.946963&lon=-83.452696
-JoshEzeRd +JoshEze http://www.openstreetmap.org/?lat=29.984388&lon=-83.493605
-CR356_S +RedPadRd http://www.openstreetmap.org/?lat=30.018018&lon=-83.528227
+JoshEzeRd http://www.openstreetmap.org/?lat=29.984388&lon=-83.493605
+CR356_S http://www.openstreetmap.org/?lat=30.018018&lon=-83.528227
 CR361 http://www.openstreetmap.org/?lat=30.051651&lon=-83.551733
 CR30_Tay http://www.openstreetmap.org/?lat=30.068186&lon=-83.559410
 US221 http://www.openstreetmap.org/?lat=30.098354&lon=-83.583389

--- a/hwy_data/FL/usausb/fl.us041busbra.wpt
+++ b/hwy_data/FL/usausb/fl.us041busbra.wpt
@@ -3,6 +3,6 @@ US41_S http://www.openstreetmap.org/?lat=27.462362&lon=-82.575345
 14thSt_N +8thAveW http://www.openstreetmap.org/?lat=27.492947&lon=-82.575211
 9thSt_S +9thStW http://www.openstreetmap.org/?lat=27.492886&lon=-82.571177
 FL64 http://www.openstreetmap.org/?lat=27.494782&lon=-82.571182
-10thSt +FL43 http://www.openstreetmap.org/?lat=27.521224&lon=-82.572918
-21stSt +21stStW http://www.openstreetmap.org/?lat=27.532256&lon=-82.572754
+10thSt http://www.openstreetmap.org/?lat=27.521224&lon=-82.572918
+21stSt http://www.openstreetmap.org/?lat=27.532256&lon=-82.572754
 US41_N http://www.openstreetmap.org/?lat=27.540911&lon=-82.564187

--- a/hwy_data/FL/usausb/fl.us041bustam.wpt
+++ b/hwy_data/FL/usausb/fl.us041bustam.wpt
@@ -11,15 +11,15 @@ FL45 http://www.openstreetmap.org/?lat=27.949893&lon=-82.450193
 FL618(8) http://www.openstreetmap.org/?lat=27.949514&lon=-82.451376
 FL60_W http://www.openstreetmap.org/?lat=27.947336&lon=-82.457789
 TylSt +ETylSt http://www.openstreetmap.org/?lat=27.952141&lon=-82.459927
-I-275 +ScoSt +KaySt +EKaySt http://www.openstreetmap.org/?lat=27.956612&lon=-82.460214
+I-275 +ScoSt +EKaySt http://www.openstreetmap.org/?lat=27.956612&lon=-82.460214
 PalmAve http://www.openstreetmap.org/?lat=27.962272&lon=-82.460176
-ColDr +EColDr http://www.openstreetmap.org/?lat=27.966896&lon=-82.460152
-FloAve +EFloAve http://www.openstreetmap.org/?lat=27.970914&lon=-82.460163
+ColDr http://www.openstreetmap.org/?lat=27.966896&lon=-82.460152
+FloAve http://www.openstreetmap.org/?lat=27.970914&lon=-82.460163
 FL574 http://www.openstreetmap.org/?lat=27.981519&lon=-82.460742
-VolSt +WVolSt http://www.openstreetmap.org/?lat=27.990636&lon=-82.460753
+VolSt http://www.openstreetmap.org/?lat=27.990636&lon=-82.460753
 US92 http://www.openstreetmap.org/?lat=27.996159&lon=-82.459452
 SliAve +CR598 http://www.openstreetmap.org/?lat=28.010683&lon=-82.459525
-BirdSt +EBirSt http://www.openstreetmap.org/?lat=28.022558&lon=-82.459522
+BirdSt http://www.openstreetmap.org/?lat=28.022558&lon=-82.459522
 FL580 http://www.openstreetmap.org/?lat=28.032942&lon=-82.459460
 FL582 http://www.openstreetmap.org/?lat=28.054636&lon=-82.459388
 FL579 http://www.openstreetmap.org/?lat=28.069315&lon=-82.459353

--- a/hwy_data/FL/usausb/fl.us041busven.wpt
+++ b/hwy_data/FL/usausb/fl.us041busven.wpt
@@ -1,5 +1,5 @@
 US41_S http://www.openstreetmap.org/?lat=27.074541&lon=-82.425056
 CenRd http://www.openstreetmap.org/?lat=27.077244&lon=-82.428060
-GolfDr +GolDr http://www.openstreetmap.org/?lat=27.090668&lon=-82.444241
+GolfDr http://www.openstreetmap.org/?lat=27.090668&lon=-82.444241
 VenAve +VenAveE http://www.openstreetmap.org/?lat=27.099854&lon=-82.444290
 US41_N http://www.openstreetmap.org/?lat=27.109280&lon=-82.444088

--- a/hwy_data/FL/usausb/fl.us090altjac.wpt
+++ b/hwy_data/FL/usausb/fl.us090altjac.wpt
@@ -2,6 +2,6 @@ US90_W http://www.openstreetmap.org/?lat=30.305274&lon=-81.635362
 US1Alt http://www.openstreetmap.org/?lat=30.308187&lon=-81.619121
 FL109 http://www.openstreetmap.org/?lat=30.313980&lon=-81.599410
 ArlRd http://www.openstreetmap.org/?lat=30.313422&lon=-81.579039
-FL10/115 +FL10 +FL10/115_N http://www.openstreetmap.org/?lat=30.316548&lon=-81.558823
+FL10/115 +FL10/115_N http://www.openstreetmap.org/?lat=30.316548&lon=-81.558823
 IveyRd http://www.openstreetmap.org/?lat=30.300167&lon=-81.558675
 US90_E http://www.openstreetmap.org/?lat=30.286589&lon=-81.559171

--- a/hwy_data/FL/usausb/fl.us098buspan.wpt
+++ b/hwy_data/FL/usausb/fl.us098buspan.wpt
@@ -1,17 +1,17 @@
 US98_W http://www.openstreetmap.org/?lat=30.177770&lon=-85.701470
-CR28 +W11thSt http://www.openstreetmap.org/?lat=30.168140&lon=-85.701545
-10thSt_W +W10thSt_W http://www.openstreetmap.org/?lat=30.167405&lon=-85.701556
-10thSt_E +W10thSt_E http://www.openstreetmap.org/?lat=30.167410&lon=-85.700516
+CR28 http://www.openstreetmap.org/?lat=30.168140&lon=-85.701545
+10thSt_W http://www.openstreetmap.org/?lat=30.167405&lon=-85.701556
+10thSt_E http://www.openstreetmap.org/?lat=30.167410&lon=-85.700516
 +X000(US98B) http://www.openstreetmap.org/?lat=30.166564&lon=-85.700505
 CR385 http://www.openstreetmap.org/?lat=30.166538&lon=-85.692136
-BeaDr_W +WBeaDr_W http://www.openstreetmap.org/?lat=30.165068&lon=-85.692136
+BeaDr_W http://www.openstreetmap.org/?lat=30.165068&lon=-85.692136
 BalAve http://www.openstreetmap.org/?lat=30.161343&lon=-85.675284
-BeaDr_E +WBeaDr_E http://www.openstreetmap.org/?lat=30.158850&lon=-85.666300
+BeaDr_E http://www.openstreetmap.org/?lat=30.158850&lon=-85.666300
 US231 http://www.openstreetmap.org/?lat=30.158820&lon=-85.660349
 FL77 http://www.openstreetmap.org/?lat=30.157457&lon=-85.650361
 FL389 http://www.openstreetmap.org/?lat=30.156800&lon=-85.625145
 FL22 http://www.openstreetmap.org/?lat=30.153110&lon=-85.617177
 PitAve http://www.openstreetmap.org/?lat=30.131390&lon=-85.612807
-Hwy22-A +BobLitRd http://www.openstreetmap.org/?lat=30.131070&lon=-85.599538
-BoatRaceRd +BoaRacRd_E http://www.openstreetmap.org/?lat=30.131052&lon=-85.597060
+Hwy22-A http://www.openstreetmap.org/?lat=30.131070&lon=-85.599538
+BoatRaceRd http://www.openstreetmap.org/?lat=30.131052&lon=-85.597060
 US98_E http://www.openstreetmap.org/?lat=30.126853&lon=-85.591300

--- a/hwy_data/FL/usausb/fl.us098buspen.wpt
+++ b/hwy_data/FL/usausb/fl.us098buspen.wpt
@@ -1,6 +1,6 @@
 US98_W http://www.openstreetmap.org/?lat=30.411874&lon=-87.241726
 BarAve http://www.openstreetmap.org/?lat=30.411300&lon=-87.229471
 PalSt +NPalSt http://www.openstreetmap.org/?lat=30.412940&lon=-87.215403
-AlcSt_S +SAkcSt +AkcSt_S http://www.openstreetmap.org/?lat=30.413995&lon=-87.210300
+AlcSt_S +SAkcSt http://www.openstreetmap.org/?lat=30.413995&lon=-87.210300
 I-110 +I-110(1) http://www.openstreetmap.org/?lat=30.416200&lon=-87.210782
 US98_E http://www.openstreetmap.org/?lat=30.416615&lon=-87.205626

--- a/hwy_data/FL/usausb/fl.us221trkper.wpt
+++ b/hwy_data/FL/usausb/fl.us221trkper.wpt
@@ -2,6 +2,6 @@ US221_S +US221_End http://www.openstreetmap.org/?lat=30.098354&lon=-83.583389
 ChuSt http://www.openstreetmap.org/?lat=30.105361&lon=-83.589107
 US27/98 +US27/98_W http://www.openstreetmap.org/?lat=30.111605&lon=-83.589215
 MainSt_Per http://www.openstreetmap.org/?lat=30.117970&lon=-83.589467
-CR356_N +CR356 http://www.openstreetmap.org/?lat=30.124171&lon=-83.594300
+CR356_N http://www.openstreetmap.org/?lat=30.124171&lon=-83.594300
 US19/27_N http://www.openstreetmap.org/?lat=30.146296&lon=-83.611488
 US221_N http://www.openstreetmap.org/?lat=30.146512&lon=-83.588944

--- a/hwy_data/FL/usausb/fl.us441trklak.wpt
+++ b/hwy_data/FL/usausb/fl.us441trklak.wpt
@@ -3,4 +3,4 @@ US441_S http://www.openstreetmap.org/?lat=30.147421&lon=-82.639879
 MalSt http://www.openstreetmap.org/?lat=30.163744&lon=-82.641955
 FL47 http://www.openstreetmap.org/?lat=30.168662&lon=-82.640957
 FL10A http://www.openstreetmap.org/?lat=30.183456&lon=-82.639343
-US441_N +US90 http://www.openstreetmap.org/?lat=30.189363&lon=-82.639471
+US441_N http://www.openstreetmap.org/?lat=30.189363&lon=-82.639471


### PR DESCRIPTION
One time run on removing all unused alt labels in FL in active files.

https://forum.travelmapping.net/index.php?topic=323.msg20206#msg20206