### PR TITLE
truncate TXSpr97, add IntPkwy

### DIFF
--- a/hwy_data/TX/usasf/tx.intpkwy.wpt
+++ b/hwy_data/TX/usasf/tx.intpkwy.wpt
@@ -1,4 +1,4 @@
-TX183 http://www.openstreetmap.org/?lat=32.837026&lon=-97.040455
+TXSpr97 +TX183 http://www.openstreetmap.org/?lat=32.845629&lon=-97.040654
 RenCarDr +RenCarRd http://www.openstreetmap.org/?lat=32.852922&lon=-97.040643
 AirDr_S http://www.openstreetmap.org/?lat=32.862067&lon=-97.040552
 TerE http://www.openstreetmap.org/?lat=32.890397&lon=-97.040458

--- a/hwy_data/TX/usatxs/tx.sp0097.wpt
+++ b/hwy_data/TX/usatxs/tx.sp0097.wpt
@@ -1,0 +1,2 @@
+TX183 http://www.openstreetmap.org/?lat=32.837026&lon=-97.040455
+IntPkwy http://www.openstreetmap.org/?lat=32.845629&lon=-97.040654

--- a/hwy_data/_systems/usasf.csv
+++ b/hwy_data/_systems/usasf.csv
@@ -41,6 +41,7 @@ usasf;NY;HenHudPkwy;;;Henry Hudson Parkway;ny.henhudpkwy;
 usasf;AK;HicPkwy;;;Walter J. Hickel Parkway;ak.hicpkwy;
 usasf;NY;HutRivPkwy;;;Hutchinson River Parkway;ny.hutrivpkwy;
 usasf;OK;IndNatTpk;;;Indian Nation Turnpike;ok.indnattpk;
+usasf;TX;IntPkwy;;;International Parkway;tx.intpkwy;TXLp97
 usasf;TN;JamWhiPkwy;;;James White Parkway;tn.jamwhipkwy;
 usasf;OK;JohnKilTpk;;;John Kilpatrick Turnpike;ok.johnkiltpk;
 usasf;IN;KeyPkwy;;;Keystone Parkway;in.keypkwy;

--- a/hwy_data/_systems/usasf_con.csv
+++ b/hwy_data/_systems/usasf_con.csv
@@ -40,6 +40,7 @@ usasf;HenHudPkwy;;Henry Hudson Parkway;ny.henhudpkwy
 usasf;HicPkwy;;Walter J. Hickel Parkway;ak.hicpkwy
 usasf;HutRivPkwy;;Hutchinson River Parkway;ny.hutrivpkwy
 usasf;IndNatTpk;;Indian Nation Turnpike;ok.indnattpk
+usasf;IntPkwy;;International Parkway;tx.intpkwy
 usasf;JamWhiPkwy;;James White Parkway;tn.jamwhipkwy
 usasf;JohnKilTpk;;John Kilpatrick Turnpike;ok.johnkiltpk
 usasf;KeyPkwy;;Keystone Parkway;in.keypkwy

--- a/hwy_data/_systems/usatxs.csv
+++ b/hwy_data/_systems/usatxs.csv
@@ -37,7 +37,7 @@ usatxs;TX;TXSpr91;;;;tx.sp0091;
 usatxs;TX;TXSpr92;;;;tx.sp0092;
 usatxs;TX;TXSpr93;;;;tx.sp0093;
 usatxs;TX;TXSpr95;;;;tx.sp0095;
-usatxs;TX;TXSpr97;;;;tx.sp0097;TXLp97
+usatxs;TX;TXSpr97;;;;tx.sp0097;
 usatxs;TX;TXSpr100;;;;tx.sp0100;
 usatxs;TX;TXSpr102;;;;tx.sp0102;
 usatxs;TX;TXSpr104;;;;tx.sp0104;

--- a/updates.csv
+++ b/updates.csv
@@ -4457,6 +4457,8 @@
 2015-11-29;(USA) Tennessee;US 641;tn.us641;Extended southward from the former ending intersection with I-40 along TN 69 & TN 114 to a new southern terminus at US 64
 2015-10-25;(USA) Tennessee;I-269;tn.i269;Route added
 2015-10-25;(USA) Tennessee;I-269 Future (Memphis, TN);tn.i269futmem;Extended southward from the interchange with TN 57 to a newly opened interchange with I-269 (Exit 2)
+2020-11-17;(USA) Texas;TX Spur 97;tx.sp0097;North end truncated from TX 114/121 to the south entrance of DFW International Airport. This section is now available as International Parkway.
+2020-11-17;(USA) Texas;International Parkway;tx.intpkwy;Route added. Formerly incorrectly included as part of TX Spur 97.
 2020-09-20;(USA) Texas;TX 207;tx.tx207;Removed from demolished roadway and relocated eastward between points south and north of FM 146
 2020-09-20;(USA) Texas;TX 249;tx.tx249;North end truncated from FM 149 to the Woodtrace Boulevard interchange (segment redesignated as an extension of FM 1774), and then extended via the Aggie Expressway to FM 1488.
 2020-09-20;(USA) Texas;TX 289 Business (Prosper);tx.tx289buspro;Deleted


### PR DESCRIPTION
Truncating TXSpr97 & replacing with International Pkwy in usasf.
https://forum.travelmapping.net/index.php?topic=3480.msg17905#msg17905
Didn't do the thing where I move all the old past-the-end points to the new terminus as AltLabels, because it seems the better thing to do here is break everybody's list file thereby making them realize something's changed, check out the updates page, and add their entries for `TX IntPkwy`.