### PR TITLE
I-91 & MA2 renumbering, etc.

### DIFF
--- a/hwy_data/MA/usai/ma.i091.wpt
+++ b/hwy_data/MA/usai/ma.i091.wpt
@@ -1,35 +1,35 @@
 CT/MA +0 http://www.openstreetmap.org/?lat=42.024719&lon=-72.589630
-+X01 http://www.openstreetmap.org/?lat=42.071218&lon=-72.587700
 1 http://www.openstreetmap.org/?lat=42.075196&lon=-72.582636
 2 http://www.openstreetmap.org/?lat=42.077728&lon=-72.580029
 3 http://www.openstreetmap.org/?lat=42.082299&lon=-72.579031
 4 http://www.openstreetmap.org/?lat=42.087586&lon=-72.580817
-6 http://www.openstreetmap.org/?lat=42.096813&lon=-72.587067
-7 http://www.openstreetmap.org/?lat=42.101096&lon=-72.592335
-8 http://www.openstreetmap.org/?lat=42.107030&lon=-72.601529
-9 http://www.openstreetmap.org/?lat=42.111388&lon=-72.606357
-11 http://www.openstreetmap.org/?lat=42.121400&lon=-72.608900
-12 http://www.openstreetmap.org/?lat=42.134227&lon=-72.609372
-13 http://www.openstreetmap.org/?lat=42.136208&lon=-72.625680
-+X01A http://www.openstreetmap.org/?lat=42.152085&lon=-72.647309
-14 http://www.openstreetmap.org/?lat=42.162316&lon=-72.646259
-15 http://www.openstreetmap.org/?lat=42.174250&lon=-72.643833
-16 http://www.openstreetmap.org/?lat=42.200104&lon=-72.638382
-17 http://www.openstreetmap.org/?lat=42.212817&lon=-72.632976
-+X02 http://www.openstreetmap.org/?lat=42.227378&lon=-72.637310
-+X03 http://www.openstreetmap.org/?lat=42.275914&lon=-72.605896
-+X04 http://www.openstreetmap.org/?lat=42.295600&lon=-72.629929
-18 http://www.openstreetmap.org/?lat=42.307832&lon=-72.623277
-19 http://www.openstreetmap.org/?lat=42.333141&lon=-72.621255
-20 http://www.openstreetmap.org/?lat=42.341179&lon=-72.639477
-21 http://www.openstreetmap.org/?lat=42.360542&lon=-72.636709
-22 http://www.openstreetmap.org/?lat=42.398457&lon=-72.628296
-23 http://www.openstreetmap.org/?lat=42.432293&lon=-72.622116
-24 http://www.openstreetmap.org/?lat=42.466904&lon=-72.616325
-25 http://www.openstreetmap.org/?lat=42.483966&lon=-72.616367
-+X05 http://www.openstreetmap.org/?lat=42.535125&lon=-72.628384
-26 http://www.openstreetmap.org/?lat=42.585318&lon=-72.621388
-+X291 http://www.openstreetmap.org/?lat=42.606448&lon=-72.612419
-27 http://www.openstreetmap.org/?lat=42.616339&lon=-72.593064
-28 http://www.openstreetmap.org/?lat=42.670541&lon=-72.543197
+5A http://www.openstreetmap.org/?lat=42.096813&lon=-72.587067
+5B http://www.openstreetmap.org/?lat=42.101096&lon=-72.592335
+6 http://www.openstreetmap.org/?lat=42.107030&lon=-72.601529
+7 http://www.openstreetmap.org/?lat=42.111388&lon=-72.606357
+8 http://www.openstreetmap.org/?lat=42.121400&lon=-72.608900
+9 http://www.openstreetmap.org/?lat=42.134227&lon=-72.609372
+10 +13 http://www.openstreetmap.org/?lat=42.136208&lon=-72.625680
++X10A http://www.openstreetmap.org/?lat=42.152085&lon=-72.647309
+11 http://www.openstreetmap.org/?lat=42.162316&lon=-72.646259
+12 http://www.openstreetmap.org/?lat=42.174250&lon=-72.643833
+14 +16 http://www.openstreetmap.org/?lat=42.200104&lon=-72.638382
+15 http://www.openstreetmap.org/?lat=42.212817&lon=-72.632976
++X16 http://www.openstreetmap.org/?lat=42.227322&lon=-72.636932
++X20 http://www.openstreetmap.org/?lat=42.275181&lon=-72.605655
++X22 http://www.openstreetmap.org/?lat=42.295626&lon=-72.629599
+23 +18 http://www.openstreetmap.org/?lat=42.307832&lon=-72.623277
+25 +19 http://www.openstreetmap.org/?lat=42.333141&lon=-72.621255
+26 +20 http://www.openstreetmap.org/?lat=42.341179&lon=-72.639477
+27 http://www.openstreetmap.org/?lat=42.360542&lon=-72.636709
+30 http://www.openstreetmap.org/?lat=42.398457&lon=-72.628296
+32 http://www.openstreetmap.org/?lat=42.432293&lon=-72.622116
+35 +24 http://www.openstreetmap.org/?lat=42.466904&lon=-72.616325
+36 http://www.openstreetmap.org/?lat=42.483966&lon=-72.616367
++X40 http://www.openstreetmap.org/?lat=42.535060&lon=-72.627904
+43 http://www.openstreetmap.org/?lat=42.585318&lon=-72.621388
++X45 http://www.openstreetmap.org/?lat=42.606448&lon=-72.612419
+46 http://www.openstreetmap.org/?lat=42.616339&lon=-72.593064
+50 +28 http://www.openstreetmap.org/?lat=42.670541&lon=-72.543197
++X51 http://www.openstreetmap.org/?lat=42.681276&lon=-72.541587
 MA/VT +999 http://www.openstreetmap.org/?lat=42.730148&lon=-72.570107

--- a/hwy_data/MA/usama/ma.ma002.wpt
+++ b/hwy_data/MA/usama/ma.ma002.wpt
@@ -1,24 +1,23 @@
 NY/MA http://www.openstreetmap.org/?lat=42.723860&lon=-73.273154
-+X01 http://www.openstreetmap.org/?lat=42.701527&lon=-73.237610
-+X02 http://www.openstreetmap.org/?lat=42.688723&lon=-73.237009
+BeeHillRd_W http://www.openstreetmap.org/?lat=42.698383&lon=-73.237366
+TorWooRd http://www.openstreetmap.org/?lat=42.688516&lon=-73.236674
 US7_S http://www.openstreetmap.org/?lat=42.686694&lon=-73.230700
-BeeHillRd http://www.openstreetmap.org/?lat=42.709783&lon=-73.220744
+BeeHillRd_E http://www.openstreetmap.org/?lat=42.709783&lon=-73.220744
 US7_N http://www.openstreetmap.org/?lat=42.713660&lon=-73.209286
 MA43 http://www.openstreetmap.org/?lat=42.711258&lon=-73.199480
-+X03 http://www.openstreetmap.org/?lat=42.701729&lon=-73.183537
-MA8_S http://www.openstreetmap.org/?lat=42.700331&lon=-73.113713
+LuceRd http://www.openstreetmap.org/?lat=42.701584&lon=-73.181876
+MA8_S http://www.openstreetmap.org/?lat=42.700321&lon=-73.111919
 MA8ANor http://www.openstreetmap.org/?lat=42.700524&lon=-73.108714
 MA8_N http://www.openstreetmap.org/?lat=42.702046&lon=-73.096086
 WestShaRd http://www.openstreetmap.org/?lat=42.690299&lon=-73.080950
 +X04 http://www.openstreetmap.org/?lat=42.709150&lon=-73.062966
 +X05 http://www.openstreetmap.org/?lat=42.697006&lon=-73.065541
-+X06 http://www.openstreetmap.org/?lat=42.694102&lon=-73.028269
+NorCouRd http://www.openstreetmap.org/?lat=42.693800&lon=-73.027821
 +X07 http://www.openstreetmap.org/?lat=42.638873&lon=-72.986383
 BlaBroRd http://www.openstreetmap.org/?lat=42.634003&lon=-72.973874
 +X08 http://www.openstreetmap.org/?lat=42.642130&lon=-72.947760
 +X09 http://www.openstreetmap.org/?lat=42.633006&lon=-72.931666
-+X10 http://www.openstreetmap.org/?lat=42.642638&lon=-72.919736
-ZoarRd http://www.openstreetmap.org/?lat=42.638066&lon=-72.907521
+TowRd http://www.openstreetmap.org/?lat=42.642609&lon=-72.920444
 MA8A_S http://www.openstreetmap.org/?lat=42.626711&lon=-72.882292
 MA8A_N http://www.openstreetmap.org/?lat=42.628131&lon=-72.870104
 +X11 http://www.openstreetmap.org/?lat=42.616870&lon=-72.833047
@@ -31,75 +30,69 @@ MA2AShe_E http://www.openstreetmap.org/?lat=42.600554&lon=-72.730426
 SheCenRd http://www.openstreetmap.org/?lat=42.583783&lon=-72.704301
 OldGreRd http://www.openstreetmap.org/?lat=42.597242&lon=-72.671535
 ColSheRd http://www.openstreetmap.org/?lat=42.609972&lon=-72.671428
-+X13 http://www.openstreetmap.org/?lat=42.612765&lon=-72.663789
-+X14 http://www.openstreetmap.org/?lat=42.609543&lon=-72.645507
-+X15 http://www.openstreetmap.org/?lat=42.587240&lon=-72.628641
-I-91(26) http://www.openstreetmap.org/?lat=42.585318&lon=-72.621388
-+X291 http://www.openstreetmap.org/?lat=42.606448&lon=-72.612419
-I-91(27) http://www.openstreetmap.org/?lat=42.616339&lon=-72.593064
+SumDr http://www.openstreetmap.org/?lat=42.609501&lon=-72.645032
+43(91) +I-91(26) http://www.openstreetmap.org/?lat=42.585318&lon=-72.621388
++X45(91) http://www.openstreetmap.org/?lat=42.606448&lon=-72.612419
+46(91) +I-91(27) http://www.openstreetmap.org/?lat=42.616339&lon=-72.593064
 US5/10 http://www.openstreetmap.org/?lat=42.610559&lon=-72.585125
 MA2AGre http://www.openstreetmap.org/?lat=42.615325&lon=-72.560663
-+X16 http://www.openstreetmap.org/?lat=42.616618&lon=-72.552767
 AveA http://www.openstreetmap.org/?lat=42.613001&lon=-72.548883
-+X17 http://www.openstreetmap.org/?lat=42.605911&lon=-72.527575
-+X18 http://www.openstreetmap.org/?lat=42.607490&lon=-72.504916
+PisMouRd http://www.openstreetmap.org/?lat=42.608123&lon=-72.507298
 MA63 http://www.openstreetmap.org/?lat=42.584715&lon=-72.489488
-+X19 http://www.openstreetmap.org/?lat=42.580212&lon=-72.487578
 +X20 http://www.openstreetmap.org/?lat=42.577571&lon=-72.467408
-+X21 http://www.openstreetmap.org/?lat=42.607585&lon=-72.427797
-+X22 http://www.openstreetmap.org/?lat=42.608061&lon=-72.416103
++X21 http://www.openstreetmap.org/?lat=42.608036&lon=-72.425829
 NorSt http://www.openstreetmap.org/?lat=42.599936&lon=-72.401512
 MA2ACam_W http://www.openstreetmap.org/?lat=42.599203&lon=-72.366809
-14 http://www.openstreetmap.org/?lat=42.591771&lon=-72.335041
-15 http://www.openstreetmap.org/?lat=42.558569&lon=-72.301548
-16 http://www.openstreetmap.org/?lat=42.559434&lon=-72.285018
-17 http://www.openstreetmap.org/?lat=42.570744&lon=-72.201161
-18 http://www.openstreetmap.org/?lat=42.576565&lon=-72.170563
-19 http://www.openstreetmap.org/?lat=42.571224&lon=-72.128377
-20 http://www.openstreetmap.org/?lat=42.569920&lon=-72.072751
-21 http://www.openstreetmap.org/?lat=42.557901&lon=-72.047103
-+X23 http://www.openstreetmap.org/?lat=42.556421&lon=-72.030659
-22 http://www.openstreetmap.org/?lat=42.566712&lon=-71.992917
-23 http://www.openstreetmap.org/?lat=42.564231&lon=-71.979235
-24 http://www.openstreetmap.org/?lat=42.558691&lon=-71.931669
-25 http://www.openstreetmap.org/?lat=42.543595&lon=-71.897723
-26 http://www.openstreetmap.org/?lat=42.542588&lon=-71.883073
-27 http://www.openstreetmap.org/?lat=42.547206&lon=-71.866363
-28 http://www.openstreetmap.org/?lat=42.549701&lon=-71.847201
+67 http://www.openstreetmap.org/?lat=42.591771&lon=-72.335041
+70 +15 http://www.openstreetmap.org/?lat=42.558569&lon=-72.301548
+71 +16 http://www.openstreetmap.org/?lat=42.559434&lon=-72.285018
+75 +17 http://www.openstreetmap.org/?lat=42.570744&lon=-72.201161
+77 http://www.openstreetmap.org/?lat=42.576565&lon=-72.170563
+79 +19 http://www.openstreetmap.org/?lat=42.571224&lon=-72.128377
+82 http://www.openstreetmap.org/?lat=42.569920&lon=-72.072751
+83 http://www.openstreetmap.org/?lat=42.557901&lon=-72.047103
++X84 http://www.openstreetmap.org/?lat=42.556421&lon=-72.030659
+86 http://www.openstreetmap.org/?lat=42.566712&lon=-71.992917
+87 http://www.openstreetmap.org/?lat=42.564231&lon=-71.979235
+90 +24 http://www.openstreetmap.org/?lat=42.558691&lon=-71.931669
+92 +25 http://www.openstreetmap.org/?lat=42.543595&lon=-71.897723
+93 http://www.openstreetmap.org/?lat=42.542588&lon=-71.883073
+94 http://www.openstreetmap.org/?lat=42.547206&lon=-71.866363
+95 +28 http://www.openstreetmap.org/?lat=42.549701&lon=-71.847201
 OakHillRd http://www.openstreetmap.org/?lat=42.549298&lon=-71.831658
 MtElamRd http://www.openstreetmap.org/?lat=42.547585&lon=-71.813496
-30 http://www.openstreetmap.org/?lat=42.551456&lon=-71.782619
-31 http://www.openstreetmap.org/?lat=42.546323&lon=-71.761247
-32 http://www.openstreetmap.org/?lat=42.537506&lon=-71.743995
-33 http://www.openstreetmap.org/?lat=42.522218&lon=-71.726732
-34 http://www.openstreetmap.org/?lat=42.521554&lon=-71.707989
-35 http://www.openstreetmap.org/?lat=42.519666&lon=-71.692550
-36 http://www.openstreetmap.org/?lat=42.516372&lon=-71.664551
-37 http://www.openstreetmap.org/?lat=42.520925&lon=-71.635816
-+X24 http://www.openstreetmap.org/?lat=42.516984&lon=-71.605797
-38 http://www.openstreetmap.org/?lat=42.523807&lon=-71.581845
-+X25 http://www.openstreetmap.org/?lat=42.528469&lon=-71.527863
-39 http://www.openstreetmap.org/?lat=42.522819&lon=-71.512499
-40 http://www.openstreetmap.org/?lat=42.520826&lon=-71.508207
-41 http://www.openstreetmap.org/?lat=42.500508&lon=-71.475340
-42 http://www.openstreetmap.org/?lat=42.477929&lon=-71.448528
-43 http://www.openstreetmap.org/?lat=42.473691&lon=-71.444017
+98 +30 http://www.openstreetmap.org/?lat=42.551456&lon=-71.782619
+99 +31 http://www.openstreetmap.org/?lat=42.546323&lon=-71.761247
+100 +32 http://www.openstreetmap.org/?lat=42.537506&lon=-71.743995
+101 +33 http://www.openstreetmap.org/?lat=42.522218&lon=-71.726732
+102 http://www.openstreetmap.org/?lat=42.521554&lon=-71.707989
+103 http://www.openstreetmap.org/?lat=42.519666&lon=-71.692550
+105 http://www.openstreetmap.org/?lat=42.516372&lon=-71.664551
+106 +37 http://www.openstreetmap.org/?lat=42.520925&lon=-71.635816
++X107 http://www.openstreetmap.org/?lat=42.517098&lon=-71.605842
+109 +38 http://www.openstreetmap.org/?lat=42.523807&lon=-71.581845
++X111 http://www.openstreetmap.org/?lat=42.528469&lon=-71.527863
+112 +39 http://www.openstreetmap.org/?lat=42.522819&lon=-71.512499
+113 +40 http://www.openstreetmap.org/?lat=42.520826&lon=-71.508207
+115 http://www.openstreetmap.org/?lat=42.500508&lon=-71.475340
+117 +42 http://www.openstreetmap.org/?lat=42.477929&lon=-71.448528
+118 +43 http://www.openstreetmap.org/?lat=42.473691&lon=-71.444017
 HosSt http://www.openstreetmap.org/?lat=42.471258&lon=-71.426529
 MA2A/119 http://www.openstreetmap.org/?lat=42.467293&lon=-71.397207
 ElmSt http://www.openstreetmap.org/?lat=42.464210&lon=-71.387680
 MA62 http://www.openstreetmap.org/?lat=42.455872&lon=-71.379198
 MA126 http://www.openstreetmap.org/?lat=42.444326&lon=-71.340092
-50 +MA2ACam http://www.openstreetmap.org/?lat=42.449246&lon=-71.321719
+125 +50 +MA2ACam http://www.openstreetmap.org/?lat=42.449246&lon=-71.321719
 BedRd http://www.openstreetmap.org/?lat=42.440743&lon=-71.298823
-52 http://www.openstreetmap.org/?lat=42.428113&lon=-71.258655
-53 http://www.openstreetmap.org/?lat=42.423148&lon=-71.248838
-54 http://www.openstreetmap.org/?lat=42.421639&lon=-71.231757
-55 http://www.openstreetmap.org/?lat=42.418281&lon=-71.215090
-56 http://www.openstreetmap.org/?lat=42.417457&lon=-71.204833
-57 http://www.openstreetmap.org/?lat=42.415338&lon=-71.194287
-58 http://www.openstreetmap.org/?lat=42.410934&lon=-71.181638
-59 http://www.openstreetmap.org/?lat=42.405773&lon=-71.163812
-60 http://www.openstreetmap.org/?lat=42.402600&lon=-71.156301
+127 +52 http://www.openstreetmap.org/?lat=42.428113&lon=-71.258655
+128 http://www.openstreetmap.org/?lat=42.423148&lon=-71.248838
+129 +54 http://www.openstreetmap.org/?lat=42.421639&lon=-71.231757
+130 +55 http://www.openstreetmap.org/?lat=42.418281&lon=-71.215090
+131 http://www.openstreetmap.org/?lat=42.417457&lon=-71.204833
+132 http://www.openstreetmap.org/?lat=42.415338&lon=-71.194287
+133 +58 http://www.openstreetmap.org/?lat=42.410934&lon=-71.181638
+134 +59 http://www.openstreetmap.org/?lat=42.405773&lon=-71.163812
+135 http://www.openstreetmap.org/?lat=42.402600&lon=-71.156301
 US3_N http://www.openstreetmap.org/?lat=42.397833&lon=-71.141885
 ConAve_W http://www.openstreetmap.org/?lat=42.388433&lon=-71.143448
 ConAve_E http://www.openstreetmap.org/?lat=42.386722&lon=-71.141002

--- a/hwy_data/MA/usama/ma.ma002acam.wpt
+++ b/hwy_data/MA/usama/ma.ma002acam.wpt
@@ -4,20 +4,20 @@ MA122 http://www.openstreetmap.org/?lat=42.590810&lon=-72.309694
 BroRd http://www.openstreetmap.org/?lat=42.582073&lon=-72.255192
 MA32_N http://www.openstreetmap.org/?lat=42.595122&lon=-72.221117
 MA32_S http://www.openstreetmap.org/?lat=42.582724&lon=-72.202846
-MA2(18) http://www.openstreetmap.org/?lat=42.576565&lon=-72.170563
+MA2(77) +MA2(18) http://www.openstreetmap.org/?lat=42.576565&lon=-72.170563
 AthRd http://www.openstreetmap.org/?lat=42.570257&lon=-72.154899
-MA2(19) http://www.openstreetmap.org/?lat=42.571224&lon=-72.128377
+MA2(79) http://www.openstreetmap.org/?lat=42.571224&lon=-72.128377
 US202_N http://www.openstreetmap.org/?lat=42.576991&lon=-72.116919
 BroVilRd http://www.openstreetmap.org/?lat=42.562511&lon=-72.091279
 MA101_W http://www.openstreetmap.org/?lat=42.555599&lon=-72.066922
-MA2(21) http://www.openstreetmap.org/?lat=42.557901&lon=-72.047103
+MA2(83) http://www.openstreetmap.org/?lat=42.557901&lon=-72.047103
 MA101_E http://www.openstreetmap.org/?lat=42.562321&lon=-72.037654
 PleSt http://www.openstreetmap.org/?lat=42.564275&lon=-71.998563
 MA68 http://www.openstreetmap.org/?lat=42.561510&lon=-71.990458
 MinRd http://www.openstreetmap.org/?lat=42.551431&lon=-71.967487
 WMainSt http://www.openstreetmap.org/?lat=42.549581&lon=-71.918070
 SouSt http://www.openstreetmap.org/?lat=42.544839&lon=-71.910968
-MA2(25) http://www.openstreetmap.org/?lat=42.543595&lon=-71.897723
+MA2(92) +MA2(25) http://www.openstreetmap.org/?lat=42.543595&lon=-71.897723
 SAshRd http://www.openstreetmap.org/?lat=42.560061&lon=-71.866229
 MA31_S http://www.openstreetmap.org/?lat=42.564059&lon=-71.846359
 MA12_N http://www.openstreetmap.org/?lat=42.576559&lon=-71.834182
@@ -43,7 +43,7 @@ MA2_Con http://www.openstreetmap.org/?lat=42.467293&lon=-71.397207
 ElmSt http://www.openstreetmap.org/?lat=42.464210&lon=-71.387680
 MA62 http://www.openstreetmap.org/?lat=42.455872&lon=-71.379198
 MA126 http://www.openstreetmap.org/?lat=42.444326&lon=-71.340092
-MA2(50) http://www.openstreetmap.org/?lat=42.449246&lon=-71.321719
+MA2(125) +MA2(50) http://www.openstreetmap.org/?lat=42.449246&lon=-71.321719
 CamTpk +MA2_Lin http://www.openstreetmap.org/?lat=42.450053&lon=-71.320565
 LexRd http://www.openstreetmap.org/?lat=42.453248&lon=-71.310024
 HanDr http://www.openstreetmap.org/?lat=42.448665&lon=-71.285284

--- a/hwy_data/MA/usama/ma.ma008.wpt
+++ b/hwy_data/MA/usama/ma.ma008.wpt
@@ -26,7 +26,9 @@ FarRd http://www.openstreetmap.org/?lat=42.537482&lon=-73.181549
 LanRd http://www.openstreetmap.org/?lat=42.558285&lon=-73.167443
 MA116 http://www.openstreetmap.org/?lat=42.620133&lon=-73.120118
 MA8ANor_S http://www.openstreetmap.org/?lat=42.665139&lon=-73.107855
-MA2_W http://www.openstreetmap.org/?lat=42.700331&lon=-73.113713
+MarSt_N http://www.openstreetmap.org/?lat=42.700896&lon=-73.113705
+HolSt_N http://www.openstreetmap.org/?lat=42.700851&lon=-73.111887
+MA2_W http://www.openstreetmap.org/?lat=42.700321&lon=-73.111919
 MA8ANor_N http://www.openstreetmap.org/?lat=42.700524&lon=-73.108714
 MA2_E http://www.openstreetmap.org/?lat=42.702046&lon=-73.096086
 EastRd http://www.openstreetmap.org/?lat=42.717315&lon=-73.072697

--- a/hwy_data/MA/usama/ma.ma010.wpt
+++ b/hwy_data/MA/usama/ma.ma010.wpt
@@ -2,36 +2,35 @@ CT/MA http://www.openstreetmap.org/?lat=42.000038&lon=-72.794895
 MA168 http://www.openstreetmap.org/?lat=42.025611&lon=-72.786269
 MA57_W http://www.openstreetmap.org/?lat=42.054805&lon=-72.770176
 MA57_E http://www.openstreetmap.org/?lat=42.062548&lon=-72.765155
-+X1020201 http://www.openstreetmap.org/?lat=42.110947&lon=-72.764468
+MillSt http://www.openstreetmap.org/?lat=42.111249&lon=-72.764291
 BroSt http://www.openstreetmap.org/?lat=42.114279&lon=-72.747409
 US20_E http://www.openstreetmap.org/?lat=42.120572&lon=-72.748911
 US20_W http://www.openstreetmap.org/?lat=42.124265&lon=-72.748075
 I-90 http://www.openstreetmap.org/?lat=42.141960&lon=-72.733269
-+X1020102 http://www.openstreetmap.org/?lat=42.153455&lon=-72.725716
 US202_N http://www.openstreetmap.org/?lat=42.182868&lon=-72.726359
 FomRd http://www.openstreetmap.org/?lat=42.219804&lon=-72.732410
 PomMeaRd http://www.openstreetmap.org/?lat=42.236329&lon=-72.725158
 MA141 http://www.openstreetmap.org/?lat=42.270431&lon=-72.672329
-+X01 http://www.openstreetmap.org/?lat=42.275843&lon=-72.674260
+WestSt http://www.openstreetmap.org/?lat=42.274586&lon=-72.673592
 MA9_W http://www.openstreetmap.org/?lat=42.317756&lon=-72.633914
 US5/9 http://www.openstreetmap.org/?lat=42.319558&lon=-72.629800
 DamRd http://www.openstreetmap.org/?lat=42.337769&lon=-72.637396
-I-91(20) http://www.openstreetmap.org/?lat=42.340271&lon=-72.639112
-I-91(21) http://www.openstreetmap.org/?lat=42.361255&lon=-72.638705
-I-91(22) http://www.openstreetmap.org/?lat=42.398457&lon=-72.628296
+I-91(26) +I-91(20) http://www.openstreetmap.org/?lat=42.340271&lon=-72.639112
+HatSt http://www.openstreetmap.org/?lat=42.345436&lon=-72.643192
+I-91(27) http://www.openstreetmap.org/?lat=42.361255&lon=-72.638705
+I-91(30) +I-91(22) http://www.openstreetmap.org/?lat=42.398457&lon=-72.628296
 DepRd http://www.openstreetmap.org/?lat=42.411261&lon=-72.622885
-I-91(23) http://www.openstreetmap.org/?lat=42.432293&lon=-72.622116
+I-91(32) http://www.openstreetmap.org/?lat=42.432293&lon=-72.622116
 SwaRd http://www.openstreetmap.org/?lat=42.451391&lon=-72.627010
-I-91(24) http://www.openstreetmap.org/?lat=42.466904&lon=-72.616325
+I-91(35) +I-91(24) http://www.openstreetmap.org/?lat=42.466904&lon=-72.616325
 MA116_S http://www.openstreetmap.org/?lat=42.469185&lon=-72.614694
 MA116_N http://www.openstreetmap.org/?lat=42.482415&lon=-72.612634
 CheSt http://www.openstreetmap.org/?lat=42.570592&lon=-72.592356
 MA2A http://www.openstreetmap.org/?lat=42.587877&lon=-72.600231
 SilSt http://www.openstreetmap.org/?lat=42.606263&lon=-72.588773
 MA2 http://www.openstreetmap.org/?lat=42.610559&lon=-72.585125
-SevSt http://www.openstreetmap.org/?lat=42.638663&lon=-72.571864
 US5_N http://www.openstreetmap.org/?lat=42.671582&lon=-72.554312
-I-91(28) http://www.openstreetmap.org/?lat=42.670541&lon=-72.543197
+I-91(50) +I-91(28) http://www.openstreetmap.org/?lat=42.670541&lon=-72.543197
 MA142 http://www.openstreetmap.org/?lat=42.676530&lon=-72.496161
 MA63_S http://www.openstreetmap.org/?lat=42.684830&lon=-72.460048
 MA63_N http://www.openstreetmap.org/?lat=42.718419&lon=-72.446487

--- a/hwy_data/MA/usama/ma.ma111.wpt
+++ b/hwy_data/MA/usama/ma.ma111.wpt
@@ -1,20 +1,20 @@
 MA2A/119 +MA2/119 http://www.openstreetmap.org/?lat=42.467293&lon=-71.397207
 HomSt http://www.openstreetmap.org/?lat=42.471258&lon=-71.426529
-MA2(43) http://www.openstreetmap.org/?lat=42.473691&lon=-71.444017
+MA2(118) +MA2(43) http://www.openstreetmap.org/?lat=42.473691&lon=-71.444017
 MA27 http://www.openstreetmap.org/?lat=42.474892&lon=-71.453748
 CenSt http://www.openstreetmap.org/?lat=42.476174&lon=-71.474733
 I-495 http://www.openstreetmap.org/?lat=42.486878&lon=-71.544986
-+X01 http://www.openstreetmap.org/?lat=42.494483&lon=-71.562366
+WooHillRd http://www.openstreetmap.org/?lat=42.494496&lon=-71.562758
 SloRd http://www.openstreetmap.org/?lat=42.490731&lon=-71.574050
 MA110_S http://www.openstreetmap.org/?lat=42.500843&lon=-71.583781
-MA2(38) http://www.openstreetmap.org/?lat=42.523807&lon=-71.581845
+MA2(109) +MA2(38) http://www.openstreetmap.org/?lat=42.523807&lon=-71.581845
 MA2A/110 http://www.openstreetmap.org/?lat=42.552822&lon=-71.572387
 ParkSt http://www.openstreetmap.org/?lat=42.559966&lon=-71.589940
 MA2A_W http://www.openstreetmap.org/?lat=42.568895&lon=-71.592729
 MA225_W http://www.openstreetmap.org/?lat=42.605863&lon=-71.582472
 MA119/225 http://www.openstreetmap.org/?lat=42.610243&lon=-71.573814
 MA119_W http://www.openstreetmap.org/?lat=42.631127&lon=-71.599596
-+X02 http://www.openstreetmap.org/?lat=42.654835&lon=-71.583867
+CanSt http://www.openstreetmap.org/?lat=42.656474&lon=-71.584098
 MA113 http://www.openstreetmap.org/?lat=42.666328&lon=-71.588362
 HolSt http://www.openstreetmap.org/?lat=42.674706&lon=-71.580552
 +X03 http://www.openstreetmap.org/?lat=42.676514&lon=-71.568310

--- a/hwy_data/MA/usama/ma.ma116.wpt
+++ b/hwy_data/MA/usama/ma.ma116.wpt
@@ -1,5 +1,5 @@
 MA20A http://www.openstreetmap.org/?lat=42.110152&lon=-72.601626
-I-91(11) http://www.openstreetmap.org/?lat=42.121400&lon=-72.608900
+I-91(8) http://www.openstreetmap.org/?lat=42.121400&lon=-72.608900
 I-391(2) http://www.openstreetmap.org/?lat=42.140782&lon=-72.612634
 FroSt http://www.openstreetmap.org/?lat=42.148920&lon=-72.607795
 I-391(3) http://www.openstreetmap.org/?lat=42.154146&lon=-72.610874
@@ -23,11 +23,11 @@ BullHillRd http://www.openstreetmap.org/?lat=42.444989&lon=-72.553754
 MA47_N http://www.openstreetmap.org/?lat=42.466440&lon=-72.579482
 US5/10_S http://www.openstreetmap.org/?lat=42.469185&lon=-72.614694
 US5/10_N http://www.openstreetmap.org/?lat=42.482415&lon=-72.612634
-I-91(25) http://www.openstreetmap.org/?lat=42.483966&lon=-72.616367
+I-91(36) +I-91(25) http://www.openstreetmap.org/?lat=42.483966&lon=-72.616367
 +X01 http://www.openstreetmap.org/?lat=42.510491&lon=-72.656879
 SheFalRd http://www.openstreetmap.org/?lat=42.509549&lon=-72.698872
 DelAve http://www.openstreetmap.org/?lat=42.508189&lon=-72.710803
-+X03 http://www.openstreetmap.org/?lat=42.519587&lon=-72.725029
+HicRidRd http://www.openstreetmap.org/?lat=42.519545&lon=-72.724584
 WilRd http://www.openstreetmap.org/?lat=42.510451&lon=-72.775551
 +X04 http://www.openstreetmap.org/?lat=42.525739&lon=-72.784295
 MA112_N http://www.openstreetmap.org/?lat=42.529597&lon=-72.806311

--- a/hwy_data/MA/usama/ma.ma140.wpt
+++ b/hwy_data/MA/usama/ma.ma140.wpt
@@ -63,8 +63,8 @@ MA62 http://www.openstreetmap.org/?lat=42.433334&lon=-71.812263
 MA31_S http://www.openstreetmap.org/?lat=42.476423&lon=-71.844599
 MA31_N http://www.openstreetmap.org/?lat=42.497457&lon=-71.858075
 ParkRd http://www.openstreetmap.org/?lat=42.515285&lon=-71.883094
-MA2(25) http://www.openstreetmap.org/?lat=42.543595&lon=-71.897723
-MA2(24) http://www.openstreetmap.org/?lat=42.558691&lon=-71.931669
+92(2) +MA2(25) http://www.openstreetmap.org/?lat=42.543595&lon=-71.897723
+90(2) +MA2(24) http://www.openstreetmap.org/?lat=42.558691&lon=-71.931669
 BetSprRd http://www.openstreetmap.org/?lat=42.565624&lon=-71.944463
 MA101 http://www.openstreetmap.org/?lat=42.591005&lon=-71.960857
 OldCouRd http://www.openstreetmap.org/?lat=42.618938&lon=-72.008257

--- a/hwy_data/MA/usaus/ma.us005.wpt
+++ b/hwy_data/MA/usaus/ma.us005.wpt
@@ -8,7 +8,7 @@ MSt http://www.openstreetmap.org/?lat=42.092952&lon=-72.592742
 MA147 http://www.openstreetmap.org/?lat=42.097601&lon=-72.597055
 US20 http://www.openstreetmap.org/?lat=42.107592&lon=-72.616142
 ElmSt http://www.openstreetmap.org/?lat=42.124750&lon=-72.625921
-I-91(13) http://www.openstreetmap.org/?lat=42.136208&lon=-72.625680
+I-91(10) +I-91(13) http://www.openstreetmap.org/?lat=42.136208&lon=-72.625680
 I-90/91 http://www.openstreetmap.org/?lat=42.156596&lon=-72.632718
 MainSt http://www.openstreetmap.org/?lat=42.170465&lon=-72.632160
 HolyFamRd http://www.openstreetmap.org/?lat=42.173880&lon=-72.633099
@@ -17,26 +17,26 @@ US202 http://www.openstreetmap.org/?lat=42.199053&lon=-72.631173
 FraSt http://www.openstreetmap.org/?lat=42.204479&lon=-72.630832
 MA141 http://www.openstreetmap.org/?lat=42.211927&lon=-72.629757
 LinSt http://www.openstreetmap.org/?lat=42.215297&lon=-72.629371
-+X01 http://www.openstreetmap.org/?lat=42.235485&lon=-72.627954
-+X02 http://www.openstreetmap.org/?lat=42.272078&lon=-72.603836
+MouParkRd http://www.openstreetmap.org/?lat=42.234046&lon=-72.628056
+SmiFerRd http://www.openstreetmap.org/?lat=42.275316&lon=-72.604571
 EastSt http://www.openstreetmap.org/?lat=42.286389&lon=-72.616453
-I-91(18) http://www.openstreetmap.org/?lat=42.307832&lon=-72.623277
+I-91(23) +I-91(18) http://www.openstreetmap.org/?lat=42.307832&lon=-72.623277
 MA9 http://www.openstreetmap.org/?lat=42.319558&lon=-72.629800
 DamRd http://www.openstreetmap.org/?lat=42.337769&lon=-72.637396
-I-91(20) http://www.openstreetmap.org/?lat=42.340271&lon=-72.639112
-I-91(21) http://www.openstreetmap.org/?lat=42.361255&lon=-72.638705
-I-91(22) http://www.openstreetmap.org/?lat=42.398457&lon=-72.628296
+I-91(26) +I-91(20) http://www.openstreetmap.org/?lat=42.340271&lon=-72.639112
+HatSt http://www.openstreetmap.org/?lat=42.345436&lon=-72.643192
+I-91(27) http://www.openstreetmap.org/?lat=42.361255&lon=-72.638705
+I-91(30) +I-91(22) http://www.openstreetmap.org/?lat=42.398457&lon=-72.628296
 DepRd http://www.openstreetmap.org/?lat=42.411261&lon=-72.622885
-I-91(23) http://www.openstreetmap.org/?lat=42.432293&lon=-72.622116
+I-91(32) http://www.openstreetmap.org/?lat=42.432293&lon=-72.622116
 SwaRd http://www.openstreetmap.org/?lat=42.451391&lon=-72.627010
-I-91(24) http://www.openstreetmap.org/?lat=42.466904&lon=-72.616325
+I-91(35) +I-91(24) http://www.openstreetmap.org/?lat=42.466904&lon=-72.616325
 MA116_S http://www.openstreetmap.org/?lat=42.469185&lon=-72.614694
 MA116_N http://www.openstreetmap.org/?lat=42.482415&lon=-72.612634
 CheSt http://www.openstreetmap.org/?lat=42.570592&lon=-72.592356
 MA2A http://www.openstreetmap.org/?lat=42.587877&lon=-72.600231
 SilSt http://www.openstreetmap.org/?lat=42.606263&lon=-72.588773
 MA2 http://www.openstreetmap.org/?lat=42.610559&lon=-72.585125
-SevSt http://www.openstreetmap.org/?lat=42.638663&lon=-72.571864
 MA10_N http://www.openstreetmap.org/?lat=42.671582&lon=-72.554312
-+X03 http://www.openstreetmap.org/?lat=42.688532&lon=-72.547188
+BurFlatRd http://www.openstreetmap.org/?lat=42.687716&lon=-72.547443
 MA/VT http://www.openstreetmap.org/?lat=42.730118&lon=-72.573195

--- a/hwy_data/MA/usaus/ma.us020.wpt
+++ b/hwy_data/MA/usaus/ma.us020.wpt
@@ -24,8 +24,9 @@ OldStaHwy http://www.openstreetmap.org/?lat=42.256602&lon=-72.934906
 MA112 http://www.openstreetmap.org/?lat=42.233602&lon=-72.879782
 +X07 http://www.openstreetmap.org/?lat=42.220148&lon=-72.859740
 MainSt_Rus http://www.openstreetmap.org/?lat=42.189677&lon=-72.859080
-+X08 http://www.openstreetmap.org/?lat=42.177693&lon=-72.835665
+WorRd http://www.openstreetmap.org/?lat=42.170819&lon=-72.832028
 MA23 http://www.openstreetmap.org/?lat=42.165280&lon=-72.832146
++X695889 http://www.openstreetmap.org/?lat=42.158463&lon=-72.815875
 BatRd http://www.openstreetmap.org/?lat=42.148387&lon=-72.813735
 LloHillRd http://www.openstreetmap.org/?lat=42.127551&lon=-72.777005
 US202_N http://www.openstreetmap.org/?lat=42.124265&lon=-72.748075
@@ -34,7 +35,8 @@ MA187 http://www.openstreetmap.org/?lat=42.112582&lon=-72.718720
 EMouRd http://www.openstreetmap.org/?lat=42.107806&lon=-72.704043
 KinHwy http://www.openstreetmap.org/?lat=42.107106&lon=-72.647395
 US5 http://www.openstreetmap.org/?lat=42.107592&lon=-72.616142
-I-91(9) +I-91(10) http://www.openstreetmap.org/?lat=42.111388&lon=-72.606357
+I-91(7) +I-91(9) +I-91(10) http://www.openstreetmap.org/?lat=42.111388&lon=-72.606357
++x4u70-461485 http://www.openstreetmap.org/?lat=42.111147&lon=-72.606090
 I-91/291 +I-291(1) http://www.openstreetmap.org/?lat=42.107030&lon=-72.601529
 I-291(2) http://www.openstreetmap.org/?lat=42.110352&lon=-72.595985
 I-291(3) http://www.openstreetmap.org/?lat=42.118279&lon=-72.584435
@@ -72,7 +74,7 @@ MA12_N http://www.openstreetmap.org/?lat=42.179974&lon=-71.869555
 I-395 http://www.openstreetmap.org/?lat=42.184204&lon=-71.847024
 SouSt http://www.openstreetmap.org/?lat=42.187109&lon=-71.834069
 MilSt http://www.openstreetmap.org/?lat=42.198067&lon=-71.819000
-+X16 http://www.openstreetmap.org/?lat=42.212996&lon=-71.803379
+WinDr http://www.openstreetmap.org/?lat=42.213032&lon=-71.802928
 I-90/146 http://www.openstreetmap.org/?lat=42.210608&lon=-71.788960
 MA122 http://www.openstreetmap.org/?lat=42.235365&lon=-71.748898
 MA140 http://www.openstreetmap.org/?lat=42.250249&lon=-71.711626

--- a/hwy_data/MA/usaus/ma.us202.wpt
+++ b/hwy_data/MA/usaus/ma.us202.wpt
@@ -2,12 +2,11 @@ CT/MA http://www.openstreetmap.org/?lat=42.000038&lon=-72.794895
 MA168 http://www.openstreetmap.org/?lat=42.025611&lon=-72.786269
 MA57_W http://www.openstreetmap.org/?lat=42.054805&lon=-72.770176
 MA57_E http://www.openstreetmap.org/?lat=42.062548&lon=-72.765155
-+X1020201 http://www.openstreetmap.org/?lat=42.110947&lon=-72.764468
+MillSt http://www.openstreetmap.org/?lat=42.111249&lon=-72.764291
 SBroSt http://www.openstreetmap.org/?lat=42.114279&lon=-72.747409
 US20_E http://www.openstreetmap.org/?lat=42.120572&lon=-72.748911
 US20_W http://www.openstreetmap.org/?lat=42.124265&lon=-72.748075
 I-90 http://www.openstreetmap.org/?lat=42.141960&lon=-72.733269
-+X1020102 http://www.openstreetmap.org/?lat=42.153455&lon=-72.725716
 MA10_N http://www.openstreetmap.org/?lat=42.182868&lon=-72.726359
 OldCouRd http://www.openstreetmap.org/?lat=42.178193&lon=-72.687650
 HomAve http://www.openstreetmap.org/?lat=42.187034&lon=-72.650700
@@ -17,7 +16,7 @@ FraSt http://www.openstreetmap.org/?lat=42.204479&lon=-72.630832
 MA141 http://www.openstreetmap.org/?lat=42.211927&lon=-72.629757
 US5_N http://www.openstreetmap.org/?lat=42.215297&lon=-72.629371
 LymSt http://www.openstreetmap.org/?lat=42.212468&lon=-72.611861
-MainSt http://www.openstreetmap.org/?lat=42.221748&lon=-72.602935
+MainSt_SHa http://www.openstreetmap.org/?lat=42.221748&lon=-72.602935
 MA116 http://www.openstreetmap.org/?lat=42.222130&lon=-72.589846
 MA33 http://www.openstreetmap.org/?lat=42.226198&lon=-72.572122
 PleSt http://www.openstreetmap.org/?lat=42.246755&lon=-72.544355
@@ -27,8 +26,8 @@ MA181 http://www.openstreetmap.org/?lat=42.276832&lon=-72.400932
 MA9 http://www.openstreetmap.org/?lat=42.289405&lon=-72.406855
 AmhRd http://www.openstreetmap.org/?lat=42.392082&lon=-72.403478
 PreRd http://www.openstreetmap.org/?lat=42.449238&lon=-72.387972
-+X01 http://www.openstreetmap.org/?lat=42.473003&lon=-72.351151
-+X02 http://www.openstreetmap.org/?lat=42.535541&lon=-72.317762
+ShuRd http://www.openstreetmap.org/?lat=42.473480&lon=-72.350866
+ElmSt http://www.openstreetmap.org/?lat=42.536147&lon=-72.311306
 MA122_S http://www.openstreetmap.org/?lat=42.537398&lon=-72.304502
 MA122_N http://www.openstreetmap.org/?lat=42.549824&lon=-72.298021
 MA2_W http://www.openstreetmap.org/?lat=42.559434&lon=-72.285018
@@ -39,7 +38,7 @@ MA2A_E http://www.openstreetmap.org/?lat=42.576991&lon=-72.116919
 MA68_N http://www.openstreetmap.org/?lat=42.594891&lon=-72.093744
 BalRd http://www.openstreetmap.org/?lat=42.605916&lon=-72.076406
 MA68_S http://www.openstreetmap.org/?lat=42.607337&lon=-72.075076
-+X03 http://www.openstreetmap.org/?lat=42.667878&lon=-72.079024
+MainSt_Win http://www.openstreetmap.org/?lat=42.667638&lon=-72.079129
 RivSt http://www.openstreetmap.org/?lat=42.675494&lon=-72.067995
 MA12_N http://www.openstreetmap.org/?lat=42.681741&lon=-72.052460
 MA12_S http://www.openstreetmap.org/?lat=42.680921&lon=-72.048683

--- a/updates.csv
+++ b/updates.csv
@@ -4308,7 +4308,9 @@ date;region;route;root;description
 2017-06-09;(USA) Maryland;MD 351;;Deleted route
 2016-04-24;(USA) Maryland;MD 717;md.md717;Added route
 2015-08-17;(USA) Maryland;MD 200;md.md200;Extended east end of route from I-95 to US1
-2021-09-03;(USA) Massachusetts;I-395;ma.i395;Relabeled exits from sequential to mileage-based.
+2021-09-10;(USA) Massachusetts;I-91;ma.i091;Relabeled exits from sequential to mileage-based.
+2021-09-10;(USA) Massachusetts;US 5;ma.us005;Waypoint I-91(23) moved from State Rd in Whately, now labeled I-91(32), to Mount Tom Rd in Northampton. I-91(21) relabeled to I-91(27).
+2021-09-10;(USA) Massachusetts;MA 2;ma.ma002;Relabeled exits from sequential to mileage-based.
 2021-06-28;(USA) Massachusetts;I-495;ma.i495;Relabeled exits from sequential to mileage-based.
 2021-06-02;(USA) Massachusetts;I-93;ma.i093;Relabeled exits from sequential to mileage-based.
 2021-06-02;(USA) Massachusetts;MA 3;ma.ma003;Waypoint 18(93) moved from Massachusetts Ave Connector (now labeled 15(93)) to the northern I-93 split.


### PR DESCRIPTION
# MA2
No .list files broken.
The smallest new exit number is greater than the largest old number.

---

# I-91
**Broken labels** that have moved from one location to another:
6 7 8 12 14 25 26 27

`16` was not retained as an AltLabel for `14`, because the 1 person using it has the old Exit 27 as the other waypoint. Rather than create bad stats & maps, I opted to just break osu_lsu.list & thus include a note in the .log file that it needs attention.

**All travelers with broken .lists:**
1 afarina ben114 bhemphill clark1mt dave1693 dfilpus fwydriver405 highplainstrvlr highway63 hsford Ib3kii jstalica julmac jwood lakewy17 M3200 mapmikey mc49399 mefailenglish mikeandkristie new_friends_gr ngrier njhighways osu_lsu sbeaver44 scott_stieglitz SK220 Smeeg101 sneezy squatchis stnyroads tckma thehighwayman3561 therealcu2010 vespertine whopperman

**Those who update via GitHub (TM usernames):**
afarina ben114 clark1mt dave1693 mapmikey SK220 stnyroads

**GitHub usernames:**
@ajfarina @benchase1 @clark1mt @dave1693 @mapmikey @USRoute220 @dlainhart

**Those left over who update by email:**
1 bhemphill dfilpus fwydriver405 highplainstrvlr highway63 hsford Ib3kii jstalica julmac jwood lakewy17 M3200 mc49399 mefailenglish mikeandkristie new_friends_gr ngrier njhighways osu_lsu sbeaver44 scott_stieglitz Smeeg101 sneezy squatchis tckma thehighwayman3561 therealcu2010 vespertine whopperman

---

# US5
Waypoint `I-91(23)` moved from State Rd in Whately, now labeled `I-91(32)`, to Mount Tom Rd in Northampton.
`I-91(21)` purposefully broken, as it was only paired with `I-91(23)`.
Ping @jjbers2-1.