### PR TITLE
PA 50 and PA 980 Point Additions Related to PA 576

### DIFF
--- a/hwy_data/PA/usapa/pa.pa050.wpt
+++ b/hwy_data/PA/usapa/pa.pa050.wpt
@@ -12,6 +12,7 @@ PA18_S http://www.openstreetmap.org/?lat=40.293345&lon=-80.333354
 PA18_N http://www.openstreetmap.org/?lat=40.296149&lon=-80.325446
 McCRd http://www.openstreetmap.org/?lat=40.298238&lon=-80.311062
 PA519 http://www.openstreetmap.org/?lat=40.303121&lon=-80.302154
+FortCheRd http://www.openstreetmap.org/?lat=40.305115&lon=-80.299375
 PleRd http://www.openstreetmap.org/?lat=40.313417&lon=-80.276786
 HorRd http://www.openstreetmap.org/?lat=40.315727&lon=-80.258182
 *OldPA980 http://www.openstreetmap.org/?lat=40.320972&lon=-80.232661
@@ -19,6 +20,7 @@ PA980 http://www.openstreetmap.org/?lat=40.321058&lon=-80.232248
 MuseBisRd http://www.openstreetmap.org/?lat=40.319494&lon=-80.201603
 ReiRd http://www.openstreetmap.org/?lat=40.329475&lon=-80.185328
 CecHenRd http://www.openstreetmap.org/?lat=40.330352&lon=-80.183925
+FayWay http://www.openstreetmap.org/?lat=40.336799&lon=-80.178764
 PA978 http://www.openstreetmap.org/?lat=40.340838&lon=-80.171541
 +X1B http://www.openstreetmap.org/?lat=40.345438&lon=-80.165858
 AlpRd http://www.openstreetmap.org/?lat=40.345448&lon=-80.154721
@@ -26,7 +28,7 @@ AlpRd http://www.openstreetmap.org/?lat=40.345448&lon=-80.154721
 +X1D http://www.openstreetmap.org/?lat=40.353273&lon=-80.132789
 MilRunRd http://www.openstreetmap.org/?lat=40.357932&lon=-80.126241
 I-79(54) http://www.openstreetmap.org/?lat=40.356155&lon=-80.118434
-WasPike  +WasPk http://www.openstreetmap.org/?lat=40.354522&lon=-80.114767
+WasPike +WasPk http://www.openstreetmap.org/?lat=40.354522&lon=-80.114767
 BowHillRd http://www.openstreetmap.org/?lat=40.360004&lon=-80.111586
 PreRd http://www.openstreetmap.org/?lat=40.362591&lon=-80.110486
 I-79(55) http://www.openstreetmap.org/?lat=40.372961&lon=-80.099344

--- a/hwy_data/PA/usapa/pa.pa980.wpt
+++ b/hwy_data/PA/usapa/pa.pa980.wpt
@@ -9,7 +9,7 @@ GlaRd http://www.openstreetmap.org/?lat=40.352239&lon=-80.242175
 ReiRd http://www.openstreetmap.org/?lat=40.358203&lon=-80.236129
 LinAve_E http://www.openstreetmap.org/?lat=40.368825&lon=-80.234925
 NobRd http://www.openstreetmap.org/?lat=40.365011&lon=-80.246646
-+X(FortCheRd) http://www.openstreetmap.org/?lat=40.373457&lon=-80.253316
++X(FortCheRd) http://www.openstreetmap.org/?lat=40.373547&lon=-80.253051
 NorBraRd http://www.openstreetmap.org/?lat=40.386170&lon=-80.267827
 QuiRd http://www.openstreetmap.org/?lat=40.395138&lon=-80.285549
 BeeHolRd http://www.openstreetmap.org/?lat=40.400104&lon=-80.286761

--- a/hwy_data/PA/usapa/pa.pa980.wpt
+++ b/hwy_data/PA/usapa/pa.pa980.wpt
@@ -9,7 +9,7 @@ GlaRd http://www.openstreetmap.org/?lat=40.352239&lon=-80.242175
 ReiRd http://www.openstreetmap.org/?lat=40.358203&lon=-80.236129
 LinAve_E http://www.openstreetmap.org/?lat=40.368825&lon=-80.234925
 NobRd http://www.openstreetmap.org/?lat=40.365011&lon=-80.246646
-+X(FortCheRd) http://www.openstreetmap.org/?lat=40.373547&lon=-80.253051
+FortCheRd http://www.openstreetmap.org/?lat=40.373547&lon=-80.253051
 NorBraRd http://www.openstreetmap.org/?lat=40.386170&lon=-80.267827
 QuiRd http://www.openstreetmap.org/?lat=40.395138&lon=-80.285549
 BeeHolRd http://www.openstreetmap.org/?lat=40.400104&lon=-80.286761


### PR DESCRIPTION
https://forum.travelmapping.net/index.php?topic=4088.0

PA 50: Added Fort Cherry Rd (FortCheRd) and Fayette Way (FayWay). (https://www.patpconstruction.com/southern_beltway/pdf/2020-10-30%20Southern%20Beltway%20Weekly%20Update.pdf)
PA 980:  Relocated and Unhid Fort Cherry Rd (FortCheRd) point. (https://www.patpconstruction.com/southern_beltway/pdf/2021-01-29%20Southern%20Beltway%20Weekly%20Update.pdf)  The file says the permanent traffic pattern is in place so I think that FortCheRd is open.