### PR TITLE
delete TX167

### DIFF
--- a/hwy_data/TX/usatx/tx.tx167.wpt
+++ b/hwy_data/TX/usatx/tx.tx167.wpt
@@ -1,2 +1,0 @@
-US67/377 http://www.openstreetmap.org/?lat=32.109824&lon=-98.330625
-US67Bus http://www.openstreetmap.org/?lat=32.108480&lon=-98.329303

--- a/hwy_data/TX/usaus/tx.us067.wpt
+++ b/hwy_data/TX/usaus/tx.us067.wpt
@@ -143,7 +143,6 @@ FM1476_S http://www.openstreetmap.org/?lat=31.990029&lon=-98.434105
 US67BusDub_S http://www.openstreetmap.org/?lat=32.063837&lon=-98.367113
 TX6 http://www.openstreetmap.org/?lat=32.093182&lon=-98.368202
 FM219 http://www.openstreetmap.org/?lat=32.105107&lon=-98.350763
-TX167 http://www.openstreetmap.org/?lat=32.109824&lon=-98.330625
 US67BusDub_N http://www.openstreetmap.org/?lat=32.111287&lon=-98.327540
 FM988 http://www.openstreetmap.org/?lat=32.201613&lon=-98.245797
 US377Bus http://www.openstreetmap.org/?lat=32.207441&lon=-98.230289

--- a/hwy_data/TX/usaus/tx.us377.wpt
+++ b/hwy_data/TX/usaus/tx.us377.wpt
@@ -91,7 +91,6 @@ FM1476_S http://www.openstreetmap.org/?lat=31.990029&lon=-98.434105
 US377BusDub_S http://www.openstreetmap.org/?lat=32.063837&lon=-98.367113
 TX6 http://www.openstreetmap.org/?lat=32.093182&lon=-98.368202
 FM219 http://www.openstreetmap.org/?lat=32.105107&lon=-98.350763
-TX167 http://www.openstreetmap.org/?lat=32.109824&lon=-98.330625
 US377BusDub_N http://www.openstreetmap.org/?lat=32.111287&lon=-98.327540
 FM988 http://www.openstreetmap.org/?lat=32.201613&lon=-98.245797
 US377BusSte_S http://www.openstreetmap.org/?lat=32.207441&lon=-98.230289

--- a/hwy_data/TX/usausb/tx.us067busdub.wpt
+++ b/hwy_data/TX/usausb/tx.us067busdub.wpt
@@ -1,5 +1,4 @@
 US67_S http://www.openstreetmap.org/?lat=32.063837&lon=-98.367113
 TX6 http://www.openstreetmap.org/?lat=32.085215&lon=-98.342405
 FM219_N http://www.openstreetmap.org/?lat=32.096250&lon=-98.338838
-TX167 http://www.openstreetmap.org/?lat=32.108480&lon=-98.329303
 US67_N http://www.openstreetmap.org/?lat=32.111287&lon=-98.327540

--- a/hwy_data/TX/usausb/tx.us377busdub.wpt
+++ b/hwy_data/TX/usausb/tx.us377busdub.wpt
@@ -1,5 +1,4 @@
 US377_S http://www.openstreetmap.org/?lat=32.063837&lon=-98.367113
 TX6 http://www.openstreetmap.org/?lat=32.085215&lon=-98.342405
 FM219_N http://www.openstreetmap.org/?lat=32.096250&lon=-98.338838
-TX167 http://www.openstreetmap.org/?lat=32.108480&lon=-98.329303
 US377_N http://www.openstreetmap.org/?lat=32.111287&lon=-98.327540

--- a/hwy_data/_systems/usatx.csv
+++ b/hwy_data/_systems/usatx.csv
@@ -190,7 +190,6 @@ usatx;TX;TX163;;;;tx.tx163;
 usatx;TX;TX164;;;;tx.tx164;
 usatx;TX;TX165;;;;tx.tx165;
 usatx;TX;TX166;;;;tx.tx166;
-usatx;TX;TX167;;;;tx.tx167;
 usatx;TX;TX168;;;;tx.tx168;
 usatx;TX;TX170;;;;tx.tx170;
 usatx;TX;TX171;;;;tx.tx171;

--- a/hwy_data/_systems/usatx_con.csv
+++ b/hwy_data/_systems/usatx_con.csv
@@ -190,7 +190,6 @@ usatx;TX163;;;tx.tx163
 usatx;TX164;;;tx.tx164
 usatx;TX165;;;tx.tx165
 usatx;TX166;;;tx.tx166
-usatx;TX167;;;tx.tx167
 usatx;TX168;;;tx.tx168
 usatx;TX170;;;tx.tx170
 usatx;TX171;;;tx.tx171

--- a/updates.csv
+++ b/updates.csv
@@ -4862,6 +4862,7 @@ date;region;route;root;description
 2015-11-29;(USA) Tennessee;US 641;tn.us641;Extended southward from the former ending intersection with I-40 along TN 69 & TN 114 to a new southern terminus at US 64
 2015-10-25;(USA) Tennessee;I-269;tn.i269;Route added
 2015-10-25;(USA) Tennessee;I-269 Future (Memphis, TN);tn.i269futmem;Extended southward from the interchange with TN 57 to a newly opened interchange with I-269 (Exit 2)
+2021-05-01;(USA) Texas;TX 167;;Route deleted.
 2021-04-22;(USA) Texas;TX 249;tx.tx249;Extended northward from FM 1488 east of Magnolia to FM 1774 north of Todd Mission.
 2021-03-13;(USA) Texas;TX Spur 17;tx.sp0017;Route added.
 2020-11-26;(USA) Texas;TX Loop 255;tx.lp0255;Route added.


### PR DESCRIPTION
https://publicdocs.txdot.gov/minord/MinuteOrderDocLib/12-DEC13_2012NUM.pdf
> *The Fort Worth District has requested that a segment of County Road 351 (CR 351) be
temporarily designated as SH 167. The designation will remain in effect until construction of the
US 67 Relief Route around the city of Dublin is complete. Once the relief route has been
completed in its entirety, the designated segment of CR 351 will be removed from the state system.
The temporary designation of SH 167 will run from US 67 along existing CR 351 in the city of
Dublin westward approximately 230 feet to SH 267.*