### PR TITLE
Patch 7

### DIFF
--- a/hwy_data/AL/usai/al.i085.wpt
+++ b/hwy_data/AL/usai/al.i085.wpt
@@ -27,4 +27,4 @@ I-65 +0 http://www.openstreetmap.org/?lat=32.366918&lon=-86.322176
 70 http://www.openstreetmap.org/?lat=32.746199&lon=-85.281007
 77 http://www.openstreetmap.org/?lat=32.821862&lon=-85.213292
 79 http://www.openstreetmap.org/?lat=32.847829&lon=-85.185596
-AL/GA +999 http://www.openstreetmap.org/?lat=32.855013&lon=-85.178161
+AL/GA +999 http://www.openstreetmap.org/?lat=32.854400&lon=-85.178761

--- a/hwy_data/GA/usai/ga.i085.wpt
+++ b/hwy_data/GA/usai/ga.i085.wpt
@@ -1,4 +1,4 @@
-AL/GA +0 http://www.openstreetmap.org/?lat=32.855013&lon=-85.178161
+AL/GA +0 http://www.openstreetmap.org/?lat=32.854400&lon=-85.178761
 2 http://www.openstreetmap.org/?lat=32.877839&lon=-85.151489
 6 http://www.openstreetmap.org/?lat=32.928014&lon=-85.109073
 +X000(I85) http://www.openstreetmap.org/?lat=32.969329&lon=-85.072771


### PR DESCRIPTION
Reposition the I-85 AL/GA point to the mean water mark on the Alabama side, which per court records and a forum discussion is the official AL/GA state line.