### PR TITLE
UT 138 truncation redux

### DIFF
--- a/hwy_data/UT/usaut/ut.ut138.wpt
+++ b/hwy_data/UT/usaut/ut.ut138.wpt
@@ -1,7 +1,8 @@
 I-80 http://www.openstreetmap.org/?lat=40.709532&lon=-112.529697
++X308106 http://www.openstreetmap.org/?lat=40.697201&lon=-112.530169
 MisRd http://www.openstreetmap.org/?lat=40.676440&lon=-112.550511
 +X509823 http://www.openstreetmap.org/?lat=40.600366&lon=-112.482147
 WesSt http://www.openstreetmap.org/?lat=40.599910&lon=-112.477427
+KeaSt http://www.openstreetmap.org/?lat=40.599837&lon=-112.457943
 UT112 http://www.openstreetmap.org/?lat=40.599552&lon=-112.425992
-SheLn http://www.openstreetmap.org/?lat=40.614246&lon=-112.371168
-UT179 +UT36 http://www.openstreetmap.org/?lat=40.619645&lon=-112.361888
+UT179 +UT36 http://www.openstreetmap.org/?lat=40.614539&lon=-112.371104

--- a/hwy_data/UT/usaut/ut.ut179.wpt
+++ b/hwy_data/UT/usaut/ut.ut179.wpt
@@ -1,3 +1,5 @@
 I-80 http://www.openstreetmap.org/?lat=40.662752&lon=-112.330602
 +X874932 http://www.openstreetmap.org/?lat=40.641703&lon=-112.355053
-UT138 http://www.openstreetmap.org/?lat=40.619645&lon=-112.361888
+ParParkLn http://www.openstreetmap.org/?lat=40.622723&lon=-112.358959
+*OldUT138 http://www.openstreetmap.org/?lat=40.616624&lon=-112.367027
+UT138 http://www.openstreetmap.org/?lat=40.614539&lon=-112.371104


### PR DESCRIPTION
This fixes the 138/179 transition based on local tip that what OSM currently shows does not match ground reality