### PR TITLE
US 19 TRUCK (Pittsburgh), PA 28, PA 60, PA 66, PA 168, and PA 351 Revisions

### DIFF
--- a/hwy_data/PA/usapa/pa.pa028.wpt
+++ b/hwy_data/PA/usapa/pa.pa028.wpt
@@ -31,7 +31,7 @@ PA85 http://www.openstreetmap.org/?lat=40.818092&lon=-79.489740
 AndCreRd http://www.openstreetmap.org/?lat=40.837990&lon=-79.466383
 RidRd http://www.openstreetmap.org/?lat=40.868487&lon=-79.428862
 OliRd http://www.openstreetmap.org/?lat=40.877583&lon=-79.394527
-+X3A http://www.openstreetmap.org/?lat=40.895908&lon=-79.371371
+SR1027 http://www.openstreetmap.org/?lat=40.893506&lon=-79.375282
 CalSchRd http://www.openstreetmap.org/?lat=40.917722&lon=-79.365071
 KohRd http://www.openstreetmap.org/?lat=40.969441&lon=-79.357158
 PheFarmRd http://www.openstreetmap.org/?lat=40.972031&lon=-79.351882

--- a/hwy_data/PA/usapa/pa.pa060.wpt
+++ b/hwy_data/PA/usapa/pa.pa060.wpt
@@ -1,10 +1,10 @@
 US19/51 http://www.openstreetmap.org/?lat=40.444183&lon=-80.028190
 WabSt http://www.openstreetmap.org/?lat=40.440909&lon=-80.034813
-MainSt http://www.openstreetmap.org/?lat=40.440564&lon=-80.035631
+MainSt_W  +MainSt http://www.openstreetmap.org/?lat=40.440564&lon=-80.035631
 +X1 http://www.openstreetmap.org/?lat=40.435760&lon=-80.035972
 PA50 http://www.openstreetmap.org/?lat=40.437953&lon=-80.053918
 +X2 http://www.openstreetmap.org/?lat=40.436624&lon=-80.059988
-+X3 http://www.openstreetmap.org/?lat=40.430748&lon=-80.061525
+McMAve http://www.openstreetmap.org/?lat=40.430589&lon=-80.062040
 CraBlvd_W http://www.openstreetmap.org/?lat=40.430203&lon=-80.063805
 NobAve http://www.openstreetmap.org/?lat=40.434797&lon=-80.065527
 SteSt_E http://www.openstreetmap.org/?lat=40.437892&lon=-80.065967
@@ -12,7 +12,6 @@ BalRd http://www.openstreetmap.org/?lat=40.439986&lon=-80.084088
 I-79 http://www.openstreetmap.org/?lat=40.450068&lon=-80.110931
 McCRd http://www.openstreetmap.org/?lat=40.449305&lon=-80.124758
 BeaGraRd http://www.openstreetmap.org/?lat=40.452064&lon=-80.133915
-TidRd http://www.openstreetmap.org/?lat=40.450223&lon=-80.140071
 ChuHillRd http://www.openstreetmap.org/?lat=40.444159&lon=-80.147117
 CamRunRd http://www.openstreetmap.org/?lat=40.448423&lon=-80.157996
-I-376/22  +I-376 http://www.openstreetmap.org/?lat=40.447312&lon=-80.166064
+I-376/22 +I-376 http://www.openstreetmap.org/?lat=40.447312&lon=-80.166064

--- a/hwy_data/PA/usapa/pa.pa066.wpt
+++ b/hwy_data/PA/usapa/pa.pa066.wpt
@@ -50,7 +50,7 @@ PA85 http://www.openstreetmap.org/?lat=40.818092&lon=-79.489740
 AndCreRd http://www.openstreetmap.org/?lat=40.837990&lon=-79.466383
 RidRd http://www.openstreetmap.org/?lat=40.868487&lon=-79.428862
 OliRd http://www.openstreetmap.org/?lat=40.877583&lon=-79.394527
-+X3A http://www.openstreetmap.org/?lat=40.895908&lon=-79.371371
+SR1027 http://www.openstreetmap.org/?lat=40.893506&lon=-79.375282
 CalSchRd http://www.openstreetmap.org/?lat=40.917722&lon=-79.365071
 KohRd http://www.openstreetmap.org/?lat=40.969441&lon=-79.357158
 PheFarmRd http://www.openstreetmap.org/?lat=40.972031&lon=-79.351882

--- a/hwy_data/PA/usapa/pa.pa168.wpt
+++ b/hwy_data/PA/usapa/pa.pa168.wpt
@@ -32,8 +32,9 @@ HalRd http://www.openstreetmap.org/?lat=40.912560&lon=-80.393414
 I-376 http://www.openstreetmap.org/?lat=40.918624&lon=-80.385134
 PA18_B http://www.openstreetmap.org/?lat=40.921277&lon=-80.376293
 WamRd_S http://www.openstreetmap.org/?lat=40.920771&lon=-80.373546
-OldCheRd http://www.openstreetmap.org/?lat=40.927787&lon=-80.368507
+OldPA168 http://www.openstreetmap.org/?lat=40.927787&lon=-80.368507
 3rdSt_E http://www.openstreetmap.org/?lat=40.927996&lon=-80.363349
+UniValRd http://www.openstreetmap.org/?lat=40.938233&lon=-80.363440
 US422 http://www.openstreetmap.org/?lat=40.969463&lon=-80.365175
 MorSt_S http://www.openstreetmap.org/?lat=40.979301&lon=-80.350992
 PA18/108 http://www.openstreetmap.org/?lat=40.983184&lon=-80.350335

--- a/hwy_data/PA/usapa/pa.pa351.wpt
+++ b/hwy_data/PA/usapa/pa.pa351.wpt
@@ -18,4 +18,6 @@ CheHillRd http://www.openstreetmap.org/?lat=40.848848&lon=-80.312910
 14thSt http://www.openstreetmap.org/?lat=40.858172&lon=-80.300966
 PA351Trk_W http://www.openstreetmap.org/?lat=40.858426&lon=-80.292243
 5thSt http://www.openstreetmap.org/?lat=40.858519&lon=-80.287260
+4thSt_N http://www.openstreetmap.org/?lat=40.858543&lon=-80.285602
+4thSt_S http://www.openstreetmap.org/?lat=40.857448&lon=-80.285554
 PA65/288 http://www.openstreetmap.org/?lat=40.857505&lon=-80.282392

--- a/hwy_data/PA/usausb/pa.us019trkpit.wpt
+++ b/hwy_data/PA/usausb/pa.us019trkpit.wpt
@@ -24,5 +24,5 @@ ViewAve http://www.openstreetmap.org/?lat=40.500027&lon=-80.012508
 BabBlvd http://www.openstreetmap.org/?lat=40.513997&lon=-80.004158
 PeeRd http://www.openstreetmap.org/?lat=40.554452&lon=-80.021300
 DunAve http://www.openstreetmap.org/?lat=40.568477&lon=-80.023926
-IgnRd http://www.openstreetmap.org/?lat=40.583363&lon=-80.030615
+IngRd http://www.openstreetmap.org/?lat=40.583363&lon=-80.030615
 US19_N http://www.openstreetmap.org/?lat=40.588205&lon=-80.045861


### PR DESCRIPTION
US 19 TRUCK (Pittsburgh): IgnRd>-IngRd
PA 28/PA 66: Replaced +X3A with SR1027.
PA 60: MainSt>-WalSt (Walbridge St).  Replaced +X3 with McMunn Ave (McMAve).  Removed TidRd.
PA 168: OldCheRd>-OldPA168.  Added Union Valley Rd (UniValRd).
PA 351: Added 4thSt_N and 4thSt_S.