### PR TITLE
delete TXLp354, add US290BusCyp

### DIFF
--- a/hwy_data/TX/usai/tx.i369.wpt
+++ b/hwy_data/TX/usai/tx.i369.wpt
@@ -1,5 +1,5 @@
 111A +TXLp151 +US59/Lp151 http://www.openstreetmap.org/?lat=33.394876&lon=-94.098080
-111B +FroRd http://www.openstreetmap.org/?lat=33.402695&lon=-94.097761
+111B http://www.openstreetmap.org/?lat=33.402695&lon=-94.097761
 112 http://www.openstreetmap.org/?lat=33.418663&lon=-94.096514
 113 http://www.openstreetmap.org/?lat=33.431990&lon=-94.096476
 114A http://www.openstreetmap.org/?lat=33.443331&lon=-94.096785

--- a/hwy_data/TX/usatx/tx.tx007.wpt
+++ b/hwy_data/TX/usatx/tx.tx007.wpt
@@ -60,7 +60,7 @@ FM1275_N http://www.openstreetmap.org/?lat=31.579609&lon=-94.646112
 FM1275_S http://www.openstreetmap.org/?lat=31.579600&lon=-94.643151
 FM2259 http://www.openstreetmap.org/?lat=31.579596&lon=-94.633425
 TX21_E http://www.openstreetmap.org/?lat=31.589649&lon=-94.619520
-TX7Bus/224 +US59Bus_N http://www.openstreetmap.org/?lat=31.599660&lon=-94.620062
+TX7Bus/224 http://www.openstreetmap.org/?lat=31.599660&lon=-94.620062
 FM2112 http://www.openstreetmap.org/?lat=31.613874&lon=-94.522070
 FM2713 http://www.openstreetmap.org/?lat=31.619963&lon=-94.483017
 FM95_S http://www.openstreetmap.org/?lat=31.642668&lon=-94.414374

--- a/hwy_data/TX/usatxl/tx.lp0012.wpt
+++ b/hwy_data/TX/usatxl/tx.lp0012.wpt
@@ -47,5 +47,5 @@ TX289 http://www.openstreetmap.org/?lat=32.865553&lon=-96.804083
 DalNorTlwy http://www.openstreetmap.org/?lat=32.865577&lon=-96.811478
 MidRd http://www.openstreetmap.org/?lat=32.863881&lon=-96.836345
 MarLn http://www.openstreetmap.org/?lat=32.861065&lon=-96.855142
-TXLp354 +TXLp354/Spr482 http://www.openstreetmap.org/?lat=32.858415&lon=-96.880869
+TXSpr482 +TXLp354/Spr482 http://www.openstreetmap.org/?lat=32.858415&lon=-96.880869
 I-35E(436)_E http://www.openstreetmap.org/?lat=32.862412&lon=-96.893722

--- a/hwy_data/TX/usatxl/tx.lp0354.wpt
+++ b/hwy_data/TX/usatxl/tx.lp0354.wpt
@@ -1,5 +1,0 @@
-TXLp12 +TXLp12/Spr482 http://www.openstreetmap.org/?lat=32.858415&lon=-96.880869
-WalHillLn http://www.openstreetmap.org/?lat=32.881159&lon=-96.885579
-RoyLn http://www.openstreetmap.org/?lat=32.895651&lon=-96.891335
-I-635 http://www.openstreetmap.org/?lat=32.908267&lon=-96.895251
-I-35E http://www.openstreetmap.org/?lat=32.913468&lon=-96.897955

--- a/hwy_data/TX/usatxl/tx.lp0368.wpt
+++ b/hwy_data/TX/usatxl/tx.lp0368.wpt
@@ -3,6 +3,7 @@ NewAve http://www.openstreetmap.org/?lat=29.440527&lon=-98.477674
 JosSt http://www.openstreetmap.org/?lat=29.444456&lon=-98.476247
 MulAve http://www.openstreetmap.org/?lat=29.454340&lon=-98.471537
 HilAve http://www.openstreetmap.org/?lat=29.465761&lon=-98.463700
+BurrRd http://www.openstreetmap.org/?lat=29.468227&lon=-98.463614
 Bro_N +Bro http://www.openstreetmap.org/?lat=29.477922&lon=-98.462804
 NewBraAve http://www.openstreetmap.org/?lat=29.483689&lon=-98.459306
 RitRd http://www.openstreetmap.org/?lat=29.484805&lon=-98.452966

--- a/hwy_data/TX/usatxs/tx.sp0482.wpt
+++ b/hwy_data/TX/usatxs/tx.sp0482.wpt
@@ -1,3 +1,3 @@
 TX114/183 http://www.openstreetmap.org/?lat=32.838852&lon=-96.905293
 FroRd http://www.openstreetmap.org/?lat=32.846680&lon=-96.894827
-TXLp12/354 http://www.openstreetmap.org/?lat=32.858415&lon=-96.880869
+TXLp12 +TXLp12/354 http://www.openstreetmap.org/?lat=32.858415&lon=-96.880869

--- a/hwy_data/TX/usausb/tx.us290buscyp.wpt
+++ b/hwy_data/TX/usausb/tx.us290buscyp.wpt
@@ -1,0 +1,4 @@
+US290_W http://www.openstreetmap.org/?lat=29.974979&lon=-95.706925
+FryRd http://www.openstreetmap.org/?lat=29.971526&lon=-95.701008
+SprCypRd http://www.openstreetmap.org/?lat=29.969126&lon=-95.697562
+US290_E http://www.openstreetmap.org/?lat=29.963970&lon=-95.689403

--- a/hwy_data/_systems/usatxl.csv
+++ b/hwy_data/_systems/usatxl.csv
@@ -134,7 +134,6 @@ usatxl;TX;TXLp344;;;;tx.lp0344;
 usatxl;TX;TXLp345;;;;tx.lp0345;
 usatxl;TX;TXLp350;;;;tx.lp0350;
 usatxl;TX;TXLp353;;;;tx.lp0353;
-usatxl;TX;TXLp354;;;;tx.lp0354;
 usatxl;TX;TXLp360;;;;tx.lp0360;
 usatxl;TX;TXLp361;;;;tx.lp0361;
 usatxl;TX;TXLp362;;;;tx.lp0362;

--- a/hwy_data/_systems/usatxl_con.csv
+++ b/hwy_data/_systems/usatxl_con.csv
@@ -134,7 +134,6 @@ usatxl;TXLp344;;;tx.lp0344
 usatxl;TXLp345;;;tx.lp0345
 usatxl;TXLp350;;;tx.lp0350
 usatxl;TXLp353;;;tx.lp0353
-usatxl;TXLp354;;;tx.lp0354
 usatxl;TXLp360;;;tx.lp0360
 usatxl;TXLp361;;;tx.lp0361
 usatxl;TXLp362;;;tx.lp0362

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -987,6 +987,7 @@ usausb;TX;US287;Bus;Ver;Vernon, TX;tx.us287busver;
 usausb;WY;US287;Byp;Raw;Rawlins, WY;wy.us287bypraw;
 usausb;TX;US290;Bus;Bre;Brenham, TX;tx.us290busbre;
 usausb;TX;US290;Bus;Hem;Hempstead, TX;tx.us290bushem;
+usausb;TX;US290;Bus;Cyp;Cypress, TX;tx.us290buscyp;
 usausb;FL;US301;Alt;Sta;Starke, FL;fl.us301altsta;
 usausb;FL;US301;Byp;Bal;Baldwin, FL;fl.us301bypbal;
 usausb;GA;US301;Bus;Syl;Sylania, GA;ga.us301bussyl;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -974,6 +974,7 @@ usausb;US287;Bus;Vernon, TX;tx.us287busver
 usausb;US287;Byp;Rawlins, WY;wy.us287bypraw
 usausb;US290;Bus;Brenham, TX;tx.us290busbre
 usausb;US290;Bus;Hempstead, TX;tx.us290bushem
+usausb;US290;Bus;Cypress, TX;tx.us290buscyp
 usausb;US301;Alt;Starke, FL;fl.us301altsta
 usausb;US301;Byp;Baldwin, FL;fl.us301bypbal
 usausb;US301;Bus;Sylania, GA;ga.us301bussyl

--- a/updates.csv
+++ b/updates.csv
@@ -5452,8 +5452,9 @@ date;region;route;root;description
 2015-11-29;(USA) Tennessee;US 641;tn.us641;Extended southward from the former ending intersection with I-40 along TN 69 & TN 114 to a new southern terminus at US 64
 2015-10-25;(USA) Tennessee;I-269;tn.i269;Route added
 2015-10-25;(USA) Tennessee;I-269 Future (Memphis, TN);tn.i269futmem;Extended southward from the interchange with TN 57 to a newly opened interchange with I-269 (Exit 2)
+2022-02-10;(USA) Texas;TX Loop 354;;Route deleted.
 2022-02-09;(USA) Texas;TX Spur 29;tx.sp0029;Route added.
-2022-02-09;(USA) Texas;TX Loop 118;tx.lp0118;Route deleted.
+2022-02-09;(USA) Texas;TX Loop 118;;Route deleted.
 2022-02-08;(USA) Texas;TX Loop 368;tx.lp0368;Extended southward from Burr Rd to the south edge of the I-35/37 interchange footprint. A 2015 truncation of this route did not actually take effect.
 2022-01-15;(USA) Texas;Westpark Tollway;tx.westlwy;West end truncated from FM 1463 to FM 723. Route was erroneously extended on TM one point too far on 2017-12-12.
 2022-01-12;(USA) Texas;TX Spur 379;;Route deleted.

--- a/updates.csv
+++ b/updates.csv
@@ -5452,6 +5452,7 @@ date;region;route;root;description
 2015-11-29;(USA) Tennessee;US 641;tn.us641;Extended southward from the former ending intersection with I-40 along TN 69 & TN 114 to a new southern terminus at US 64
 2015-10-25;(USA) Tennessee;I-269;tn.i269;Route added
 2015-10-25;(USA) Tennessee;I-269 Future (Memphis, TN);tn.i269futmem;Extended southward from the interchange with TN 57 to a newly opened interchange with I-269 (Exit 2)
+2022-02-10;(USA) Texas;US 290 Business (Cypress);tx.us290buscyp;Route added.
 2022-02-10;(USA) Texas;TX Loop 354;;Route deleted.
 2022-02-09;(USA) Texas;TX Spur 29;tx.sp0029;Route added.
 2022-02-09;(USA) Texas;TX Loop 118;;Route deleted.


### PR DESCRIPTION
* **TXLp354:** https://publicdocs.txdot.gov/minord/MinuteOrderDocLib/115188.pdf
* **US290BusCyp** was removed from CHM due to being unsigned. Signage has since been added. Not the best, but [it's](https://www.google.com/maps/@29.9752065,-95.7077622,3a,75y,136.47h,94.13t/data=!3m6!1e1!3m4!1sSq-1DMaXM41rwt3oQPBQ_A!2e0!7i16384!8i8192) [something](https://www.google.com/maps/@29.9711851,-95.6933276,3a,15y,329.01h,90.85t/data=!3m6!1e1!3m4!1s0fUCrx_C9oUTwtLASD4-pw!2e0!7i16384!8i8192).