### PR TITLE
Tweaks to QC A-85 extension in St-Antonin

### DIFF
--- a/hwy_data/QC/canqc/qc.qc185.wpt
+++ b/hwy_data/QC/canqc/qc.qc185.wpt
@@ -7,4 +7,4 @@ QC291 http://www.openstreetmap.org/?lat=47.691617&lon=-69.135965
 RuePri_W http://www.openstreetmap.org/?lat=47.687856&lon=-69.216281
 +X167769 http://www.openstreetmap.org/?lat=47.682964&lon=-69.239343
 ChTac http://www.openstreetmap.org/?lat=47.696369&lon=-69.276789
-A-85_N http://www.openstreetmap.org/?lat=47.724274&lon=-69.334443
+A-85_N http://www.openstreetmap.org/?lat=47.702311&lon=-69.289033

--- a/hwy_data/QC/canqca/qc.a085.wpt
+++ b/hwy_data/QC/canqca/qc.a085.wpt
@@ -1,4 +1,4 @@
-QC185 http://www.openstreetmap.org/?lat=47.724274&lon=-69.334443
+QC185 http://www.openstreetmap.org/?lat=47.702311&lon=-69.289033
 85 http://www.openstreetmap.org/?lat=47.764690&lon=-69.438716
 *3Rang http://www.openstreetmap.org/?lat=47.770189&lon=-69.446596
 89 http://www.openstreetmap.org/?lat=47.782282&lon=-69.464703

--- a/hwy_data/QC/cantch/qc.tchmai.wpt
+++ b/hwy_data/QC/cantch/qc.tchmai.wpt
@@ -157,7 +157,7 @@ A-20/85 +A-20(499) http://www.openstreetmap.org/?lat=47.790976&lon=-69.578289
 89(85) http://www.openstreetmap.org/?lat=47.782282&lon=-69.464703
 *3Rang http://www.openstreetmap.org/?lat=47.770189&lon=-69.446596
 85(85) http://www.openstreetmap.org/?lat=47.764690&lon=-69.438716
-RteRoc_N http://www.openstreetmap.org/?lat=47.724274&lon=-69.334443
+*RteRoc_N http://www.openstreetmap.org/?lat=47.702311&lon=-69.289033
 ChTac http://www.openstreetmap.org/?lat=47.696369&lon=-69.276789
 +X167769 http://www.openstreetmap.org/?lat=47.682964&lon=-69.239343
 RuePri_W http://www.openstreetmap.org/?lat=47.687856&lon=-69.216281


### PR DESCRIPTION
Adjusts A-85 northern segment endpoint, at now-closed intersection with Route des Roches (bypassed segment of QC 185), to reflect corrected OSM mapping and my field check earlier this month. QC 185 and TCHMai route files adjusted accordingly.

No Updates entry needed.

Datacheck successful.