### PR TITLE
Deering's Corner Roundabout

### DIFF
--- a/hwy_data/ME/usame/me.me025.wpt
+++ b/hwy_data/ME/usame/me.me025.wpt
@@ -39,5 +39,5 @@ CapSt http://www.openstreetmap.org/?lat=43.673265&lon=-70.314968
 WooSt http://www.openstreetmap.org/?lat=43.668987&lon=-70.302292
 ME9 http://www.openstreetmap.org/?lat=43.666614&lon=-70.295843
 StJohnSt http://www.openstreetmap.org/?lat=43.663458&lon=-70.284745
-BriAve_E http://www.openstreetmap.org/?lat=43.661709&lon=-70.278825
+FalSt +BriAve_E http://www.openstreetmap.org/?lat=43.661709&lon=-70.278825
 ME22 http://www.openstreetmap.org/?lat=43.656365&lon=-70.273471


### PR DESCRIPTION
https://www.portlandmaine.gov/2286/Deerings-Corner-Roundabout
Brighton Ave east of ME25 appears to be permanently closed.