### PR TITLE
MA US6 exit renumbering

### DIFF
--- a/hwy_data/MA/usama/ma.ma003.wpt
+++ b/hwy_data/MA/usama/ma.ma003.wpt
@@ -7,7 +7,7 @@
 15 +6 http://www.openstreetmap.org/?lat=41.954448&lon=-70.682344
 16 http://www.openstreetmap.org/?lat=41.966415&lon=-70.696721
 17 http://www.openstreetmap.org/?lat=41.975983&lon=-70.710556
-18 +9 http://www.openstreetmap.org/?lat=41.988125&lon=-70.717519
+18 http://www.openstreetmap.org/?lat=41.988125&lon=-70.717519
 20 http://www.openstreetmap.org/?lat=42.013966&lon=-70.726542
 22 +11 http://www.openstreetmap.org/?lat=42.055546&lon=-70.725313
 27 http://www.openstreetmap.org/?lat=42.108177&lon=-70.766748

--- a/hwy_data/MA/usama/ma.ma006ayar.wpt
+++ b/hwy_data/MA/usama/ma.ma006ayar.wpt
@@ -1,4 +1,4 @@
-US6_W http://www.openstreetmap.org/?lat=41.770287&lon=-70.543878
+US6_W http://www.openstreetmap.org/?lat=41.771658&lon=-70.543478
 MA130 http://www.openstreetmap.org/?lat=41.766903&lon=-70.521412
 TupRd http://www.openstreetmap.org/?lat=41.764184&lon=-70.498645
 MainSt http://www.openstreetmap.org/?lat=41.754881&lon=-70.488721
@@ -6,18 +6,18 @@ QuaMeeRd http://www.openstreetmap.org/?lat=41.744014&lon=-70.457640
 HowLn http://www.openstreetmap.org/?lat=41.725984&lon=-70.396550
 MA149 http://www.openstreetmap.org/?lat=41.708216&lon=-70.372453
 MA132 http://www.openstreetmap.org/?lat=41.695841&lon=-70.344290
-+X02 http://www.openstreetmap.org/?lat=41.704627&lon=-70.309796
-HyaBarRd http://www.openstreetmap.org/?lat=41.700430&lon=-70.300355
+RenLn http://www.openstreetmap.org/?lat=41.704206&lon=-70.308479
+HyaRd +HyaBarRd http://www.openstreetmap.org/?lat=41.700388&lon=-70.300178
 WilSt http://www.openstreetmap.org/?lat=41.703256&lon=-70.255980
 UniSt http://www.openstreetmap.org/?lat=41.705466&lon=-70.228257
 SetRd http://www.openstreetmap.org/?lat=41.712925&lon=-70.204225
-+X03 http://www.openstreetmap.org/?lat=41.747226&lon=-70.179291
+SesNeckRd http://www.openstreetmap.org/?lat=41.747357&lon=-70.178379
 MA134 http://www.openstreetmap.org/?lat=41.742717&lon=-70.161545
 LowRd http://www.openstreetmap.org/?lat=41.754740&lon=-70.112343
 StoBroRd http://www.openstreetmap.org/?lat=41.751189&lon=-70.100874
 MA137 http://www.openstreetmap.org/?lat=41.757109&lon=-70.088439
 MA124 http://www.openstreetmap.org/?lat=41.760906&lon=-70.082935
 MilRd http://www.openstreetmap.org/?lat=41.773034&lon=-70.044343
-US6 http://www.openstreetmap.org/?lat=41.778193&lon=-70.003424
+US6(89) +US6 http://www.openstreetmap.org/?lat=41.778193&lon=-70.003424
 MA28 http://www.openstreetmap.org/?lat=41.792139&lon=-69.986756
 US6_E http://www.openstreetmap.org/?lat=41.798911&lon=-69.984026

--- a/hwy_data/MA/usama/ma.ma140.wpt
+++ b/hwy_data/MA/usama/ma.ma140.wpt
@@ -12,7 +12,7 @@
 16 http://www.openstreetmap.org/?lat=41.840864&lon=-71.009043
 19 http://www.openstreetmap.org/?lat=41.867084&lon=-71.048233
 20 http://www.openstreetmap.org/?lat=41.872089&lon=-71.055526
-US44_E http://www.openstreetmap.org/?lat=41.901638&lon=-71.089611
+US44_E http://www.openstreetmap.org/?lat=41.901592&lon=-71.089268
 US44/138 http://www.openstreetmap.org/?lat=41.901958&lon=-71.093431
 TreSt http://www.openstreetmap.org/?lat=41.912513&lon=-71.137912
 EddySt http://www.openstreetmap.org/?lat=41.935769&lon=-71.158812

--- a/hwy_data/MA/usaus/ma.us006.wpt
+++ b/hwy_data/MA/usaus/ma.us006.wpt
@@ -43,30 +43,30 @@ DepSt http://www.openstreetmap.org/?lat=41.761021&lon=-70.673547
 MainSt_Bou http://www.openstreetmap.org/?lat=41.746065&lon=-70.618047
 MarSt http://www.openstreetmap.org/?lat=41.748411&lon=-70.612049
 MA28_S +MA28_Bou http://www.openstreetmap.org/?lat=41.752025&lon=-70.597072
-+X449640 http://www.openstreetmap.org/?lat=41.753397&lon=-70.582743
++X52 http://www.openstreetmap.org/?lat=41.753397&lon=-70.582743
 HerPondRd http://www.openstreetmap.org/?lat=41.773984&lon=-70.560143
 MA3 http://www.openstreetmap.org/?lat=41.782401&lon=-70.543524
-MA6A_Bou http://www.openstreetmap.org/?lat=41.770287&lon=-70.543878
-MA130 http://www.openstreetmap.org/?lat=41.739209&lon=-70.493018
-QMHRd http://www.openstreetmap.org/?lat=41.730907&lon=-70.457597
-ChaRd http://www.openstreetmap.org/?lat=41.716845&lon=-70.420561
-MA149 http://www.openstreetmap.org/?lat=41.696468&lon=-70.384469
-+X01 http://www.openstreetmap.org/?lat=41.684107&lon=-70.356960
-MA132 http://www.openstreetmap.org/?lat=41.687912&lon=-70.336061
-WilSt http://www.openstreetmap.org/?lat=41.687191&lon=-70.257000
-UniSt http://www.openstreetmap.org/?lat=41.690172&lon=-70.214481
-MA134 http://www.openstreetmap.org/?lat=41.698055&lon=-70.153799
-MA124 http://www.openstreetmap.org/?lat=41.705841&lon=-70.076959
-MA137 http://www.openstreetmap.org/?lat=41.722635&lon=-70.034870
-+X02 http://www.openstreetmap.org/?lat=41.752978&lon=-70.001879
-MA6A_Orl http://www.openstreetmap.org/?lat=41.778193&lon=-70.003424
-+X03 http://www.openstreetmap.org/?lat=41.792859&lon=-70.000441
+55 +MA6A_Bou http://www.openstreetmap.org/?lat=41.771658&lon=-70.543478
+59 +MA130 http://www.openstreetmap.org/?lat=41.739209&lon=-70.493018
+61 http://www.openstreetmap.org/?lat=41.730907&lon=-70.457597
+63 http://www.openstreetmap.org/?lat=41.716845&lon=-70.420561
+65 http://www.openstreetmap.org/?lat=41.696468&lon=-70.384469
++X67 http://www.openstreetmap.org/?lat=41.684107&lon=-70.356960
+68 +MA132 http://www.openstreetmap.org/?lat=41.687912&lon=-70.336061
+72 +WilSt http://www.openstreetmap.org/?lat=41.687191&lon=-70.257000
+75 +UniSt http://www.openstreetmap.org/?lat=41.690172&lon=-70.214481
+78 http://www.openstreetmap.org/?lat=41.698055&lon=-70.153799
+82 http://www.openstreetmap.org/?lat=41.705841&lon=-70.076959
+85 +MA137 http://www.openstreetmap.org/?lat=41.722635&lon=-70.034870
++X87 http://www.openstreetmap.org/?lat=41.752978&lon=-70.001879
+89 +MA6A_Orl http://www.openstreetmap.org/?lat=41.778193&lon=-70.003424
++X90 http://www.openstreetmap.org/?lat=41.792859&lon=-70.000441
 MA6A_Eas http://www.openstreetmap.org/?lat=41.798911&lon=-69.984026
-+X04 http://www.openstreetmap.org/?lat=41.815972&lon=-69.968169
+GovPreRd http://www.openstreetmap.org/?lat=41.816056&lon=-69.968236
 SamRd http://www.openstreetmap.org/?lat=41.830281&lon=-69.973780
-MasRd http://www.openstreetmap.org/?lat=41.848593&lon=-69.987459
+MasRd http://www.openstreetmap.org/?lat=41.848425&lon=-69.987330
 LecHolRd http://www.openstreetmap.org/?lat=41.916330&lon=-69.989605
-+X05 http://www.openstreetmap.org/?lat=41.918733&lon=-70.004196
+Way112 http://www.openstreetmap.org/?lat=41.918813&lon=-70.004287
 BriLn http://www.openstreetmap.org/?lat=41.945718&lon=-70.031506
 PamPtRd http://www.openstreetmap.org/?lat=41.960942&lon=-70.029436
 SPamRd http://www.openstreetmap.org/?lat=41.993181&lon=-70.048399

--- a/hwy_data/MA/usaus/ma.us044.wpt
+++ b/hwy_data/MA/usaus/ma.us044.wpt
@@ -1,8 +1,9 @@
 RI/MA http://www.openstreetmap.org/?lat=41.823269&lon=-71.347189
 MA114A http://www.openstreetmap.org/?lat=41.824101&lon=-71.341825
+WilBriRd http://www.openstreetmap.org/?lat=41.837342&lon=-71.277991
 MA118 http://www.openstreetmap.org/?lat=41.854539&lon=-71.238999
-MA138 http://www.openstreetmap.org/?lat=41.901958&lon=-71.093431
-MA140_S http://www.openstreetmap.org/?lat=41.901638&lon=-71.089611
+MA138/140 +MA138 http://www.openstreetmap.org/?lat=41.901958&lon=-71.093431
+MA140_S http://www.openstreetmap.org/?lat=41.901592&lon=-71.089268
 MA104 http://www.openstreetmap.org/?lat=41.905950&lon=-71.068411
 MA24 http://www.openstreetmap.org/?lat=41.906333&lon=-71.042404
 I-495 http://www.openstreetmap.org/?lat=41.902692&lon=-70.964813
@@ -12,9 +13,9 @@ EveSt http://www.openstreetmap.org/?lat=41.907164&lon=-70.921812
 PlySt http://www.openstreetmap.org/?lat=41.907747&lon=-70.912371
 MA105 http://www.openstreetmap.org/?lat=41.910869&lon=-70.882931
 MA58 http://www.openstreetmap.org/?lat=41.926356&lon=-70.807314
-SprSt http://www.openstreetmap.org/?lat=41.944362&lon=-70.770149
+SprSt http://www.openstreetmap.org/?lat=41.945401&lon=-70.769843
 +X01 http://www.openstreetmap.org/?lat=41.961062&lon=-70.740967
-ComWay http://www.openstreetmap.org/?lat=41.958469&lon=-70.713565
+ComWay http://www.openstreetmap.org/?lat=41.959356&lon=-70.710089
 MA3(16) +MA3(7) http://www.openstreetmap.org/?lat=41.966415&lon=-70.696721
 MA3(15) +MA3(6) http://www.openstreetmap.org/?lat=41.954448&lon=-70.682344
 MA3A http://www.openstreetmap.org/?lat=41.960192&lon=-70.670328

--- a/hwy_data/RI/usaus/ri.us001.wpt
+++ b/hwy_data/RI/usaus/ri.us001.wpt
@@ -72,7 +72,7 @@ RocAve http://www.openstreetmap.org/?lat=41.846793&lon=-71.405130
 RI126 http://www.openstreetmap.org/?lat=41.852321&lon=-71.401718
 RI122 http://www.openstreetmap.org/?lat=41.858023&lon=-71.398948
 GeoSt_S http://www.openstreetmap.org/?lat=41.870282&lon=-71.387830
-I-95(27) +RI114_N http://www.openstreetmap.org/?lat=41.873078&lon=-71.387559
+I-95(27) http://www.openstreetmap.org/?lat=41.873078&lon=-71.387559
 I-95(28) http://www.openstreetmap.org/?lat=41.874258&lon=-71.381135
 I-95(29) http://www.openstreetmap.org/?lat=41.882307&lon=-71.377468
 CenAve http://www.openstreetmap.org/?lat=41.884571&lon=-71.376339

--- a/hwy_data/RI/usaus/ri.us006.wpt
+++ b/hwy_data/RI/usaus/ri.us006.wpt
@@ -10,6 +10,7 @@ I-295(9) +I-295(6) http://www.openstreetmap.org/?lat=41.820571&lon=-71.512748
 RI5 http://www.openstreetmap.org/?lat=41.817069&lon=-71.496685
 US6Alt_C http://www.openstreetmap.org/?lat=41.820315&lon=-71.478513
 RI128 http://www.openstreetmap.org/?lat=41.821990&lon=-71.470235
++X706080 http://www.openstreetmap.org/?lat=41.821444&lon=-71.453423
 US6Alt_E http://www.openstreetmap.org/?lat=41.817121&lon=-71.448402
 RI14 http://www.openstreetmap.org/?lat=41.814222&lon=-71.444387
 RI10_S http://www.openstreetmap.org/?lat=41.813776&lon=-71.439972


### PR DESCRIPTION
Non-newsworthy:
Formerly used old CHM-style crossroad-labels rather than the sequential exit numbers.
No labels moved; no .lists broken.