### PR TITLE
MA3 partial exit renumbering as of 2020-12-06

### DIFF
--- a/hwy_data/MA/usama/ma.ma003.wpt
+++ b/hwy_data/MA/usama/ma.ma003.wpt
@@ -7,16 +7,16 @@
 6 http://www.openstreetmap.org/?lat=41.954448&lon=-70.682344
 7 http://www.openstreetmap.org/?lat=41.966415&lon=-70.696721
 8 http://www.openstreetmap.org/?lat=41.975983&lon=-70.710556
-9 http://www.openstreetmap.org/?lat=41.988125&lon=-70.717519
-10 http://www.openstreetmap.org/?lat=42.013966&lon=-70.726542
-11 http://www.openstreetmap.org/?lat=42.055546&lon=-70.725313
+18 +9 http://www.openstreetmap.org/?lat=41.988125&lon=-70.717519
+20 http://www.openstreetmap.org/?lat=42.013966&lon=-70.726542
+22 +11 http://www.openstreetmap.org/?lat=42.055546&lon=-70.725313
 27 +12 http://www.openstreetmap.org/?lat=42.108177&lon=-70.766748
 32 http://www.openstreetmap.org/?lat=42.151040&lon=-70.845482
 35 +14 http://www.openstreetmap.org/?lat=42.165976&lon=-70.893247
 36 http://www.openstreetmap.org/?lat=42.178897&lon=-70.916158
 38 +16 http://www.openstreetmap.org/?lat=42.194621&lon=-70.955731
 40 +17 http://www.openstreetmap.org/?lat=42.210274&lon=-70.996549
-41 +18 http://www.openstreetmap.org/?lat=42.225725&lon=-71.004816
+41 http://www.openstreetmap.org/?lat=42.225725&lon=-71.004816
 42 +19 http://www.openstreetmap.org/?lat=42.227945&lon=-71.010395
 7(93) http://www.openstreetmap.org/?lat=42.226928&lon=-71.020474
 8(93) http://www.openstreetmap.org/?lat=42.241990&lon=-71.026568

--- a/hwy_data/MA/usama/ma.ma003aply.wpt
+++ b/hwy_data/MA/usama/ma.ma003aply.wpt
@@ -10,12 +10,12 @@ SanSt_N +SumSt http://www.openstreetmap.org/?lat=41.954716&lon=-70.662636
 US44 http://www.openstreetmap.org/?lat=41.960192&lon=-70.670328
 CheSt http://www.openstreetmap.org/?lat=41.974539&lon=-70.685263
 CreSt http://www.openstreetmap.org/?lat=41.984493&lon=-70.702600
-MA3(9) http://www.openstreetmap.org/?lat=41.988125&lon=-70.717519
+MA3(18) +MA3(9) http://www.openstreetmap.org/?lat=41.988125&lon=-70.717519
 MA80 http://www.openstreetmap.org/?lat=41.990113&lon=-70.723758
 MA106 http://www.openstreetmap.org/?lat=41.992489&lon=-70.726569
 EveSt http://www.openstreetmap.org/?lat=41.998059&lon=-70.730233
 MA53_S http://www.openstreetmap.org/?lat=42.011544&lon=-70.732276
-MA3(10) http://www.openstreetmap.org/?lat=42.013966&lon=-70.726542
+MA3(20) http://www.openstreetmap.org/?lat=42.013966&lon=-70.726542
 TobGarSt http://www.openstreetmap.org/?lat=42.025154&lon=-70.697241
 MA14 http://www.openstreetmap.org/?lat=42.048675&lon=-70.691829
 MA139 http://www.openstreetmap.org/?lat=42.059213&lon=-70.691206

--- a/updates.csv
+++ b/updates.csv
@@ -4230,7 +4230,7 @@
 2018-12-06;(USA) Oregon;OR 35;or.or035;Extended route north onto Hood River Bridge
 2018-12-06;(USA) Oregon;OR 140;or.or140;Extended west from OR 62 in White City to I-5/OR 99 at exit 35 and relabeled OR 39 points from OR39_W to OR39_S and OR39_E to OR39_W
 2018-11-23;(USA) Oregon;OR 39 Business (Klamath Falls);;Deleted route
-2018-11-23;(USA) Oregon;OR 39 (Klamath Falls);or.or039kla;Added route (former
+2018-11-23;(USA) Oregon;OR 39 (Klamath Falls);or.or039kla;Added route (former OR 39 Business)
 2018-11-23;(USA) Oregon;OR 18;or.or018;Route extended east past northern end of overlap with OR 99E  along Newberg-Dundee Bypass to OR 219
 2017-09-06;(USA) Oregon;US 30;us.or030;(late entry) Moved route from Huntington alignment onto I-84 in lieu of new business 30 route.
 2017-09-06;(USA) Oregon;US 30 Business (Huntington);us.or030bushun;Added route.


### PR DESCRIPTION
This only affects neroute2.list, which was [broken ahead of time](https://github.com/TravelMapping/UserData/pull/4719), so this neither breaks nor fixes it (yet).