### PR TITLE
canqca.con.csv: LATIN SMALL LETTER E WITH ACUTE

### DIFF
--- a/hwy_data/NS/cannss/ns.martrl.wpt
+++ b/hwy_data/NS/cannss/ns.martrl.wpt
@@ -19,4 +19,4 @@ MainDieuRd_E http://www.openstreetmap.org/?lat=46.005176&lon=-59.846224
 BalRd http://www.openstreetmap.org/?lat=45.974456&lon=-59.842377
 OceCre http://www.openstreetmap.org/?lat=45.957252&lon=-59.857944
 +x17 http://www.openstreetmap.org/?lat=45.933453&lon=-59.917281
-MainDieuRd_S http://www.openstreetmap.org/?lat=45.929949&lon=-59.955872
+NS22 http://www.openstreetmap.org/?lat=45.929949&lon=-59.955872

--- a/hwy_data/_systems/canqca_con.csv
+++ b/hwy_data/_systems/canqca_con.csv
@@ -7,8 +7,8 @@ canqca;A-19;;;qc.a019
 canqca;A-20;;Montréal;qc.a020
 canqca;A-20;;Rimouski;qc.a020rim
 canqca;A-25;;;qc.a025
-canqca;A-30;;MontrÃ©al;qc.a030
-canqca;A-30;;BÃ©cancour;qc.a030bec
+canqca;A-30;;Montréal;qc.a030
+canqca;A-30;;Bécancour;qc.a030bec
 canqca;A-31;;;qc.a031
 canqca;A-35;;;qc.a035
 canqca;A-40;;;qc.a040
@@ -20,8 +20,8 @@ canqca;A-85;;Notre-Dame-du-Lac;qc.a085not
 canqca;A-85;;Rivière-du-Loup;qc.a085
 canqca;A-410;;;qc.a410
 canqca;A-440;;Laval;qc.a440
-canqca;A-440;;(West) QuÃ©bec;qc.a440wqu
-canqca;A-440;;(East) QuÃ©bec;qc.a440equ
+canqca;A-440;;(West) Québec;qc.a440wqu
+canqca;A-440;;(East) Québec;qc.a440equ
 canqca;A-520;;;qc.a520
 canqca;A-530;;;qc.a530
 canqca;A-540;;;qc.a540


### PR DESCRIPTION
Changes a few **`é`** characters to the standard UTF-8 **`C3 A9`** from **`C3 83 C2 A9`**. Strangely, after passing thru MySQL, PHP, and Apache the result is a normal-looking **`é`** in the HB, that looks like **`Ã©`** in userlogs.

https://community.bmc.com/s/feed/0D53n00007aEKvQCAW
> Viewing a tcpdump trace with Wireshark, we see that the "é" char is transmitted as "C3 83 C2 A9" instead of the simple UTF-8 translation "C3 A9".
>
> "C3 83 C2 A9" in UTF-8 is indeed "Ã©", which is the ANSI for the UTF-8 "é", so our guess is that there is a component on their side that is doing incorrect/unwanted transcoding.

These snuck in in ba109dab5e5 while fixing an extended ASCII **`è`**, aka **`E8`**.

This encoding is already used in the Montréal segment of A-20, and everywhere in canqc.csv. Ping @ovoss.
![LATIN_SMALL_LETTER_E_WITH_ACUTE](https://user-images.githubusercontent.com/13720877/101456890-b8518480-3902-11eb-8083-7c63495d48ce.png)
