### PR TITLE
PA 441 Realignment in Middletown

### DIFF
--- a/hwy_data/PA/usapa/pa.pa230.wpt
+++ b/hwy_data/PA/usapa/pa.pa230.wpt
@@ -5,10 +5,11 @@ PaxSt http://www.openstreetmap.org/?lat=40.255740&lon=-76.869423
 13thSt http://www.openstreetmap.org/?lat=40.243361&lon=-76.858182
 SwaSt http://www.openstreetmap.org/?lat=40.232669&lon=-76.836609
 ChaSt http://www.openstreetmap.org/?lat=40.224164&lon=-76.826642
++X0 http://www.openstreetmap.org/?lat=40.216881&lon=-76.816430
 EisBlvd http://www.openstreetmap.org/?lat=40.210835&lon=-76.794970
 AirCon http://www.openstreetmap.org/?lat=40.199470&lon=-76.760316
-PA441Trk_S http://www.openstreetmap.org/?lat=40.196669&lon=-76.739175
-PA441 http://www.openstreetmap.org/?lat=40.199814&lon=-76.731273
+PA441_S +PA441Trk_S http://www.openstreetmap.org/?lat=40.196669&lon=-76.739175
+PA441_N  +PA441 http://www.openstreetmap.org/?lat=40.199814&lon=-76.731273
 VineSt http://www.openstreetmap.org/?lat=40.201342&lon=-76.724331
 PA341 http://www.openstreetmap.org/?lat=40.196616&lon=-76.705585
 +X1 http://www.openstreetmap.org/?lat=40.197503&lon=-76.697324

--- a/hwy_data/PA/usapa/pa.pa441.wpt
+++ b/hwy_data/PA/usapa/pa.pa441.wpt
@@ -13,13 +13,18 @@ VinFerRd http://www.openstreetmap.org/?lat=40.066752&lon=-76.600177
 BeaTGRd http://www.openstreetmap.org/?lat=40.065286&lon=-76.611080
 2ndSt http://www.openstreetmap.org/?lat=40.081035&lon=-76.656997
 PA241 http://www.openstreetmap.org/?lat=40.101879&lon=-76.672763
+GovStaRd http://www.openstreetmap.org/?lat=40.114470&lon=-76.689758
+FalRd http://www.openstreetmap.org/?lat=40.122794&lon=-76.711698
 TurRd http://www.openstreetmap.org/?lat=40.129434&lon=-76.714847
++X2R http://www.openstreetmap.org/?lat=40.134526&lon=-76.713627
 GeyChuRd http://www.openstreetmap.org/?lat=40.164853&lon=-76.718457
-PA441Trk_S +PA441TrkMid http://www.openstreetmap.org/?lat=40.192537&lon=-76.732110
-PA230/441Trk http://www.openstreetmap.org/?lat=40.199814&lon=-76.731273
-UniSt http://www.openstreetmap.org/?lat=40.212883&lon=-76.735578
+UniSt_S +PA441TrkMid +PA441Trk_S http://www.openstreetmap.org/?lat=40.192537&lon=-76.732110
+PA230_W http://www.openstreetmap.org/?lat=40.196669&lon=-76.739175
+PA230_E +PA230/441Trk http://www.openstreetmap.org/?lat=40.199814&lon=-76.731273
+UniSt_N +UniSt http://www.openstreetmap.org/?lat=40.212883&lon=-76.735578
 SprGarDr http://www.openstreetmap.org/?lat=40.222010&lon=-76.754949
 FulMillRd http://www.openstreetmap.org/?lat=40.227879&lon=-76.757875
+PowRd http://www.openstreetmap.org/?lat=40.232208&lon=-76.760176
 LonDr http://www.openstreetmap.org/?lat=40.237804&lon=-76.780416
 KecRd http://www.openstreetmap.org/?lat=40.242992&lon=-76.797856
 I-283 http://www.openstreetmap.org/?lat=40.242322&lon=-76.805141
@@ -27,4 +32,5 @@ EisBlvd_N +EisDr_N http://www.openstreetmap.org/?lat=40.241840&lon=-76.806858
 EisBlvd_S +EisDr_S http://www.openstreetmap.org/?lat=40.238600&lon=-76.804615
 HigSt_W http://www.openstreetmap.org/?lat=40.238695&lon=-76.815054
 ChaHillRd http://www.openstreetmap.org/?lat=40.247111&lon=-76.825622
+28thSt_N http://www.openstreetmap.org/?lat=40.254483&lon=-76.841654
 PaxSt http://www.openstreetmap.org/?lat=40.254766&lon=-76.850921

--- a/hwy_data/PA/usapa/pa.pa441trkmid.wpt
+++ b/hwy_data/PA/usapa/pa.pa441trkmid.wpt
@@ -1,3 +1,0 @@
-PA441_S http://www.openstreetmap.org/?lat=40.192537&lon=-76.732110
-PA230_W http://www.openstreetmap.org/?lat=40.196669&lon=-76.739175
-PA441_N http://www.openstreetmap.org/?lat=40.199814&lon=-76.731273

--- a/hwy_data/_systems/usapa.csv
+++ b/hwy_data/_systems/usapa.csv
@@ -324,7 +324,6 @@ usapa;PA;PA436;;;;pa.pa436;
 usapa;PA;PA437;;;;pa.pa437;
 usapa;PA;PA438;;;;pa.pa438;
 usapa;PA;PA441;;;;pa.pa441;
-usapa;PA;PA441;Trk;Mid;Middletown;pa.pa441trkmid;
 usapa;PA;PA442;;;;pa.pa442;
 usapa;PA;PA443;;;;pa.pa443;
 usapa;PA;PA445;;;;pa.pa445;

--- a/hwy_data/_systems/usapa_con.csv
+++ b/hwy_data/_systems/usapa_con.csv
@@ -322,7 +322,6 @@ usapa;PA436;;;pa.pa436
 usapa;PA437;;;pa.pa437
 usapa;PA438;;;pa.pa438
 usapa;PA441;;;pa.pa441
-usapa;PA441;Trk;Middletown;pa.pa441trkmid
 usapa;PA442;;;pa.pa442
 usapa;PA443;;;pa.pa443
 usapa;PA445;;;pa.pa445

--- a/updates.csv
+++ b/updates.csv
@@ -4197,6 +4197,8 @@
 2017-09-06;(USA) Oregon;OR 99;or.or099;Restored route from I-5 onto Yoncalla-Drain routing.
 2017-09-06;(USA) Oregon;OR 99W;or.or099w;Truncated route from I-5(306) to I-5(294) to reflect signage and prepare for Oregon Highways dataset.
 2017-09-06;(USA) Oregon;OR 126;or.or126;Moved route from Bus 97 to US 97 in Redmond.
+2020-10-10;(USA) Pennsylvania;PA 441;pa.pa441;Realigned to use former route of PA 441 Truck (Middletown) between Union St (UniSt_S) and PA230_E.  
+2020-10-10;(USA) Pennsylvania;PA 441 Truck (Middletown);;Route deleted. (replaced by realignment of PA 441)
 2020-10-09;(USA) Pennsylvania;US 322;pa.us322;Realigned between RedMillRd and *OldUS322_B onto new four lane freeway at Potters Mills Gap.
 2020-10-09;(USA) Pennsylvania;PA 144 Truck (Potters Mills);pa.pa144trkpot;Rerouted to use new Potters Mills Gap Interchange between RedMillRd and PA144_S.
 2020-09-28;(USA) Pennsylvania;PA 915;pa.pa915;Realigned between Palmer St (PalSt) and PA 26.
@@ -4244,56 +4246,56 @@
 2019-05-20;(USA) Pennsylvania;Harvey Taylor Bridge;pa.hartaybri;Route added.
 2019-05-06;(USA) Pennsylvania;PA 519;pa.pa519;Realigned between Bernie Dr (BerDr) and Thomas 84 Rd (Tho84Rd) with point at Brownlee Rd (BroRd) relocated to accomodate both roundabouts.
 2019-04-20;(USA) Pennsylvania;PA 347;pa.pa347;Extended south to Green Ridge St (SR 6011).
-2019-04-20;(USA) Pennsylvania;PA 690 Truck (Moscow);pa.pa690trkmos;Route added
-2019-04-20;(USA) Pennsylvania;PA 390 Truck (Hawley);pa.pa390trkhaw;Route added
+2019-04-20;(USA) Pennsylvania;PA 690 Truck (Moscow);pa.pa690trkmos;Route added.
+2019-04-20;(USA) Pennsylvania;PA 390 Truck (Hawley);pa.pa390trkhaw;Route added.
 2019-04-20;(USA) Pennsylvania;PA 435;pa.pa435;Extended to the center of I-380 (Exit 13) based on signage.
 2019-04-20;(USA) Pennsylvania;PA 507;pa.pa507;Truncated on south end to PA 435, which was extended to the center of I-380 (Exit 13), based on signage.  
 2019-04-13;(USA) Pennsylvania;I-376;pa.i376;Truncated Route to Exit 85 where it defaults onto US 22.
 2019-03-22;(USA) Pennsylvania;PA 523;pa.pa523;Extended to Logan Place (LogPl) in Confluence along PA 281 based on signage.
 2019-03-18;(USA) Pennsylvania;PA 381;pa.pa381;Realigned route onto new alignment at intersection with US 40 (between points *OldPA381 and US40).  The PA381_S point on US 40 was also marked as closed with PA381_N becoming an alternate label for PA 381.
 2019-03-11;(USA) Pennsylvania;I-476;pa.i476;Extended to US 6 WB/US 11 to match mile-marker signage.
-2019-02-21;(USA) Pennsylvania;US 209 Truck (Brodheadsville);;Route deleted
+2019-02-21;(USA) Pennsylvania;US 209 Truck (Brodheadsville);;Route deleted.
 2019-01-08;(USA) Pennsylvania;PA 116;pa.pa116;Relocated in Hanover to follow posted routing along Frederick St.  This breaks the concurrency with PA 194 as the route is now shown only following the routing of PA 194 NB (Frederick St).
-2018-12-30;(USA) Pennsylvania;PA 402 Truck (Hawley);pa.pa402trkhaw;Route added
+2018-12-30;(USA) Pennsylvania;PA 402 Truck (Hawley);pa.pa402trkhaw;Route added.
 2018-12-25;(USA) Pennsylvania;PA 61;pa.pa061;Fixed route in Mount Carmel to follow 5th St, Market St, East Ave, West Ave, and Poplar St.
 2018-12-25;(USA) Pennsylvania;PA 147;pa.pa147;Fixed PA61_N and PA61_S labels as they were backwards.
-2018-12-11;(USA) Pennsylvania;PA 65 Truck (New Castle);;Route deleted
-2018-12-11;(USA) Pennsylvania;PA 488 Truck (Ellwood City);;Route deleted
+2018-12-11;(USA) Pennsylvania;PA 65 Truck (New Castle);;Route deleted.
+2018-12-11;(USA) Pennsylvania;PA 488 Truck (Ellwood City);;Route deleted.
 2018-12-03;(USA) Pennsylvania;I-95;pa.i095;Removed in-use alternate labels 46, 48, 51, and 999 due to potential mapping errors.
-2018-12-01;(USA) Pennsylvania;PA 295;pa.pa297;Route renumbered to PA 297
+2018-12-01;(USA) Pennsylvania;PA 295;pa.pa297;Route renumbered to PA 297.
 2018-11-25;(USA) Pennsylvania;US 219;pa.us219;Rerouted onto new freeway between Meyersdale (at north end of US 219 Business(Meyersdale)) and Somerset (at Berlin Plank Rd).
 2018-11-20;(USA) Pennsylvania;PA 715 Truck (North) Tannersville;pa.pa715trknta;Route added. (Only posted northbound)
 2018-11-20;(USA) Pennsylvania;PA 715 Truck (South) Tannersville;pa.pa715trksta;Route added. (Only posted southbound)
 2018-11-15;(USA) Pennsylvania;PA 32 Alternate Truck (Morrisville);pa.pa032alttrkmor;Route added.
 2018-11-15;(USA) Pennsylvania;PA 52 Alternate Truck (Thornbury Township);pa.pa052alttrktho;Route added.  (Only posted northbound)
-2018-11-15;(USA) Pennsylvania;PA 926 Alternate Truck (Thornbury Township);pa.pa926alttrktho;Route added
+2018-11-15;(USA) Pennsylvania;PA 926 Alternate Truck (Thornbury Township);pa.pa926alttrktho;Route added.
 2018-11-15;(USA) Pennsylvania;PA 741;pa.pa741;Truncated on its western end to Commerical Ave between PA 283 and PA 722.
 2018-11-15;(USA) Pennsylvania;US 1 Alternate Truck (West Grove);pa.us001alttrkwes;Route added.  (Only posted southbound)
-2018-11-15;(USA) Pennsylvania;PA 841 Alternate Truck (West Grove);pa.pa841alttrkwes;Route added
+2018-11-15;(USA) Pennsylvania;PA 841 Alternate Truck (West Grove);pa.pa841alttrkwes;Route added.
 2018-11-13;(USA) Pennsylvania;US 322 Truck (Downingtown);pa.us322trkdow;Relocated/Extended west to follow US 30 Business Alternate Truck (Downingtown), via PA 113, US 30, and US 322, to the west end of the latter route at US 30 Business (this portion is also posted as US 322 Alternate Truck).  Truncated on its east end to the US 30/US 30 BUS interchange due to the true route being detoured and unposted east of here due to a weight-restricted bridge on Boot Rd.
-2018-11-13;(USA) Pennsylvania;US 30 Business Alternate Truck (Downingtown);pa.us030bustrkdow;Route added
+2018-11-13;(USA) Pennsylvania;US 30 Business Alternate Truck (Downingtown);pa.us030bustrkdow;Route added.
 2018-11-08;(USA) Pennsylvania;PA 61 Truck (North) Sunbury;pa.pa061trknsu;Route added.  Note that PA 61 Truck (Sunbury) was renamed to PA 61 Truck (South) Sunbury.
 2018-11-08;(USA) Pennsylvania;PA 643;pa.pa643;Fixed route so that labels go from west (I-70) to east (US 522).
-2018-10-27;(USA) Pennsylvania;PA 655 Truck (Belleville);;Route deleted
-2018-10-27;(USA) Pennsylvania;PA 982 Truck (Derry);pa.pa982trkder;Route added
+2018-10-27;(USA) Pennsylvania;PA 655 Truck (Belleville);;Route deleted.
+2018-10-27;(USA) Pennsylvania;PA 982 Truck (Derry);pa.pa982trkder;Route added.
 2018-10-15;(USA) Pennsylvania;PA 478;pa.pa478;Fixed route so that labels go from west (PA 38/PA 208) to east (PA 58).
 2018-10-13;(USA) Pennsylvania;PA 8;pa.pa008;Fixed PA380_W and PA380_E labels as they were backwards.
-2018-10-08;(USA) Pennsylvania;PA 420 Alternate Truck (Ridley Township);pa.pa420alttrkrid;Route added
-2018-10-08;(USA) Pennsylvania;PA 420 Alternate Truck (Prospect Park);pa.pa420alttrkpro;Route added
-2018-10-08;(USA) Pennsylvania;PA 329 Truck (Northampton);pa.pa329trknor;Route added
-2018-10-03;(USA) Pennsylvania;US 13 Alternate Truck (Bensalem);pa.us013alttrkben;Route added
-2018-09-30;(USA) Pennsylvania;US 6 Business (Carbondale);pa.us006buscar;Renamed and extended west to US 11
+2018-10-08;(USA) Pennsylvania;PA 420 Alternate Truck (Ridley Township);pa.pa420alttrkrid;Route added.
+2018-10-08;(USA) Pennsylvania;PA 420 Alternate Truck (Prospect Park);pa.pa420alttrkpro;Route added.
+2018-10-08;(USA) Pennsylvania;PA 329 Truck (Northampton);pa.pa329trknor;Route added.
+2018-10-03;(USA) Pennsylvania;US 13 Alternate Truck (Bensalem);pa.us013alttrkben;Route added.
+2018-09-30;(USA) Pennsylvania;US 6 Business (Carbondale);pa.us006buscar;Renamed and extended west to US 11.
 2018-09-30;(USA) Pennsylvania;Central Scranton Expressway;pa.censcrexp;Route added.  (connects I-81 to US 11/PA 307 in Downtown Scranton)
 2018-09-26;(USA) Pennsylvania;Betsy Ross Bridge;pa.betrossbri;Route added.  (connects I-95 to NJ 90 at PA/NJ State Line)
-2018-09-24;(USA) Pennsylvania;PA 413;pa.pa413;Rerouted at its northern end in Pipersville to follow Old Easton Rd and Deep Run Rd west to PA 611
+2018-09-24;(USA) Pennsylvania;PA 413;pa.pa413;Rerouted at its northern end in Pipersville to follow Old Easton Rd and Deep Run Rd west to PA 611.
 2018-09-24;(USA) Pennsylvania;I-276;pa.i276;Truncated at its east end to I-95(Exit 40) at newly opened interchange.
 2018-09-24;(USA) Pennsylvania;I-295;pa.i295;Extended into PA onto the former routing of I-95 north of I-276 (PA Turnpike).
 2018-09-24;(USA) Pennsylvania;I-95;pa.i095;Rerouted to follow I-276 (PA Turnpike) from newly opened interchange to the continuation of I-95 at the PA/NJ Line.
-2018-09-20;(USA) Pennsylvania;US 1 Alternate Truck (Philadelphia);pa.us001alttrkphi;Route added
-2018-09-20;(USA) Pennsylvania;PA 743 Truck (Hershey);pa.pa743trkher;Route added
-2018-09-09;(USA) Pennsylvania;US 202 Alternate Truck (North Wales);pa.us202alttrknor;Route added
-2018-09-06;(USA) Pennsylvania;PA 23 Alternate Truck (King of Prussia);pa.pa023alttrkkop;Route added
-2018-09-06;(USA) Pennsylvania;PA 160 Truck (Wilmore);pa.pa160trkwil;Route added
+2018-09-20;(USA) Pennsylvania;US 1 Alternate Truck (Philadelphia);pa.us001alttrkphi;Route added.
+2018-09-20;(USA) Pennsylvania;PA 743 Truck (Hershey);pa.pa743trkher;Route added.
+2018-09-09;(USA) Pennsylvania;US 202 Alternate Truck (North Wales);pa.us202alttrknor;Route added.
+2018-09-06;(USA) Pennsylvania;PA 23 Alternate Truck (King of Prussia);pa.pa023alttrkkop;Route added.
+2018-09-06;(USA) Pennsylvania;PA 160 Truck (Wilmore);pa.pa160trkwil;Route added.
 2018-08-26;(USA) Pennsylvania;PA 27;pa.pa027;Extended west of Park Ave to US 6/US 19 in Meadville via North St, Market St, Terrace St, and Reynolds Ave.
 2018-08-14;(USA) Pennsylvania;PA 10;pa.pa010;Extended south from PA 472 to Market Street.
 2018-08-14;(USA) Pennsylvania;I-476;pa.i476;Relabeled exits 18A -> 19 & 19 -> 20A to correctly match signage in the area.

--- a/updates.csv
+++ b/updates.csv
@@ -4197,6 +4197,8 @@
 2017-09-06;(USA) Oregon;OR 99;or.or099;Restored route from I-5 onto Yoncalla-Drain routing.
 2017-09-06;(USA) Oregon;OR 99W;or.or099w;Truncated route from I-5(306) to I-5(294) to reflect signage and prepare for Oregon Highways dataset.
 2017-09-06;(USA) Oregon;OR 126;or.or126;Moved route from Bus 97 to US 97 in Redmond.
+2020-10-09;(USA) Pennsylvania;US 322;pa.us322;Realigned between RedMillRd and *OldUS322_B onto new four lane freeway at Potters Mills Gap.
+2020-10-09;(USA) Pennsylvania;PA 144 TRUCK (Potters Mills);pa.pa144trkpot;Rerouted to use new Potters Mill Gap Interchange between RedMillRd and PA144_S.
 2020-09-28;(USA) Pennsylvania;PA 915;pa.pa915;Realigned between Palmer St (PalSt) and PA 26.
 2020-09-21;(USA) Pennsylvania;PA 183;pa.pa183;Realigned between New Schaefferstown Rd (NewSchRd) and Walden West Rd (WalWestRd).
 2020-08-10;(USA) Pennsylvania;PA 381;pa.pa381;Relocated SugRd waypoint (Old location replaced by *OldSugRd).

--- a/updates.csv
+++ b/updates.csv
@@ -4198,7 +4198,7 @@
 2017-09-06;(USA) Oregon;OR 99W;or.or099w;Truncated route from I-5(306) to I-5(294) to reflect signage and prepare for Oregon Highways dataset.
 2017-09-06;(USA) Oregon;OR 126;or.or126;Moved route from Bus 97 to US 97 in Redmond.
 2020-10-09;(USA) Pennsylvania;US 322;pa.us322;Realigned between RedMillRd and *OldUS322_B onto new four lane freeway at Potters Mills Gap.
-2020-10-09;(USA) Pennsylvania;PA 144 TRUCK (Potters Mills);pa.pa144trkpot;Rerouted to use new Potters Mills Gap Interchange between RedMillRd and PA144_S.
+2020-10-09;(USA) Pennsylvania;PA 144 Truck (Potters Mills);pa.pa144trkpot;Rerouted to use new Potters Mills Gap Interchange between RedMillRd and PA144_S.
 2020-09-28;(USA) Pennsylvania;PA 915;pa.pa915;Realigned between Palmer St (PalSt) and PA 26.
 2020-09-21;(USA) Pennsylvania;PA 183;pa.pa183;Realigned between New Schaefferstown Rd (NewSchRd) and Walden West Rd (WalWestRd).
 2020-08-10;(USA) Pennsylvania;PA 381;pa.pa381;Relocated SugRd waypoint (Old location replaced by *OldSugRd).


### PR DESCRIPTION
PA 230: Changes due to PA 441 Realignment.  Also added +X0.
PA 441: Realigned to use former route of PA 441 TRUCK (Middletown) between Union St (UniSt_S) and PA230_E.  (https://forum.travelmapping.net/index.php?topic=3837.0)

Added Governor Stable Rd (GovStaRd), Falmouth Rd (FalRd), Powderhorn Rd (PowRd), and 28th St (28thSt_N).  