### PR TITLE
NY: Hutchinson River Parkway mileage-based exits

### DIFF
--- a/hwy_data/NY/usasf/ny.hutrivpkwy.wpt
+++ b/hwy_data/NY/usasf/ny.hutrivpkwy.wpt
@@ -1,29 +1,27 @@
-1 http://www.openstreetmap.org/?lat=40.828992&lon=-73.837105
-2 http://www.openstreetmap.org/?lat=40.841898&lon=-73.838146
-3 http://www.openstreetmap.org/?lat=40.856020&lon=-73.832846
-4 http://www.openstreetmap.org/?lat=40.861026&lon=-73.828200
-5 http://www.openstreetmap.org/?lat=40.872961&lon=-73.818641
-6 http://www.openstreetmap.org/?lat=40.886719&lon=-73.815336
-7 http://www.openstreetmap.org/?lat=40.891910&lon=-73.815980
-9 http://www.openstreetmap.org/?lat=40.902647&lon=-73.814993
-10 http://www.openstreetmap.org/?lat=40.908275&lon=-73.813512
-12 http://www.openstreetmap.org/?lat=40.916318&lon=-73.811903
-13 http://www.openstreetmap.org/?lat=40.921571&lon=-73.809671
-14 http://www.openstreetmap.org/?lat=40.925608&lon=-73.806474
+1A +1 http://www.openstreetmap.org/?lat=40.828992&lon=-73.837105
+1B http://www.openstreetmap.org/?lat=40.841898&lon=-73.838146
+1C http://www.openstreetmap.org/?lat=40.856020&lon=-73.832846
+2 +4 http://www.openstreetmap.org/?lat=40.861026&lon=-73.828200
+3 http://www.openstreetmap.org/?lat=40.872961&lon=-73.818641
+4A +6 http://www.openstreetmap.org/?lat=40.886719&lon=-73.815336
+4B http://www.openstreetmap.org/?lat=40.891910&lon=-73.815980
+5A http://www.openstreetmap.org/?lat=40.902647&lon=-73.814993
+5B http://www.openstreetmap.org/?lat=40.908275&lon=-73.813512
+6A http://www.openstreetmap.org/?lat=40.916318&lon=-73.811903
+6B http://www.openstreetmap.org/?lat=40.921571&lon=-73.809671
+7 http://www.openstreetmap.org/?lat=40.925608&lon=-73.806474
 +X01 http://www.openstreetmap.org/?lat=40.931380&lon=-73.802934
-15 http://www.openstreetmap.org/?lat=40.934881&lon=-73.807569
-16 http://www.openstreetmap.org/?lat=40.944056&lon=-73.801432
-17 http://www.openstreetmap.org/?lat=40.951284&lon=-73.798063
-18 http://www.openstreetmap.org/?lat=40.955181&lon=-73.799028
-19 http://www.openstreetmap.org/?lat=40.959500&lon=-73.795338
-20 http://www.openstreetmap.org/?lat=40.969331&lon=-73.774148
-21 http://www.openstreetmap.org/?lat=40.970437&lon=-73.768666
-22 http://www.openstreetmap.org/?lat=40.976869&lon=-73.758538
-23 http://www.openstreetmap.org/?lat=40.983397&lon=-73.744183
-25 http://www.openstreetmap.org/?lat=40.999795&lon=-73.726051
-26 http://www.openstreetmap.org/?lat=41.014070&lon=-73.717146
-26A http://www.openstreetmap.org/?lat=41.019170&lon=-73.715236
-27 http://www.openstreetmap.org/?lat=41.022318&lon=-73.710086
-28 http://www.openstreetmap.org/?lat=41.023443&lon=-73.695345
-29 http://www.openstreetmap.org/?lat=41.028284&lon=-73.683457
+8 http://www.openstreetmap.org/?lat=40.934881&lon=-73.807569
+8A http://www.openstreetmap.org/?lat=40.944056&lon=-73.801432
+9 http://www.openstreetmap.org/?lat=40.955181&lon=-73.799028
+9C http://www.openstreetmap.org/?lat=40.959500&lon=-73.795338
+11 http://www.openstreetmap.org/?lat=40.969331&lon=-73.774148
+12 http://www.openstreetmap.org/?lat=40.976869&lon=-73.758538
+13 +23 http://www.openstreetmap.org/?lat=40.983397&lon=-73.744183
+14 http://www.openstreetmap.org/?lat=40.999795&lon=-73.726051
+15 +26 http://www.openstreetmap.org/?lat=41.014070&lon=-73.717146
+16A +26A http://www.openstreetmap.org/?lat=41.019170&lon=-73.715236
+16B http://www.openstreetmap.org/?lat=41.022318&lon=-73.710086
+17 http://www.openstreetmap.org/?lat=41.023443&lon=-73.695345
+18 http://www.openstreetmap.org/?lat=41.028284&lon=-73.683457
 NY/CT http://www.openstreetmap.org/?lat=41.036810&lon=-73.675529

--- a/updates.csv
+++ b/updates.csv
@@ -4865,6 +4865,7 @@ date;region;route;root;description
 2015-11-20;(USA) New Mexico;US 70;nm.us070;In Lordsburg, route moved from I-10 between exits 22 and 24, and Main St. (NM 494), north to Motel Dr. (I-10BL)
 2015-11-02;(USA) New Mexico;US 380;nm.us380;Swapped locations of labels US285Trk and US70/285
 2015-11-02;(USA) New Mexico;US 70 Truck (Roswell);nm.us070trkros;Removed from southern part of relief route on the west side of Roswell and relocated onto northern part
+2022-01-03;(USA) New York;Hutchinson River Parkway;ny.hutrivpkwy;Relabeled exits from sequential to mileage-based.
 2021-08-12;(USA) New York;NY 97;ny.ny097;Removed from Front St in Hancock and relocated onto Main St and Read St. This is only a correction to Travel Mapping's data, and does not reflect an actual change in routing.
 2021-02-09;(USA) New York;Inner Loop;ny.innloop;Route added.
 2021-01-26;(USA) New York;NY 107;ny.ny107;North end truncated from Glen Cove Avenue to Pulaski Street.


### PR DESCRIPTION
Hutchinson River Parkway has been renumbered from sequential to mileage-based.

**Broken exit numbers:**
2 3 7 13 15

**All travelers with broken .lists:**
alex barefoot_driver brendan cebarb98 chaddean chart33 dave1693 eth foresthills93 formulanone froggie gpw hurricanehink jackgaynor jaehak JamesMD keithcavey master_son nezinscot noelbotevera sbeaver44 shiggins

**Those who update via GitHub (TM usernames):**
alex chart33 dave1693 eth formulanone froggie jackgaynor keithcavey master_son nezinscot

**GitHub usernames:**
@alexgotz @cahart1 @dave1693 @tmharley @freakwentflier @ajfroggie @mrpoodlepants @keithcavey @ssoworld @denishanson 

**Those left over who update by email:**
barefoot_driver brendan cebarb98 chaddean foresthills93 gpw hurricanehink jaehak JamesMD noelbotevera sbeaver44 shiggins 

You just watch. Once the last state completes their conversion, the US will finally switch to metric.