### PR TITLE
CA I-710 extension, other CA updates

### DIFF
--- a/hwy_data/CA/usaca/ca.ca047.wpt
+++ b/hwy_data/CA/usaca/ca.ca047.wpt
@@ -2,6 +2,6 @@
 1C http://www.openstreetmap.org/?lat=33.749567&lon=-118.281062
 FerSt http://www.openstreetmap.org/?lat=33.748960&lon=-118.263048
 NavyWay http://www.openstreetmap.org/?lat=33.753969&lon=-118.251755
-SeaFwy_E http://www.openstreetmap.org/?lat=33.758438&lon=-118.238506
+I-710 +SeaFwy_E http://www.openstreetmap.org/?lat=33.758460&lon=-118.238520
 4 http://www.openstreetmap.org/?lat=33.761172&lon=-118.238945
 CA103 http://www.openstreetmap.org/?lat=33.774652&lon=-118.240120

--- a/hwy_data/CA/usaca/ca.ca072.wpt
+++ b/hwy_data/CA/usaca/ca.ca072.wpt
@@ -1,5 +1,4 @@
-PicoRivLim http://www.openstreetmap.org/?lat=33.995043&lon=-118.071608
-I-605 http://www.openstreetmap.org/?lat=33.993406&lon=-118.069253
+I-605 +PicoRivLim http://www.openstreetmap.org/?lat=33.993406&lon=-118.069253
 NorBlvd http://www.openstreetmap.org/?lat=33.989921&lon=-118.064028
 HadSt http://www.openstreetmap.org/?lat=33.982718&lon=-118.053374
 WasBlvd http://www.openstreetmap.org/?lat=33.968232&lon=-118.042066

--- a/hwy_data/CA/usaca/ca.ca232.wpt
+++ b/hwy_data/CA/usaca/ca.ca232.wpt
@@ -1,3 +1,3 @@
-CA1 http://www.openstreetmap.org/?lat=34.226481&lon=-119.177419
+EspDr +CA1 http://www.openstreetmap.org/?lat=34.230007&lon=-119.174661
 US101 http://www.openstreetmap.org/?lat=34.231838&lon=-119.173234
 CA118 http://www.openstreetmap.org/?lat=34.273972&lon=-119.135292

--- a/hwy_data/CA/usaca/ca.ca241.wpt
+++ b/hwy_data/CA/usaca/ca.ca241.wpt
@@ -9,7 +9,8 @@
 25 http://www.openstreetmap.org/?lat=33.695579&lon=-117.692580
 27 http://www.openstreetmap.org/?lat=33.713792&lon=-117.720609
 +X03 http://www.openstreetmap.org/?lat=33.742684&lon=-117.717991
-33 http://www.openstreetmap.org/?lat=33.784212&lon=-117.746863
+33 http://www.openstreetmap.org/?lat=33.780522&lon=-117.748030
+32 http://www.openstreetmap.org/?lat=33.784212&lon=-117.746863
 +X06 http://www.openstreetmap.org/?lat=33.807893&lon=-117.723569
 39 http://www.openstreetmap.org/?lat=33.866394&lon=-117.716532
 

--- a/hwy_data/CA/usaca/ca.ca261.wpt
+++ b/hwy_data/CA/usaca/ca.ca261.wpt
@@ -1,5 +1,5 @@
 1 http://www.openstreetmap.org/?lat=33.711775&lon=-117.800860
 2 http://www.openstreetmap.org/?lat=33.726405&lon=-117.778995
 3 http://www.openstreetmap.org/?lat=33.740828&lon=-117.766968
-6A http://www.openstreetmap.org/?lat=33.782219&lon=-117.749426
+6A http://www.openstreetmap.org/?lat=33.782269&lon=-117.749420
 6B http://www.openstreetmap.org/?lat=33.784212&lon=-117.746863

--- a/hwy_data/CA/usai/ca.i710.wpt
+++ b/hwy_data/CA/usai/ca.i710.wpt
@@ -1,5 +1,7 @@
-1A +0 +1B http://www.openstreetmap.org/?lat=33.767142&lon=-118.207499
-1C http://www.openstreetmap.org/?lat=33.778423&lon=-118.207167
+1 http://www.openstreetmap.org/?lat=33.758460&lon=-118.238520
+1E http://www.openstreetmap.org/?lat=33.767090&lon=-118.210273
+1A +0 http://www.openstreetmap.org/?lat=33.770037&lon=-118.207005
+1B http://www.openstreetmap.org/?lat=33.778423&lon=-118.207167
 1D http://www.openstreetmap.org/?lat=33.782682&lon=-118.207612
 2 http://www.openstreetmap.org/?lat=33.789904&lon=-118.207827
 3 http://www.openstreetmap.org/?lat=33.804388&lon=-118.207424

--- a/hwy_data/CA/usaus/ca.us101.wpt
+++ b/hwy_data/CA/usaus/ca.us101.wpt
@@ -133,7 +133,7 @@ I-5/10 http://www.openstreetmap.org/?lat=34.034046&lon=-118.221120
 +X840702 http://www.openstreetmap.org/?lat=34.465753&lon=-120.103430
 ArrHonPre http://www.openstreetmap.org/?lat=34.474656&lon=-120.142166
 128 http://www.openstreetmap.org/?lat=34.473435&lon=-120.206856
-+x26 http://www.openstreetmap.org/?lat=34.476310&lon=-120.227595
+GavBeaRd http://www.openstreetmap.org/?lat=34.477861&lon=-120.228494
 132 +CA1_Gav http://www.openstreetmap.org/?lat=34.509200&lon=-120.225894
 OldCoaHwy http://www.openstreetmap.org/?lat=34.529301&lon=-120.196647
 139 http://www.openstreetmap.org/?lat=34.602742&lon=-120.191856
@@ -146,6 +146,7 @@ JonParkRd http://www.openstreetmap.org/?lat=34.652820&lon=-120.182790
 AliCanRd http://www.openstreetmap.org/?lat=34.731403&lon=-120.236049
 154 http://www.openstreetmap.org/?lat=34.742573&lon=-120.270832
 PalRd http://www.openstreetmap.org/?lat=34.791691&lon=-120.332930
+161 http://www.openstreetmap.org/?lat=34.825168&lon=-120.358948
 165 http://www.openstreetmap.org/?lat=34.865414&lon=-120.396187
 166 http://www.openstreetmap.org/?lat=34.879977&lon=-120.408810
 167 http://www.openstreetmap.org/?lat=34.891185&lon=-120.417677
@@ -408,8 +409,9 @@ DivSt http://www.openstreetmap.org/?lat=37.799010&lon=-122.442653
 519 http://www.openstreetmap.org/?lat=38.783461&lon=-123.009506
 520 http://www.openstreetmap.org/?lat=38.800596&lon=-123.013079
 522 http://www.openstreetmap.org/?lat=38.828178&lon=-123.014297
+525 http://www.openstreetmap.org/?lat=38.856912&lon=-123.037493
 ComStaRd http://www.openstreetmap.org/?lat=38.887392&lon=-123.053527
-+X482490 http://www.openstreetmap.org/?lat=38.926965&lon=-123.057003
+Pie http://www.openstreetmap.org/?lat=38.926411&lon=-123.056180
 EasRd http://www.openstreetmap.org/?lat=38.952801&lon=-123.098416
 CA175 http://www.openstreetmap.org/?lat=38.971246&lon=-123.116655
 +x80 http://www.openstreetmap.org/?lat=39.000939&lon=-123.117857


### PR DESCRIPTION
Extends south end of I-710 to CA 47, over replacement for Gerald Desmond Bridge in Long Beach, per forum discussion. Also includes tweaks to other routes, some of them also discussed on forum.

Updates item in separate pull request #4244.

Datacheck successful.