### PR TITLE
usafl: correct labels

### DIFF
--- a/hwy_data/FL/usafl/fl.fl010ajac.wpt
+++ b/hwy_data/FL/usafl/fl.fl010ajac.wpt
@@ -1,2 +1,2 @@
-FL115/113 http://www.openstreetmap.org/?lat=30.322900&lon=-81.559187
+FL115 http://www.openstreetmap.org/?lat=30.322900&lon=-81.559187
 FL10 http://www.openstreetmap.org/?lat=30.321540&lon=-81.551390

--- a/hwy_data/FL/usafl/fl.fl113.wpt
+++ b/hwy_data/FL/usafl/fl.fl113.wpt
@@ -1,4 +1,4 @@
-FL115/10A +FL115 http://www.openstreetmap.org/?lat=30.322900&lon=-81.559187
+FL115 http://www.openstreetmap.org/?lat=30.322900&lon=-81.559187
 RegSquBlvd http://www.openstreetmap.org/?lat=30.329240&lon=-81.554196
 TrePkwy http://www.openstreetmap.org/?lat=30.338060&lon=-81.552227
 FL116 http://www.openstreetmap.org/?lat=30.352472&lon=-81.552442


### PR DESCRIPTION
Goofed here, and need to correct these labels before anybody uses them.  Since 10A doesn't technically intersect 113 (no ramps connecting each other), the labels on either shouldn't mention the other.  Only FL-115 has connections to either at that location.  There will still be a graph connection for all 3 routes there, but that can't be helped since it's the center of the interchange.  At least the labels will be correct.