### PR TITLE
I-35W/US 10 Exit Number Changes

### DIFF
--- a/hwy_data/MN/usai/mn.i035w.wpt
+++ b/hwy_data/MN/usai/mn.i035w.wpt
@@ -39,11 +39,11 @@ FraAve http://www.openstreetmap.org/?lat=44.965700&lon=-93.268000
 24 http://www.openstreetmap.org/?lat=45.022021&lon=-93.189790
 25A http://www.openstreetmap.org/?lat=45.035632&lon=-93.190477
 25B http://www.openstreetmap.org/?lat=45.040613&lon=-93.189576
-26 http://www.openstreetmap.org/?lat=45.057380&lon=-93.187516
-27 http://www.openstreetmap.org/?lat=45.067126&lon=-93.186078
-28A http://www.openstreetmap.org/?lat=45.079089&lon=-93.185595
-28B http://www.openstreetmap.org/?lat=45.090263&lon=-93.188095
-28C http://www.openstreetmap.org/?lat=45.095413&lon=-93.188224
+26A http://www.openstreetmap.org/?lat=45.057380&lon=-93.187516
+26B http://www.openstreetmap.org/?lat=45.067126&lon=-93.186078
+27 http://www.openstreetmap.org/?lat=45.079089&lon=-93.185595
+28A http://www.openstreetmap.org/?lat=45.090263&lon=-93.188095
+28B http://www.openstreetmap.org/?lat=45.095413&lon=-93.188224
 29 http://www.openstreetmap.org/?lat=45.107954&lon=-93.188363
 30 http://www.openstreetmap.org/?lat=45.115730&lon=-93.188471
 31A http://www.openstreetmap.org/?lat=45.124353&lon=-93.188546

--- a/hwy_data/MN/usaus/mn.us010.wpt
+++ b/hwy_data/MN/usaus/mn.us010.wpt
@@ -104,8 +104,8 @@ MN65 http://www.openstreetmap.org/?lat=45.133973&lon=-93.235270
 93rdLn http://www.openstreetmap.org/?lat=45.127562&lon=-93.217760
 I-35W(30) http://www.openstreetmap.org/?lat=45.115730&lon=-93.188471
 I-35W(29) http://www.openstreetmap.org/?lat=45.107954&lon=-93.188363
-I-35W(28C) http://www.openstreetmap.org/?lat=45.095413&lon=-93.188224
-I-35W(28B) http://www.openstreetmap.org/?lat=45.090263&lon=-93.188095
+I-35W(28B) http://www.openstreetmap.org/?lat=45.095413&lon=-93.188224
+I-35W(28A) http://www.openstreetmap.org/?lat=45.090263&lon=-93.188095
 CR96 http://www.openstreetmap.org/?lat=45.079210&lon=-93.176368
 I-694(42B) http://www.openstreetmap.org/?lat=45.066034&lon=-93.165522
 I-694(42A) http://www.openstreetmap.org/?lat=45.062094&lon=-93.157132


### PR DESCRIPTION
MnDOT recently changed exit numbers along I-35W in the vicinity of I-694 and US 10.  For @alexgotz @freakwentflier @NickCPDX , this affects your lists as you're currently using the "27" point on I-35W which has been renumbered 26B.  @yakra, can you add anyone to this notification who is using the "I-35W(28B)" point on mn.us010?  That label has changed to I-35W(28A) as a result of this exit renumbering.
