### PR TITLE
US 63 (IA) and WI 42 Highway63 Updates

### DIFF
--- a/hwy_data/IA/usaus/ia.us063.wpt
+++ b/hwy_data/IA/usaus/ia.us063.wpt
@@ -80,7 +80,7 @@ FraSt http://www.openstreetmap.org/?lat=42.503838&lon=-92.338114
 CRD16 http://www.openstreetmap.org/?lat=42.527594&lon=-92.337642
 CRC66 http://www.openstreetmap.org/?lat=42.570465&lon=-92.337384
 CRC57 http://www.openstreetmap.org/?lat=42.614191&lon=-92.337856
-SStaSt http://www.openstreetmap.org/?lat=42.660474&lon=-92.338489
+StaSt http://www.openstreetmap.org/?lat=42.660474&lon=-92.338489
 175 +CRC50 http://www.openstreetmap.org/?lat=42.671361&lon=-92.344465
 250thSt http://www.openstreetmap.org/?lat=42.685835&lon=-92.337459
 178 +IA3 http://www.openstreetmap.org/?lat=42.714921&lon=-92.337084

--- a/hwy_data/WI/usawi/wi.wi042.wpt
+++ b/hwy_data/WI/usawi/wi.wi042.wpt
@@ -48,7 +48,7 @@ WI57_N http://www.openstreetmap.org/?lat=44.871169&lon=-87.336159
 CRP_Doo http://www.openstreetmap.org/?lat=44.893063&lon=-87.336845
 CRHH_Doo http://www.openstreetmap.org/?lat=44.914705&lon=-87.336760
 CRI_Doo http://www.openstreetmap.org/?lat=44.951482&lon=-87.336931
-CRG_DooS +CRG_Doo_S http://www.openstreetmap.org/?lat=44.983955&lon=-87.326717
+CRG_DooS http://www.openstreetmap.org/?lat=44.983955&lon=-87.326717
 CRG/T_Doo http://www.openstreetmap.org/?lat=45.042387&lon=-87.276936
 CRE_Doo http://www.openstreetmap.org/?lat=45.054409&lon=-87.280498
 CREE_Doo http://www.openstreetmap.org/?lat=45.069262&lon=-87.261186
@@ -66,5 +66,5 @@ MinkRivRd http://www.openstreetmap.org/?lat=45.253955&lon=-87.073260
 +X05 http://www.openstreetmap.org/?lat=45.258984&lon=-87.066607
 CRNP_Doo http://www.openstreetmap.org/?lat=45.259498&lon=-87.029958
 EuroBayRd http://www.openstreetmap.org/?lat=45.259950&lon=-87.022662
-+X06 http://www.openstreetmap.org/?lat=45.290422&lon=-87.022061
+IslCliFry http://www.openstreetmap.org/?lat=45.290422&lon=-87.022061
 PorDr +Ferry http://www.openstreetmap.org/?lat=45.290211&lon=-86.978438


### PR DESCRIPTION
US 63: Renamed SStaSt->StaSt.
WI 42: Added point IslCliFry.  Removed Unused Alternate Label.  (may solve or partially solve (https://forum.travelmapping.net/index.php?topic=3220.msg26001#msg26001))