### PR TITLE
I-69 exit numbers

### DIFF
--- a/hwy_data/TX/usai/tx.i069.wpt
+++ b/hwy_data/TX/usai/tx.i069.wpt
@@ -1,28 +1,29 @@
-TXSpr529 http://www.openstreetmap.org/?lat=29.534455&lon=-95.856603
-BamRd http://www.openstreetmap.org/?lat=29.531869&lon=-95.818961
-TX36 http://www.openstreetmap.org/?lat=29.532123&lon=-95.808222
+*TXSpr529 http://www.openstreetmap.org/?lat=29.534455&lon=-95.856603
+95 http://www.openstreetmap.org/?lat=29.534493&lon=-95.845791
+96 http://www.openstreetmap.org/?lat=29.531869&lon=-95.818961
+97 http://www.openstreetmap.org/?lat=29.532123&lon=-95.808222
 99 http://www.openstreetmap.org/?lat=29.534359&lon=-95.776475
 100 http://www.openstreetmap.org/?lat=29.542461&lon=-95.756624
 101 http://www.openstreetmap.org/?lat=29.546638&lon=-95.746756
 103 http://www.openstreetmap.org/?lat=29.555964&lon=-95.716984
 104 +TX99_S http://www.openstreetmap.org/?lat=29.561377&lon=-95.690473
 105 http://www.openstreetmap.org/?lat=29.568113&lon=-95.668323
-UniBlvd http://www.openstreetmap.org/?lat=29.580982&lon=-95.647925
-SweBlvd http://www.openstreetmap.org/?lat=29.589326&lon=-95.634707
-TX6 http://www.openstreetmap.org/?lat=29.598398&lon=-95.622508
+107 http://www.openstreetmap.org/?lat=29.580982&lon=-95.647925
+108 +SweBlvd http://www.openstreetmap.org/?lat=29.589326&lon=-95.634707
+109 http://www.openstreetmap.org/?lat=29.598398&lon=-95.622508
 110 http://www.openstreetmap.org/?lat=29.607055&lon=-95.613668
 111 http://www.openstreetmap.org/?lat=29.621580&lon=-95.601555
 112 http://www.openstreetmap.org/?lat=29.628160&lon=-95.593114
 113 http://www.openstreetmap.org/?lat=29.641686&lon=-95.578727
 114 http://www.openstreetmap.org/?lat=29.651335&lon=-95.568349
-BelPRDr http://www.openstreetmap.org/?lat=29.656605&lon=-95.562674
+WBelPR http://www.openstreetmap.org/?lat=29.656605&lon=-95.562674
 115 +TXLp8_S http://www.openstreetmap.org/?lat=29.660999&lon=-95.557969
-WesPRDr http://www.openstreetmap.org/?lat=29.670582&lon=-95.547653
+WesPR http://www.openstreetmap.org/?lat=29.670582&lon=-95.547653
 117 +BisSt http://www.openstreetmap.org/?lat=29.675877&lon=-95.541988
 118 http://www.openstreetmap.org/?lat=29.690156&lon=-95.528937
 119 http://www.openstreetmap.org/?lat=29.702253&lon=-95.515534
 121A http://www.openstreetmap.org/?lat=29.716735&lon=-95.499164
-HilTCDr http://www.openstreetmap.org/?lat=29.720539&lon=-95.494830
+HilTC http://www.openstreetmap.org/?lat=29.720539&lon=-95.494830
 121B http://www.openstreetmap.org/?lat=29.723520&lon=-95.491498
 122B http://www.openstreetmap.org/?lat=29.725812&lon=-95.484173
 122A http://www.openstreetmap.org/?lat=29.725857&lon=-95.476467
@@ -50,7 +51,7 @@ HilTCDr http://www.openstreetmap.org/?lat=29.720539&lon=-95.494830
 136 http://www.openstreetmap.org/?lat=29.829201&lon=-95.335174
 137A http://www.openstreetmap.org/?lat=29.840764&lon=-95.333452
 137B http://www.openstreetmap.org/?lat=29.848784&lon=-95.333562
-TurDr http://www.openstreetmap.org/?lat=29.851506&lon=-95.333669
+TidTC http://www.openstreetmap.org/?lat=29.851506&lon=-95.333669
 138 http://www.openstreetmap.org/?lat=29.859336&lon=-95.333487
 139 +LitYorkRd http://www.openstreetmap.org/?lat=29.870308&lon=-95.330037
 140A http://www.openstreetmap.org/?lat=29.879639&lon=-95.324609
@@ -63,7 +64,7 @@ TurDr http://www.openstreetmap.org/?lat=29.851506&lon=-95.333669
 145 http://www.openstreetmap.org/?lat=29.952262&lon=-95.290349
 146 http://www.openstreetmap.org/?lat=29.965594&lon=-95.284424
 147 +WillClaPkwy http://www.openstreetmap.org/?lat=29.982444&lon=-95.276927
-McKBlvd http://www.openstreetmap.org/?lat=29.987234&lon=-95.275095
+McKDr http://www.openstreetmap.org/?lat=29.987234&lon=-95.275095
 149 http://www.openstreetmap.org/?lat=30.001290&lon=-95.269674
 149A +FM1960 http://www.openstreetmap.org/?lat=30.004960&lon=-95.268044
 150 http://www.openstreetmap.org/?lat=30.018099&lon=-95.262221

--- a/hwy_data/TX/usaus/tx.us059.wpt
+++ b/hwy_data/TX/usaus/tx.us059.wpt
@@ -102,31 +102,32 @@ IslRd http://www.openstreetmap.org/?lat=29.494504&lon=-95.911304
 HamRd http://www.openstreetmap.org/?lat=29.501395&lon=-95.905387
 TXLp540_N http://www.openstreetmap.org/?lat=29.508566&lon=-95.899379
 TXSpr10 http://www.openstreetmap.org/?lat=29.523857&lon=-95.874228
-TXSpr529 http://www.openstreetmap.org/?lat=29.534455&lon=-95.856603
-BamRd http://www.openstreetmap.org/?lat=29.531869&lon=-95.818961
-TX36 http://www.openstreetmap.org/?lat=29.532123&lon=-95.808222
+*TXSpr529 http://www.openstreetmap.org/?lat=29.534455&lon=-95.856603
+I-69(95) http://www.openstreetmap.org/?lat=29.534493&lon=-95.845791
+I-69(96) http://www.openstreetmap.org/?lat=29.531869&lon=-95.818961
+I-69(97) http://www.openstreetmap.org/?lat=29.532123&lon=-95.808222
 I-69(99) http://www.openstreetmap.org/?lat=29.534359&lon=-95.776475
 I-69(100) http://www.openstreetmap.org/?lat=29.542461&lon=-95.756624
 I-69(101) http://www.openstreetmap.org/?lat=29.546638&lon=-95.746756
 I-69(103) http://www.openstreetmap.org/?lat=29.555964&lon=-95.716984
 I-69(104) +TX99_S http://www.openstreetmap.org/?lat=29.561377&lon=-95.690473
 I-69(105) http://www.openstreetmap.org/?lat=29.568113&lon=-95.668323
-UniBlvd http://www.openstreetmap.org/?lat=29.580982&lon=-95.647925
-SweBlvd http://www.openstreetmap.org/?lat=29.589326&lon=-95.634707
-TX6 http://www.openstreetmap.org/?lat=29.598398&lon=-95.622508
+I-69(107) http://www.openstreetmap.org/?lat=29.580982&lon=-95.647925
+I-69(108) +SweBlvd http://www.openstreetmap.org/?lat=29.589326&lon=-95.634707
+I-69(109) http://www.openstreetmap.org/?lat=29.598398&lon=-95.622508
 I-69(110) http://www.openstreetmap.org/?lat=29.607055&lon=-95.613668
 I-69(111) http://www.openstreetmap.org/?lat=29.621580&lon=-95.601555
 I-69(112) http://www.openstreetmap.org/?lat=29.628160&lon=-95.593114
 I-69(113) http://www.openstreetmap.org/?lat=29.641686&lon=-95.578727
 I-69(114) http://www.openstreetmap.org/?lat=29.651335&lon=-95.568349
-BelPRDr http://www.openstreetmap.org/?lat=29.656605&lon=-95.562674
+WBelPR http://www.openstreetmap.org/?lat=29.656605&lon=-95.562674
 I-69(115) +TXLp8_S http://www.openstreetmap.org/?lat=29.660999&lon=-95.557969
-WesPRDr http://www.openstreetmap.org/?lat=29.670582&lon=-95.547653
+WesPR http://www.openstreetmap.org/?lat=29.670582&lon=-95.547653
 I-69(117) +BisSt http://www.openstreetmap.org/?lat=29.675877&lon=-95.541988
 I-69(118) http://www.openstreetmap.org/?lat=29.690156&lon=-95.528937
 I-69(119) http://www.openstreetmap.org/?lat=29.702253&lon=-95.515534
 I-69(121A) http://www.openstreetmap.org/?lat=29.716735&lon=-95.499164
-HilTCDr http://www.openstreetmap.org/?lat=29.720539&lon=-95.494830
+HilTC http://www.openstreetmap.org/?lat=29.720539&lon=-95.494830
 I-69(121B) http://www.openstreetmap.org/?lat=29.723520&lon=-95.491498
 I-69(122B) http://www.openstreetmap.org/?lat=29.725812&lon=-95.484173
 I-69(122A) +ChiRockRd http://www.openstreetmap.org/?lat=29.725857&lon=-95.476467
@@ -154,7 +155,7 @@ I-69(134A) +I-610(20A) http://www.openstreetmap.org/?lat=29.808178&lon=-95.33579
 I-69(136) http://www.openstreetmap.org/?lat=29.829201&lon=-95.335174
 I-69(137A) http://www.openstreetmap.org/?lat=29.840764&lon=-95.333452
 I-69(137B) http://www.openstreetmap.org/?lat=29.848784&lon=-95.333562
-TurDr http://www.openstreetmap.org/?lat=29.851506&lon=-95.333669
+TidTC http://www.openstreetmap.org/?lat=29.851506&lon=-95.333669
 I-69(138) http://www.openstreetmap.org/?lat=29.859336&lon=-95.333487
 I-69(139) http://www.openstreetmap.org/?lat=29.870308&lon=-95.330037
 I-69(140A) http://www.openstreetmap.org/?lat=29.879639&lon=-95.324609
@@ -167,7 +168,7 @@ I-69(144) +TXLp8_N http://www.openstreetmap.org/?lat=29.940065&lon=-95.295727
 I-69(145) http://www.openstreetmap.org/?lat=29.952262&lon=-95.290349
 I-69(146) http://www.openstreetmap.org/?lat=29.965594&lon=-95.284424
 I-69(147) +WillClaPkwy http://www.openstreetmap.org/?lat=29.982444&lon=-95.276927
-McKBlvd http://www.openstreetmap.org/?lat=29.987234&lon=-95.275095
+McKDr http://www.openstreetmap.org/?lat=29.987234&lon=-95.275095
 I-69(149) http://www.openstreetmap.org/?lat=30.001290&lon=-95.269674
 I-69(149A) +FM1960 http://www.openstreetmap.org/?lat=30.004960&lon=-95.268044
 I-69(150) http://www.openstreetmap.org/?lat=30.018099&lon=-95.262221


### PR DESCRIPTION
Other than marking it closed, went no-build on TXSpr529. Once all the dust settles, Exit 94 may end up being a little more to the SW. This leaves future options open.