### PR TITLE
US 113/DE 20: DE24/30>-DE24

### DIFF
--- a/hwy_data/DE/usade/de.de020.wpt
+++ b/hwy_data/DE/usade/de.de020.wpt
@@ -1,10 +1,8 @@
 MD/DE http://www.openstreetmap.org/?lat=38.635373&lon=-75.707345
-WooFerRd http://www.openstreetmap.org/?lat=38.635484&lon=-75.706208
 NylBlvd http://www.openstreetmap.org/?lat=38.645899&lon=-75.627077
 BriHwy http://www.openstreetmap.org/?lat=38.648358&lon=-75.608629
 US13_N http://www.openstreetmap.org/?lat=38.652767&lon=-75.594405
 US13_S http://www.openstreetmap.org/?lat=38.640508&lon=-75.593440
-BetConRd http://www.openstreetmap.org/?lat=38.640594&lon=-75.560352
 BakMillRd http://www.openstreetmap.org/?lat=38.638767&lon=-75.552775
 KayeRd http://www.openstreetmap.org/?lat=38.624641&lon=-75.532371
 PepRd http://www.openstreetmap.org/?lat=38.626619&lon=-75.504720
@@ -17,7 +15,7 @@ CroKeysRd http://www.openstreetmap.org/?lat=38.603014&lon=-75.359428
 GodSchRd http://www.openstreetmap.org/?lat=38.600931&lon=-75.347012
 US113_N http://www.openstreetmap.org/?lat=38.599141&lon=-75.317368
 DelAve http://www.openstreetmap.org/?lat=38.589862&lon=-75.302651
-DE24/30 http://www.openstreetmap.org/?lat=38.585503&lon=-75.295165
+DE24  +DE24/30 http://www.openstreetmap.org/?lat=38.585503&lon=-75.295165
 US113_S http://www.openstreetmap.org/?lat=38.566577&lon=-75.278642
 IronBraRd http://www.openstreetmap.org/?lat=38.553741&lon=-75.249229
 DE26_W http://www.openstreetmap.org/?lat=38.549166&lon=-75.245517
@@ -27,5 +25,5 @@ OmarRd http://www.openstreetmap.org/?lat=38.527536&lon=-75.200381
 DaiRd http://www.openstreetmap.org/?lat=38.514403&lon=-75.179862
 DE17 http://www.openstreetmap.org/?lat=38.496579&lon=-75.170748
 DeerRunRd http://www.openstreetmap.org/?lat=38.482341&lon=-75.155239
-BayRd  +DE54Alt http://www.openstreetmap.org/?lat=38.478198&lon=-75.140361
+BayRd +DE54Alt http://www.openstreetmap.org/?lat=38.478198&lon=-75.140361
 DE54 http://www.openstreetmap.org/?lat=38.469838&lon=-75.115961

--- a/hwy_data/DE/usade/de.de026.wpt
+++ b/hwy_data/DE/usade/de.de026.wpt
@@ -1,6 +1,5 @@
 MD/DE http://www.openstreetmap.org/?lat=38.452160&lon=-75.393757
 DE30_W http://www.openstreetmap.org/?lat=38.460923&lon=-75.383779
-DotsRd http://www.openstreetmap.org/?lat=38.468975&lon=-75.373177
 DE54_E http://www.openstreetmap.org/?lat=38.477753&lon=-75.366479
 LowCroRd http://www.openstreetmap.org/?lat=38.491761&lon=-75.363000
 DE30_E http://www.openstreetmap.org/?lat=38.524816&lon=-75.356963
@@ -15,9 +14,8 @@ FalPoiRd http://www.openstreetmap.org/?lat=38.556837&lon=-75.200847
 WinRd http://www.openstreetmap.org/?lat=38.553712&lon=-75.192044
 BeaRd http://www.openstreetmap.org/?lat=38.556875&lon=-75.163806
 PowFarmRd http://www.openstreetmap.org/?lat=38.549621&lon=-75.147724
-IroLn http://www.openstreetmap.org/?lat=38.551971&lon=-75.141332
 DE17 http://www.openstreetmap.org/?lat=38.550777&lon=-75.131764
 WhiNeckRd http://www.openstreetmap.org/?lat=38.549674&lon=-75.123240
 CenAve http://www.openstreetmap.org/?lat=38.544333&lon=-75.090989
-KentAve  +DE54Alt http://www.openstreetmap.org/?lat=38.538471&lon=-75.061649
+KentAve +DE54Alt http://www.openstreetmap.org/?lat=38.538471&lon=-75.061649
 DE1 http://www.openstreetmap.org/?lat=38.538211&lon=-75.059299

--- a/hwy_data/DE/usade/de.de054.wpt
+++ b/hwy_data/DE/usade/de.de054.wpt
@@ -1,6 +1,5 @@
 MD/DE http://www.openstreetmap.org/?lat=38.452160&lon=-75.393757
 DE30_W http://www.openstreetmap.org/?lat=38.460923&lon=-75.383779
-DotsRd http://www.openstreetmap.org/?lat=38.468975&lon=-75.373177
 DE26/30 http://www.openstreetmap.org/?lat=38.477753&lon=-75.366479
 DonRd http://www.openstreetmap.org/?lat=38.472238&lon=-75.337388
 HudRd_A http://www.openstreetmap.org/?lat=38.472316&lon=-75.325608
@@ -14,10 +13,9 @@ DE17 http://www.openstreetmap.org/?lat=38.458086&lon=-75.220044
 MainSt_S http://www.openstreetmap.org/?lat=38.456519&lon=-75.219553
 BisRd http://www.openstreetmap.org/?lat=38.456130&lon=-75.204965
 HudRd_B +HudRd_E http://www.openstreetmap.org/?lat=38.464002&lon=-75.178462
-JohRd  +DE54AltBet http://www.openstreetmap.org/?lat=38.463408&lon=-75.155073
+JohRd +DE54AltBet http://www.openstreetmap.org/?lat=38.463408&lon=-75.155073
 LineRd http://www.openstreetmap.org/?lat=38.459982&lon=-75.133604
 DE20 http://www.openstreetmap.org/?lat=38.469838&lon=-75.115961
 FenBlvd http://www.openstreetmap.org/?lat=38.472980&lon=-75.105036
-LawsPoiRd http://www.openstreetmap.org/?lat=38.471354&lon=-75.095957
 DukAve http://www.openstreetmap.org/?lat=38.452072&lon=-75.061249
 DE1 http://www.openstreetmap.org/?lat=38.452165&lon=-75.052240

--- a/hwy_data/DE/usaus/de.us113.wpt
+++ b/hwy_data/DE/usaus/de.us113.wpt
@@ -5,7 +5,7 @@ DelAve_S http://www.openstreetmap.org/?lat=38.502614&lon=-75.237398
 BluLn http://www.openstreetmap.org/?lat=38.517478&lon=-75.240077
 DE26 http://www.openstreetmap.org/?lat=38.542426&lon=-75.257933
 DE20_E http://www.openstreetmap.org/?lat=38.566577&lon=-75.278642
-DE24/30 http://www.openstreetmap.org/?lat=38.585503&lon=-75.295165
+DE24 +DE24/30 http://www.openstreetmap.org/?lat=38.585503&lon=-75.295165
 DelAve_N http://www.openstreetmap.org/?lat=38.589862&lon=-75.302651
 DE20_W http://www.openstreetmap.org/?lat=38.599141&lon=-75.317368
 PinGroRd http://www.openstreetmap.org/?lat=38.620607&lon=-75.337557
@@ -22,7 +22,6 @@ DE16 http://www.openstreetmap.org/?lat=38.806758&lon=-75.438735
 FleRd http://www.openstreetmap.org/?lat=38.826891&lon=-75.438923
 JohRd http://www.openstreetmap.org/?lat=38.869247&lon=-75.439341
 DE36 http://www.openstreetmap.org/?lat=38.901713&lon=-75.439663
-OldShaRd http://www.openstreetmap.org/?lat=38.910448&lon=-75.443231
 DE14 http://www.openstreetmap.org/?lat=38.915845&lon=-75.442606
 10thSt http://www.openstreetmap.org/?lat=38.927693&lon=-75.432901
 DE1Bus_S http://www.openstreetmap.org/?lat=38.933314&lon=-75.430010


### PR DESCRIPTION
US 113: DE24/30>-DE24. (https://forum.travelmapping.net/index.php?topic=4672.0)  Removed OldShaRd.
DE 20: DE24/30>-DE24. (https://forum.travelmapping.net/index.php?topic=4672.0)  Removed WooFerRd and BetConRd.
DE 26:  Fixed broken concurrency with DE 30/DE 54.  Removed IroLn.
DE 54:  Fixed broken concurrency with DE 26/DE 30.  Removed LawsPoiRd.