### PR TITLE
US 460 BUS (Appomattox): Fixing VA 131 Duplicate Label Error

### DIFF
--- a/hwy_data/VA/usanp/va.gwmempkwymtv.wpt
+++ b/hwy_data/VA/usanp/va.gwmempkwymtv.wpt
@@ -1,5 +1,5 @@
 VA235 http://www.openstreetmap.org/?lat=38.711471&lon=-77.087567
-Mouver +MntVer http://www.openstreetmap.org/?lat=38.711350&lon=-77.086161
+MouVer +MntVer http://www.openstreetmap.org/?lat=38.711350&lon=-77.086161
 +X816007 http://www.openstreetmap.org/?lat=38.717344&lon=-77.082331
 StrLn http://www.openstreetmap.org/?lat=38.711166&lon=-77.071195
 FortHuntRd http://www.openstreetmap.org/?lat=38.714866&lon=-77.046905

--- a/hwy_data/VA/usausb/va.us460busapp.wpt
+++ b/hwy_data/VA/usausb/va.us460busapp.wpt
@@ -1,6 +1,6 @@
 US460_W http://www.openstreetmap.org/?lat=37.364828&lon=-78.836775
 VA131_N http://www.openstreetmap.org/?lat=37.363250&lon=-78.834050
-VA131_S +VA131 http://www.openstreetmap.org/?lat=37.362150&lon=-78.832553
+VA131_S http://www.openstreetmap.org/?lat=37.362150&lon=-78.832553
 SR727 http://www.openstreetmap.org/?lat=37.357196&lon=-78.825402
 VA131 +VA131_W http://www.openstreetmap.org/?lat=37.355307&lon=-78.822929
 US460_E http://www.openstreetmap.org/?lat=37.348045&lon=-78.808043

--- a/hwy_data/VA/usava/va.va326.wpt
+++ b/hwy_data/VA/usava/va.va326.wpt
@@ -1,2 +1,2 @@
 SR605 http://www.openstreetmap.org/?lat=37.747906&lon=-77.352215
-HanJuvCen +VirPSTC http://www.openstreetmap.org/?lat=37.754045&lon=-77.340404
+VirPSTC +HanJuvCen http://www.openstreetmap.org/?lat=37.754045&lon=-77.340404


### PR DESCRIPTION
VA131 is not currently in use so this was an easy fix.

Also fixed Label typo for the Mount Vernon portion of the GW Pkwy and switched the labels on VA 326 as HanJuvCen was supposed to become an alternate label for VirPSTC.