### PR TITLE
Point Revisions 11-22-2021

### DIFF
--- a/hwy_data/PA/usai/pa.i099.wpt
+++ b/hwy_data/PA/usai/pa.i099.wpt
@@ -3,7 +3,6 @@
 3 http://www.openstreetmap.org/?lat=40.095990&lon=-78.529194
 7 http://www.openstreetmap.org/?lat=40.146708&lon=-78.510101
 10 http://www.openstreetmap.org/?lat=40.193539&lon=-78.487154
-+X111 http://www.openstreetmap.org/?lat=40.234466&lon=-78.463473
 15 http://www.openstreetmap.org/?lat=40.258485&lon=-78.456794
 +X01 http://www.openstreetmap.org/?lat=40.335680&lon=-78.429508
 23 http://www.openstreetmap.org/?lat=40.369448&lon=-78.435696
@@ -13,12 +12,10 @@
 28 http://www.openstreetmap.org/?lat=40.439435&lon=-78.426933
 +X02 http://www.openstreetmap.org/?lat=40.462475&lon=-78.422151
 31 http://www.openstreetmap.org/?lat=40.465518&lon=-78.407864
-+X112 http://www.openstreetmap.org/?lat=40.470643&lon=-78.398993
 32 http://www.openstreetmap.org/?lat=40.479435&lon=-78.394189
 33 http://www.openstreetmap.org/?lat=40.493392&lon=-78.383479
 39 http://www.openstreetmap.org/?lat=40.562165&lon=-78.328480
 41 http://www.openstreetmap.org/?lat=40.598792&lon=-78.314694
-+X02A http://www.openstreetmap.org/?lat=40.614203&lon=-78.305448
 45 http://www.openstreetmap.org/?lat=40.641798&lon=-78.270939
 48 http://www.openstreetmap.org/?lat=40.670801&lon=-78.235016
 +X4 http://www.openstreetmap.org/?lat=40.699121&lon=-78.213258

--- a/hwy_data/PA/usai/pa.i180.wpt
+++ b/hwy_data/PA/usai/pa.i180.wpt
@@ -12,7 +12,6 @@ I-80/147 +0 +I-80 http://www.openstreetmap.org/?lat=41.049765&lon=-76.840031
 +X21(180) http://www.openstreetmap.org/?lat=41.262858&lon=-76.925985
 23A http://www.openstreetmap.org/?lat=41.251460&lon=-76.934547
 23 http://www.openstreetmap.org/?lat=41.246743&lon=-76.945909
-+X(180)23 http://www.openstreetmap.org/?lat=41.246263&lon=-76.964266
 25 http://www.openstreetmap.org/?lat=41.248691&lon=-76.975949
 26 http://www.openstreetmap.org/?lat=41.241739&lon=-76.994789
 27A +27 http://www.openstreetmap.org/?lat=41.238811&lon=-76.999129

--- a/hwy_data/PA/usaif/pa.i099futloc.wpt
+++ b/hwy_data/PA/usaif/pa.i099futloc.wpt
@@ -6,9 +6,7 @@
 +X100 http://www.openstreetmap.org/?lat=41.141158&lon=-77.370400
 116 http://www.openstreetmap.org/?lat=41.151742&lon=-77.353693
 118 http://www.openstreetmap.org/?lat=41.176425&lon=-77.324465
-+X117 http://www.openstreetmap.org/?lat=41.185128&lon=-77.305325
 120 http://www.openstreetmap.org/?lat=41.196603&lon=-77.297238
 ThoSt http://www.openstreetmap.org/?lat=41.205323&lon=-77.276341
 PA44_S http://www.openstreetmap.org/?lat=41.212486&lon=-77.250452
-+X118 http://www.openstreetmap.org/?lat=41.215828&lon=-77.241732
 OldUS220 +OldHwy220 http://www.openstreetmap.org/?lat=41.216903&lon=-77.234187

--- a/hwy_data/PA/usapa/pa.pa026.wpt
+++ b/hwy_data/PA/usapa/pa.pa026.wpt
@@ -32,7 +32,6 @@ WooValRd http://www.openstreetmap.org/?lat=40.144004&lon=-78.296497
 PlaRd http://www.openstreetmap.org/?lat=40.141896&lon=-78.285216
 PA915 http://www.openstreetmap.org/?lat=40.138152&lon=-78.267445
 *OldPA915 http://www.openstreetmap.org/?lat=40.138105&lon=-78.266792
-+X2H http://www.openstreetmap.org/?lat=40.141767&lon=-78.260510
 6MRunRd http://www.openstreetmap.org/?lat=40.162051&lon=-78.255787
 +X3 http://www.openstreetmap.org/?lat=40.185021&lon=-78.244114
 RavRunRd http://www.openstreetmap.org/?lat=40.192713&lon=-78.259193

--- a/hwy_data/PA/usapa/pa.pa042trkeag.wpt
+++ b/hwy_data/PA/usapa/pa.pa042trkeag.wpt
@@ -1,8 +1,8 @@
 PA42_S http://www.openstreetmap.org/?lat=41.344135&lon=-76.585074
-ChaHillRd http://www.openstreetmap.org/?lat=41.345371&lon=-76.556597
+VetMemRd http://www.openstreetmap.org/?lat=41.345371&lon=-76.556597
 MicRd http://www.openstreetmap.org/?lat=41.356645&lon=-76.557329
-FaiRd http://www.openstreetmap.org/?lat=41.360319&lon=-76.554025
+OldUS220_S http://www.openstreetmap.org/?lat=41.361804&lon=-76.548966
 +X200A http://www.openstreetmap.org/?lat=41.360349&lon=-76.542990
-+X200 http://www.openstreetmap.org/?lat=41.377948&lon=-76.515226
+OldUS220_N http://www.openstreetmap.org/?lat=41.386513&lon=-76.508698
 NorRd http://www.openstreetmap.org/?lat=41.402962&lon=-76.498546
 PA42_N http://www.openstreetmap.org/?lat=41.423474&lon=-76.488112

--- a/hwy_data/PA/usapa/pa.pa484.wpt
+++ b/hwy_data/PA/usapa/pa.pa484.wpt
@@ -2,13 +2,13 @@ PA26 http://www.openstreetmap.org/?lat=39.741778&lon=-78.362732
 HixRd http://www.openstreetmap.org/?lat=39.735702&lon=-78.349259
 HarRd_W http://www.openstreetmap.org/?lat=39.751912&lon=-78.326857
 HamDr http://www.openstreetmap.org/?lat=39.767789&lon=-78.318564
-+X1 http://www.openstreetmap.org/?lat=39.761909&lon=-78.303828
-FinBoaRd http://www.openstreetmap.org/?lat=39.770696&lon=-78.292772
+StaRd http://www.openstreetmap.org/?lat=39.765033&lon=-78.295138
+FinRd http://www.openstreetmap.org/?lat=39.770696&lon=-78.292772
 PA731 http://www.openstreetmap.org/?lat=39.766443&lon=-78.283019
 HarRd_E http://www.openstreetmap.org/?lat=39.754243&lon=-78.275378
 OldPA126 http://www.openstreetmap.org/?lat=39.766882&lon=-78.246976
 +X2 http://www.openstreetmap.org/?lat=39.763612&lon=-78.203859
 GreCoveRd http://www.openstreetmap.org/?lat=39.756076&lon=-78.190904
 BuckValRd_S http://www.openstreetmap.org/?lat=39.748716&lon=-78.182587
-+X3 http://www.openstreetmap.org/?lat=39.747534&lon=-78.173229
+PigCoveRd_N http://www.openstreetmap.org/?lat=39.750822&lon=-78.179491
 PA655 http://www.openstreetmap.org/?lat=39.751170&lon=-78.168317

--- a/hwy_data/PA/usapa/pa.pa867trkroa.wpt
+++ b/hwy_data/PA/usapa/pa.pa867trkroa.wpt
@@ -6,7 +6,6 @@ PA867_S http://www.openstreetmap.org/?lat=40.179599&lon=-78.471195
 KauHolRd http://www.openstreetmap.org/?lat=40.146036&lon=-78.507620
 I-99(7) http://www.openstreetmap.org/?lat=40.146708&lon=-78.510101
 I-99(10) http://www.openstreetmap.org/?lat=40.193539&lon=-78.487154
-+X111 http://www.openstreetmap.org/?lat=40.234466&lon=-78.463473
 I-99(15) http://www.openstreetmap.org/?lat=40.258485&lon=-78.456794
 +X01 http://www.openstreetmap.org/?lat=40.335680&lon=-78.429508
 I-99(23) http://www.openstreetmap.org/?lat=40.369448&lon=-78.435696

--- a/hwy_data/PA/usaus/pa.us220.wpt
+++ b/hwy_data/PA/usaus/pa.us220.wpt
@@ -6,7 +6,6 @@ WhiChuLn http://www.openstreetmap.org/?lat=39.830365&lon=-78.646523
 EviCreRd http://www.openstreetmap.org/?lat=39.873348&lon=-78.610726
 BroRd http://www.openstreetmap.org/?lat=39.940578&lon=-78.578264
 US220BusBed_S http://www.openstreetmap.org/?lat=39.959408&lon=-78.562277
-+X1(US220) http://www.openstreetmap.org/?lat=39.998813&lon=-78.527079
 US30Bus http://www.openstreetmap.org/?lat=40.022122&lon=-78.514929
 US30 http://www.openstreetmap.org/?lat=40.025990&lon=-78.513569
 I-99(1) http://www.openstreetmap.org/?lat=40.055909&lon=-78.518112
@@ -14,7 +13,6 @@ I-99(1) http://www.openstreetmap.org/?lat=40.055909&lon=-78.518112
 I-99(3) http://www.openstreetmap.org/?lat=40.095990&lon=-78.529194
 I-99(7) http://www.openstreetmap.org/?lat=40.146708&lon=-78.510101
 I-99(10) http://www.openstreetmap.org/?lat=40.193539&lon=-78.487154
-+X111 http://www.openstreetmap.org/?lat=40.234466&lon=-78.463473
 I-99(15) http://www.openstreetmap.org/?lat=40.258485&lon=-78.456794
 +X01 http://www.openstreetmap.org/?lat=40.335680&lon=-78.429508
 I-99(23) http://www.openstreetmap.org/?lat=40.369448&lon=-78.435696
@@ -24,12 +22,10 @@ I-99(23) http://www.openstreetmap.org/?lat=40.369448&lon=-78.435696
 I-99(28) http://www.openstreetmap.org/?lat=40.439435&lon=-78.426933
 +X02 http://www.openstreetmap.org/?lat=40.462475&lon=-78.422151
 I-99(31) http://www.openstreetmap.org/?lat=40.465518&lon=-78.407864
-+X112 http://www.openstreetmap.org/?lat=40.470643&lon=-78.398993
 I-99(32) http://www.openstreetmap.org/?lat=40.479435&lon=-78.394189
 I-99(33) http://www.openstreetmap.org/?lat=40.493392&lon=-78.383479
 I-99(39) http://www.openstreetmap.org/?lat=40.562165&lon=-78.328480
 I-99(41) http://www.openstreetmap.org/?lat=40.598792&lon=-78.314694
-+X02A http://www.openstreetmap.org/?lat=40.614203&lon=-78.305448
 I-99(45) http://www.openstreetmap.org/?lat=40.641798&lon=-78.270939
 I-99(48) http://www.openstreetmap.org/?lat=40.670801&lon=-78.235016
 +X4 http://www.openstreetmap.org/?lat=40.699121&lon=-78.213258
@@ -71,11 +67,9 @@ PA120 http://www.openstreetmap.org/?lat=41.127292&lon=-77.438464
 +X100 http://www.openstreetmap.org/?lat=41.141158&lon=-77.370400
 McEDr http://www.openstreetmap.org/?lat=41.151742&lon=-77.353693
 PA150_N http://www.openstreetmap.org/?lat=41.176425&lon=-77.324465
-+X117 http://www.openstreetmap.org/?lat=41.185128&lon=-77.305325
 PA44_N http://www.openstreetmap.org/?lat=41.196603&lon=-77.297238
 ThoSt http://www.openstreetmap.org/?lat=41.205323&lon=-77.276341
 PA44_S http://www.openstreetmap.org/?lat=41.212486&lon=-77.250452
-+X118 http://www.openstreetmap.org/?lat=41.215828&lon=-77.241732
 OldUS220 http://www.openstreetmap.org/?lat=41.216903&lon=-77.234187
 PA287 http://www.openstreetmap.org/?lat=41.219142&lon=-77.221286
 SpoHolRd http://www.openstreetmap.org/?lat=41.214104&lon=-77.201695
@@ -89,7 +83,6 @@ I-180(27B) http://www.openstreetmap.org/?lat=41.235896&lon=-77.006044
 I-180(27A) http://www.openstreetmap.org/?lat=41.238811&lon=-76.999129
 I-180(26) http://www.openstreetmap.org/?lat=41.241739&lon=-76.994789
 I-180(25) http://www.openstreetmap.org/?lat=41.248691&lon=-76.975949
-+X(180)23 http://www.openstreetmap.org/?lat=41.246263&lon=-76.964266
 I-180(23) http://www.openstreetmap.org/?lat=41.246743&lon=-76.945909
 I-180(23A) http://www.openstreetmap.org/?lat=41.251460&lon=-76.934547
 +X21(180) http://www.openstreetmap.org/?lat=41.262858&lon=-76.925985
@@ -101,7 +94,6 @@ MidRd http://www.openstreetmap.org/?lat=41.240549&lon=-76.796947
 RabRd http://www.openstreetmap.org/?lat=41.242723&lon=-76.777667
 AuchRd http://www.openstreetmap.org/?lat=41.250342&lon=-76.759055
 PA405 http://www.openstreetmap.org/?lat=41.245252&lon=-76.720439
-BeaLakeRd http://www.openstreetmap.org/?lat=41.249883&lon=-76.717272
 PA864 http://www.openstreetmap.org/?lat=41.279911&lon=-76.713101
 RoaRunRd http://www.openstreetmap.org/?lat=41.288118&lon=-76.709426
 +X101 http://www.openstreetmap.org/?lat=41.287151&lon=-76.698861
@@ -109,17 +101,17 @@ HigLakeRd http://www.openstreetmap.org/?lat=41.299051&lon=-76.690841
 +X881581 http://www.openstreetmap.org/?lat=41.309150&lon=-76.676698
 DeerLakeRd http://www.openstreetmap.org/?lat=41.309486&lon=-76.665543
 +X102 http://www.openstreetmap.org/?lat=41.313564&lon=-76.642529
-HolHolRd http://www.openstreetmap.org/?lat=41.309857&lon=-76.633697
+HolHolRd http://www.openstreetmap.org/?lat=41.309019&lon=-76.634628
 +X104 http://www.openstreetmap.org/?lat=41.317442&lon=-76.627817
 EdkHillRd http://www.openstreetmap.org/?lat=41.313374&lon=-76.615892
 ShiHillRd http://www.openstreetmap.org/?lat=41.311293&lon=-76.602586
 PA42_S http://www.openstreetmap.org/?lat=41.329310&lon=-76.587963
 PA42_N http://www.openstreetmap.org/?lat=41.344135&lon=-76.585074
-ChaHillRd http://www.openstreetmap.org/?lat=41.345371&lon=-76.556597
+VetMemRd http://www.openstreetmap.org/?lat=41.345371&lon=-76.556597
 MicRd http://www.openstreetmap.org/?lat=41.356645&lon=-76.557329
-FaiRd http://www.openstreetmap.org/?lat=41.360319&lon=-76.554025
+OldUS220_S http://www.openstreetmap.org/?lat=41.361804&lon=-76.548966
 +X200A http://www.openstreetmap.org/?lat=41.360349&lon=-76.542990
-+X200 http://www.openstreetmap.org/?lat=41.377948&lon=-76.515226
+OldUS220_N http://www.openstreetmap.org/?lat=41.386513&lon=-76.508698
 NorRd http://www.openstreetmap.org/?lat=41.402962&lon=-76.498546
 PA42_C +PA42 http://www.openstreetmap.org/?lat=41.423474&lon=-76.488112
 PA154 http://www.openstreetmap.org/?lat=41.429322&lon=-76.490217
@@ -130,7 +122,6 @@ OldBerRd http://www.openstreetmap.org/?lat=41.476631&lon=-76.420054
 ShiRd +Sat http://www.openstreetmap.org/?lat=41.490755&lon=-76.409781
 PA87_S http://www.openstreetmap.org/?lat=41.515511&lon=-76.406664
 PA87_N http://www.openstreetmap.org/?lat=41.524106&lon=-76.400798
-+X106 http://www.openstreetmap.org/?lat=41.532106&lon=-76.398687
 BlaRd http://www.openstreetmap.org/?lat=41.548676&lon=-76.402952
 HarRd http://www.openstreetmap.org/?lat=41.562536&lon=-76.419614
 MarRd http://www.openstreetmap.org/?lat=41.573509&lon=-76.419426
@@ -155,8 +146,6 @@ MilRd http://www.openstreetmap.org/?lat=41.907379&lon=-76.523442
 PA199 http://www.openstreetmap.org/?lat=41.936202&lon=-76.525290
 +X1101 http://www.openstreetmap.org/?lat=41.947119&lon=-76.522796
 PineSt http://www.openstreetmap.org/?lat=41.964905&lon=-76.533404
-+X1102 http://www.openstreetmap.org/?lat=41.975044&lon=-76.544243
-+X1102A http://www.openstreetmap.org/?lat=41.983958&lon=-76.546378
 WilRd http://www.openstreetmap.org/?lat=41.988965&lon=-76.548724
 I-86 +NY17 http://www.openstreetmap.org/?lat=41.999255&lon=-76.548719
 PA/NY http://www.openstreetmap.org/?lat=42.000046&lon=-76.548829


### PR DESCRIPTION
Shaping Point Reduction along US 220 (and concurrencies), PA 26, and PA 867 TRUCK (Roaring Spring), 

Other Changes:
US 220:  Relocated HolHolRd.  Replaced ChaHillRd with VetMemRd (Veterans Memorial rd).  Replaced FaiRd with OldUS220_S.  Replaced +X200 with OldUS220_N.
PA 484:  Replaced +X1  with Stahle Rd (StaRd).  Replaced +X3 with Pigeon Cove Rd (PigCoveRd_N).