### PR TITLE
Initial jpnh submission

### DIFF
--- a/hwy_data/JPN/jpnh/jpn.n131.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n131.wpt
@@ -1,0 +1,4 @@
+HanApt http://www.openstreetmap.org/?lat=35.550346&lon=139.753982
+SE1/SEK1 http://www.openstreetmap.org/?lat=35.551775&lon=139.745530
+P6/P311 http://www.openstreetmap.org/?lat=35.552355&lon=139.740357
+N15 http://www.openstreetmap.org/?lat=35.573873&lon=139.733965

--- a/hwy_data/JPN/jpnh/jpn.n132.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n132.wpt
@@ -1,0 +1,3 @@
+End http://www.openstreetmap.org/?lat=35.523445&lon=139.752316
+P6 http://www.openstreetmap.org/?lat=35.528531&lon=139.738069
+N15 http://www.openstreetmap.org/?lat=35.529803&lon=139.704670

--- a/hwy_data/JPN/jpnh/jpn.n133.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n133.wpt
@@ -1,0 +1,4 @@
+P82 http://www.openstreetmap.org/?lat=35.447738&lon=139.644749
+P21 http://www.openstreetmap.org/?lat=35.449086&lon=139.638360
+MinMirBlvd http://www.openstreetmap.org/?lat=35.450062&lon=139.636361
+N16 http://www.openstreetmap.org/?lat=35.449016&lon=139.632116

--- a/hwy_data/JPN/jpnh/jpn.n149.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n149.wpt
@@ -1,0 +1,3 @@
+N150 http://www.openstreetmap.org/?lat=35.002850&lon=138.494915
+P75/P197 http://www.openstreetmap.org/?lat=35.011065&lon=138.489221
+N1 http://www.openstreetmap.org/?lat=35.023532&lon=138.487186

--- a/hwy_data/JPN/jpnh/jpn.n154.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n154.wpt
@@ -1,0 +1,5 @@
+End http://www.openstreetmap.org/?lat=35.092245&lon=136.881783
+P227 http://www.openstreetmap.org/?lat=35.099124&lon=136.883037
+N23 http://www.openstreetmap.org/?lat=35.100254&lon=136.884680
+TokAve http://www.openstreetmap.org/?lat=35.113165&lon=136.895217
+N1 http://www.openstreetmap.org/?lat=35.124017&lon=136.900993

--- a/hwy_data/JPN/jpnh/jpn.n164.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n164.wpt
@@ -1,0 +1,6 @@
+End http://www.openstreetmap.org/?lat=34.952249&lon=136.637328
+P6 http://www.openstreetmap.org/?lat=34.959250&lon=136.632698
++X940882 http://www.openstreetmap.org/?lat=34.963588&lon=136.637070
+N23 http://www.openstreetmap.org/?lat=34.965480&lon=136.634751
+N1_N http://www.openstreetmap.org/?lat=34.969308&lon=136.624031
+N1_S http://www.openstreetmap.org/?lat=34.967536&lon=136.623314

--- a/hwy_data/JPN/jpnh/jpn.n172.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n172.wpt
@@ -1,0 +1,7 @@
+End http://www.openstreetmap.org/?lat=34.652415&lon=135.430559
+P5 http://www.openstreetmap.org/?lat=34.654608&lon=135.436157
+HE4/5 http://www.openstreetmap.org/?lat=34.655652&lon=135.438844
+N43 http://www.openstreetmap.org/?lat=34.665553&lon=135.464108
+P29 http://www.openstreetmap.org/?lat=34.682174&lon=135.486094
+P41 http://www.openstreetmap.org/?lat=34.683412&lon=135.492918
+N25 http://www.openstreetmap.org/?lat=34.683595&lon=135.500629

--- a/hwy_data/JPN/jpnh/jpn.n174.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n174.wpt
@@ -1,0 +1,2 @@
+KobCstHse http://www.openstreetmap.org/?lat=34.685215&lon=135.198553
+N2/P30 http://www.openstreetmap.org/?lat=34.686394&lon=135.198022

--- a/hwy_data/JPN/jpnh/jpn.n177.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n177.wpt
@@ -1,0 +1,3 @@
+End http://www.openstreetmap.org/?lat=35.456016&lon=135.325263
+P565 http://www.openstreetmap.org/?lat=35.453976&lon=135.328014
+N27/N175 http://www.openstreetmap.org/?lat=35.450761&lon=135.329057

--- a/hwy_data/JPN/jpnh/jpn.n189.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n189.wpt
@@ -1,0 +1,4 @@
+IwaMCAS http://www.openstreetmap.org/?lat=34.151642&lon=132.221446
+N188_S http://www.openstreetmap.org/?lat=34.154654&lon=132.219482
+P50 http://www.openstreetmap.org/?lat=34.172176&lon=132.224253
+N2 http://www.openstreetmap.org/?lat=34.176331&lon=132.226017

--- a/hwy_data/JPN/jpnh/jpn.n198.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n198.wpt
@@ -1,0 +1,3 @@
+N199 http://www.openstreetmap.org/?lat=33.943720&lon=130.959162
++X519398 http://www.openstreetmap.org/?lat=33.945825&lon=130.961591
+N3 http://www.openstreetmap.org/?lat=33.944369&lon=130.964007

--- a/hwy_data/JPN/jpnh/jpn.n295.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n295.wpt
@@ -1,0 +1,5 @@
+NarApt http://www.openstreetmap.org/?lat=35.776364&lon=140.381940
+P44 http://www.openstreetmap.org/?lat=35.781876&lon=140.377263
++X746372 http://www.openstreetmap.org/?lat=35.785673&lon=140.368323
+E51/E65 http://www.openstreetmap.org/?lat=35.783218&lon=140.354517
+N51/N408 http://www.openstreetmap.org/?lat=35.787779&lon=140.331315

--- a/hwy_data/JPN/jpnh/jpn.n332.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n332.wpt
@@ -1,0 +1,5 @@
+P231 http://www.openstreetmap.org/?lat=26.203639&lon=127.652764
+N58BypNah http://www.openstreetmap.org/?lat=26.212216&lon=127.652249
+N331 http://www.openstreetmap.org/?lat=26.205006&lon=127.667854
+P7 http://www.openstreetmap.org/?lat=26.204210&lon=127.670885
+N58 http://www.openstreetmap.org/?lat=26.207775&lon=127.674378

--- a/hwy_data/JPN/jpnh/jpn.n481.wpt
+++ b/hwy_data/JPN/jpnh/jpn.n481.wpt
@@ -1,0 +1,9 @@
+E71(5) http://www.openstreetmap.org/?lat=34.442256&lon=135.257707
+E71(3) http://www.openstreetmap.org/?lat=34.413317&lon=135.295680
+E71(4)/P29 http://www.openstreetmap.org/?lat=34.410249&lon=135.299812
+P63 http://www.openstreetmap.org/?lat=34.406328&lon=135.305560
+N26 http://www.openstreetmap.org/?lat=34.400815&lon=135.312035
+E71(2) http://www.openstreetmap.org/?lat=34.399379&lon=135.313357
+P64 http://www.openstreetmap.org/?lat=34.396426&lon=135.315798
+P30_S http://www.openstreetmap.org/?lat=34.381700&lon=135.328544
+E71(1) http://www.openstreetmap.org/?lat=34.370176&lon=135.336317

--- a/hwy_data/_systems/jpnh.csv
+++ b/hwy_data/_systems/jpnh.csv
@@ -1,0 +1,16 @@
+systemName;region;route;banner;abbreviation;city;fileNameRoot;altRouteNames
+jpnh;JPN;N130;;;;jpn.n130;
+jpnh;JPN;N131;;;;jpn.n131;
+jpnh;JPN;N132;;;;jpn.n132;
+jpnh;JPN;N133;;;;jpn.n133;
+jpnh;JPN;N149;;;;jpn.n149;
+jpnh;JPN;N154;;;;jpn.n154;
+jpnh;JPN;N164;;;;jpn.n164;
+jpnh;JPN;N172;;;;jpn.n172;
+jpnh;JPN;N174;;;;jpn.n174;
+jpnh;JPN;N177;;;;jpn.n177;
+jpnh;JPN;N189;;;;jpn.n189;
+jpnh;JPN;N198;;;;jpn.n198;
+jpnh;JPN;N295;;;;jpn.n295;
+jpnh;JPN;N332;;;;jpn.n332;
+jpnh;JPN;N481;;;;jpn.n481;

--- a/hwy_data/_systems/jpnh_con.csv
+++ b/hwy_data/_systems/jpnh_con.csv
@@ -1,0 +1,16 @@
+systemName;route;banner;groupName;roots
+jpnh;N130;;;jpn.n130
+jpnh;N131;;;jpn.n131
+jpnh;N132;;;jpn.n132
+jpnh;N133;;;jpn.n133
+jpnh;N149;;;jpn.n149
+jpnh;N154;;;jpn.n154
+jpnh;N164;;;jpn.n164
+jpnh;N172;;;jpn.n172
+jpnh;N174;;;jpn.n174
+jpnh;N177;;;jpn.n177
+jpnh;N189;;;jpn.n189
+jpnh;N198;;;jpn.n198
+jpnh;N295;;;jpn.n295
+jpnh;N332;;;jpn.n332
+jpnh;N481;;;jpn.n481

--- a/systems.csv
+++ b/systems.csv
@@ -533,6 +533,7 @@ indnh;IND;India National Highways;TMgreen;3;devel
 indwb;IND;West Bengal State Highways;TMyellow;4;devel
 #irqf;IRQ;Iraq Freeways
 #jamb;JAM;Jamaica B Roads;TMyellow;5;devel
+jpnh;JPN;Japan Ippan Kokudō;TMyellow;4;devel
 #mexdn;MEX;Mexico Federal Expressways (new);TMblue;1;devel
 #mexedn;MEX;Mexico State Expressways (new);TMteal;3;devel
 mexsf;MEX;Mexico Select Freeways;TMteal;3;devel


### PR DESCRIPTION
System files and minato (port) national highways wpt files for the **jpnh** Japan National Highway system. Minato highways are very short national highways that connect seaports/airports to other national highways.