### PR TITLE
complete MA3 exit renumbering

### DIFF
--- a/hwy_data/MA/usama/ma.ma003.wpt
+++ b/hwy_data/MA/usama/ma.ma003.wpt
@@ -1,24 +1,24 @@
 1 http://www.openstreetmap.org/?lat=41.782401&lon=-70.543524
-2 http://www.openstreetmap.org/?lat=41.813715&lon=-70.553749
-3 http://www.openstreetmap.org/?lat=41.873571&lon=-70.601535
-+X01 http://www.openstreetmap.org/?lat=41.921392&lon=-70.625439
-4 http://www.openstreetmap.org/?lat=41.933029&lon=-70.646778
-5 http://www.openstreetmap.org/?lat=41.935759&lon=-70.656708
-6 http://www.openstreetmap.org/?lat=41.954448&lon=-70.682344
-7 http://www.openstreetmap.org/?lat=41.966415&lon=-70.696721
-8 http://www.openstreetmap.org/?lat=41.975983&lon=-70.710556
+3 +2 http://www.openstreetmap.org/?lat=41.813715&lon=-70.553749
+7 http://www.openstreetmap.org/?lat=41.873571&lon=-70.601535
++X11 http://www.openstreetmap.org/?lat=41.921392&lon=-70.625439
+12 +4 http://www.openstreetmap.org/?lat=41.933029&lon=-70.646778
+13 +5 http://www.openstreetmap.org/?lat=41.935759&lon=-70.656708
+15 +6 http://www.openstreetmap.org/?lat=41.954448&lon=-70.682344
+16 http://www.openstreetmap.org/?lat=41.966415&lon=-70.696721
+17 http://www.openstreetmap.org/?lat=41.975983&lon=-70.710556
 18 +9 http://www.openstreetmap.org/?lat=41.988125&lon=-70.717519
 20 http://www.openstreetmap.org/?lat=42.013966&lon=-70.726542
 22 +11 http://www.openstreetmap.org/?lat=42.055546&lon=-70.725313
-27 +12 http://www.openstreetmap.org/?lat=42.108177&lon=-70.766748
+27 http://www.openstreetmap.org/?lat=42.108177&lon=-70.766748
 32 http://www.openstreetmap.org/?lat=42.151040&lon=-70.845482
 35 +14 http://www.openstreetmap.org/?lat=42.165976&lon=-70.893247
 36 http://www.openstreetmap.org/?lat=42.178897&lon=-70.916158
-38 +16 http://www.openstreetmap.org/?lat=42.194621&lon=-70.955731
-40 +17 http://www.openstreetmap.org/?lat=42.210274&lon=-70.996549
+38 http://www.openstreetmap.org/?lat=42.194621&lon=-70.955731
+40 http://www.openstreetmap.org/?lat=42.210274&lon=-70.996549
 41 http://www.openstreetmap.org/?lat=42.225725&lon=-71.004816
 42 +19 http://www.openstreetmap.org/?lat=42.227945&lon=-71.010395
-7(93) http://www.openstreetmap.org/?lat=42.226928&lon=-71.020474
+43 +7(93) http://www.openstreetmap.org/?lat=42.226928&lon=-71.020474
 8(93) http://www.openstreetmap.org/?lat=42.241990&lon=-71.026568
 9(93) http://www.openstreetmap.org/?lat=42.254458&lon=-71.039121
 10(93) http://www.openstreetmap.org/?lat=42.262891&lon=-71.044507

--- a/hwy_data/MA/usaus/ma.us044.wpt
+++ b/hwy_data/MA/usaus/ma.us044.wpt
@@ -15,6 +15,6 @@ MA58 http://www.openstreetmap.org/?lat=41.926356&lon=-70.807314
 SprSt http://www.openstreetmap.org/?lat=41.944362&lon=-70.770149
 +X01 http://www.openstreetmap.org/?lat=41.961062&lon=-70.740967
 ComWay http://www.openstreetmap.org/?lat=41.958469&lon=-70.713565
-MA3(7) http://www.openstreetmap.org/?lat=41.966415&lon=-70.696721
-MA3(6) http://www.openstreetmap.org/?lat=41.954448&lon=-70.682344
+MA3(16) +MA3(7) http://www.openstreetmap.org/?lat=41.966415&lon=-70.696721
+MA3(15) +MA3(6) http://www.openstreetmap.org/?lat=41.954448&lon=-70.682344
 MA3A http://www.openstreetmap.org/?lat=41.960192&lon=-70.670328

--- a/updates.csv
+++ b/updates.csv
@@ -3759,6 +3759,7 @@
 2017-06-09;(USA) Maryland;MD 351;;Deleted route
 2016-04-24;(USA) Maryland;MD 717;md.md717;Added route
 2015-08-17;(USA) Maryland;MD 200;md.md200;Extended east end of route from I-95 to US1
+2020-12-21;(USA) Massachusetts;MA 3;ma.ma003;Relabeled exits from sequential to mileage-based. All numbers changed except for Exit 1.
 2020-11-28;(USA) Massachusetts;MA 25;ma.ma025;Relabeled exits from sequential to mileage-based. Exit 3 moved from US 6 / MA 28 (now Exit 10) to Maple Springs Rd (former Exit 2).
 2020-11-18;(USA) Massachusetts;I-195;ma.i195;Relabeled exits from sequential to mileage-based. All numbers changed except for Exit 1.
 2020-10-31;(USA) Massachusetts;MA 140;ma.ma140;Relabeled exits from sequential to mileage-based. Exit 12 moved from MA 24 (now Exit 20) to County Rd (former Exit 9).


### PR DESCRIPTION
Relabeled exits from sequential to mileage-based. In-use labels that have moved: `17`, `16`, `12`, `7`.
https://forum.travelmapping.net/index.php?topic=7.new#new

**All travelers with broken .lists:**
aaroads afarina brendan dfilpus mapmikey master_son ~neroute2~ ntallyn okroads scott_stieglitz squatchis

**Those who update via GitHub (TM usernames):**
afarina mapmikey master_son ~neroute2~ ntallyn

**GitHub usernames:**
@ajfarina @mapmikey @ssoworld ~@neroute2~ @ntallyn 

**Those left over who update by email:**
aaroads brendan dfilpus okroads scott_stieglitz squatchis 


---

I believe this *fixes* MA3 for @neroute2.