### PR TITLE
QC A-10/A-55/QC112 resynch

### DIFF
--- a/hwy_data/QC/canqca/qc.a010.wpt
+++ b/hwy_data/QC/canqca/qc.a010.wpt
@@ -35,7 +35,7 @@
 115 http://www.openstreetmap.org/?lat=45.292385&lon=-72.207996
 118 http://www.openstreetmap.org/?lat=45.293628&lon=-72.164516
 121 http://www.openstreetmap.org/?lat=45.295268&lon=-72.129021
-123 http://www.openstreetmap.org/?lat=45.299826&lon=-72.099495
+123 http://www.openstreetmap.org/?lat=45.299506&lon=-72.100116
 123A http://www.openstreetmap.org/?lat=45.305977&lon=-72.088967
 128 http://www.openstreetmap.org/?lat=45.326267&lon=-72.060748
 +X07 http://www.openstreetmap.org/?lat=45.359986&lon=-72.058296

--- a/hwy_data/QC/canqca/qc.a055.wpt
+++ b/hwy_data/QC/canqca/qc.a055.wpt
@@ -10,7 +10,7 @@ ChCur http://www.openstreetmap.org/?lat=45.051301&lon=-72.083187
 32 http://www.openstreetmap.org/?lat=45.277423&lon=-72.107434
 33 http://www.openstreetmap.org/?lat=45.286102&lon=-72.118024
 121(10) http://www.openstreetmap.org/?lat=45.295268&lon=-72.129021
-123(10) http://www.openstreetmap.org/?lat=45.299826&lon=-72.099495
+123(10) http://www.openstreetmap.org/?lat=45.299506&lon=-72.100116
 123A(10) http://www.openstreetmap.org/?lat=45.305977&lon=-72.088967
 128(10) http://www.openstreetmap.org/?lat=45.326267&lon=-72.060748
 +X07 http://www.openstreetmap.org/?lat=45.359986&lon=-72.058296


### PR DESCRIPTION
Resynchs A-10 and A-55 points for exit 123 with corresponding point on QC 112. The nearby shaping points on QC 112, to break its false concurrency with A-10 and A-55, are unaffected.

No Updates entry needed. Datacheck successful (but this run, for a small and simple PR, took an unusually long time, about 40 minutes, with a listed run time of 2430.7).