### PR TITLE
Rochester Inner Loop

### DIFF
--- a/hwy_data/NY/usasf/ny.innloop.wpt
+++ b/hwy_data/NY/usasf/ny.innloop.wpt
@@ -1,0 +1,6 @@
+I-490 http://www.openstreetmap.org/?lat=43.156043&lon=-77.620865
+StaSt http://www.openstreetmap.org/?lat=43.158695&lon=-77.615780
+CliAve http://www.openstreetmap.org/?lat=43.161686&lon=-77.609337
+ScioSt http://www.openstreetmap.org/?lat=43.161240&lon=-77.597718
+MainSt http://www.openstreetmap.org/?lat=43.160888&lon=-77.596833
+UniSt http://www.openstreetmap.org/?lat=43.157939&lon=-77.595462

--- a/hwy_data/_systems/usasf.csv
+++ b/hwy_data/_systems/usasf.csv
@@ -41,6 +41,7 @@ usasf;NY;HenHudPkwy;;;Henry Hudson Parkway;ny.henhudpkwy;
 usasf;AK;HicPkwy;;;Walter J. Hickel Parkway;ak.hicpkwy;
 usasf;NY;HutRivPkwy;;;Hutchinson River Parkway;ny.hutrivpkwy;
 usasf;OK;IndNatTpk;;;Indian Nation Turnpike;ok.indnattpk;
+usasf;NY;InnLoop;;;Inner Loop;ny.innloop;
 usasf;TX;IntPkwy;;;International Parkway;tx.intpkwy;TXLp97
 usasf;TN;JamWhiPkwy;;;James White Parkway;tn.jamwhipkwy;
 usasf;OK;JohnKilTpk;;;John Kilpatrick Turnpike;ok.johnkiltpk;

--- a/hwy_data/_systems/usasf_con.csv
+++ b/hwy_data/_systems/usasf_con.csv
@@ -40,6 +40,7 @@ usasf;HenHudPkwy;;Henry Hudson Parkway;ny.henhudpkwy
 usasf;HicPkwy;;Walter J. Hickel Parkway;ak.hicpkwy
 usasf;HutRivPkwy;;Hutchinson River Parkway;ny.hutrivpkwy
 usasf;IndNatTpk;;Indian Nation Turnpike;ok.indnattpk
+usasf;InnLoop;;Inner Loop;ny.innloop
 usasf;IntPkwy;;International Parkway;tx.intpkwy
 usasf;JamWhiPkwy;;James White Parkway;tn.jamwhipkwy
 usasf;JohnKilTpk;;John Kilpatrick Turnpike;ok.johnkiltpk

--- a/updates.csv
+++ b/updates.csv
@@ -4283,6 +4283,7 @@ date;region;route;root;description
 2015-11-20;(USA) New Mexico;US 70;nm.us070;In Lordsburg, route moved from I-10 between exits 22 and 24, and Main St. (NM 494), north to Motel Dr. (I-10BL)
 2015-11-02;(USA) New Mexico;US 380;nm.us380;Swapped locations of labels US285Trk and US70/285
 2015-11-02;(USA) New Mexico;US 70 Truck (Roswell);nm.us070trkros;Removed from southern part of relief route on the west side of Roswell and relocated onto northern part
+2021-02-09;(USA) New York;Inner Loop;ny.innloop;Route added.
 2021-01-26;(USA) New York;NY 107;ny.ny107;North end truncated from Glen Cove Avenue to Pulaski Street.
 2020-11-13;(USA) New York;NY 5 Truck (Schenectady);;Deleted
 2020-11-13;(USA) New York;NY 9P Truck (Saratoga Springs);;Deleted


### PR DESCRIPTION
Data check passed.
Had a bit of a back-n-forth over whether to call it "Loop" or "Lp"; looked to existing HighwayData for guidance. Route names in CSVs used both inconsistently, so I went with "InnLoop" that's still present in a couple usany AltLabels.