### PR TITLE
MB/NB/AB

### DIFF
--- a/hwy_data/AB/canab/ab.ab014.wpt
+++ b/hwy_data/AB/canab/ab.ab014.wpt
@@ -14,7 +14,9 @@ RR220 http://www.openstreetmap.org/?lat=53.396001&lon=-113.098069
 RR204 http://www.openstreetmap.org/?lat=53.396078&lon=-112.901924
 AB630/833 http://www.openstreetmap.org/?lat=53.367134&lon=-112.803568
 AB834_W http://www.openstreetmap.org/?lat=53.366884&lon=-112.684493
-AB834_E http://www.openstreetmap.org/?lat=53.358393&lon=-112.635772
+*OldAB14_W http://www.openstreetmap.org/?lat=53.359329&lon=-112.646545
+AB834_E http://www.openstreetmap.org/?lat=53.357747&lon=-112.637560
+*OldAB14_E http://www.openstreetmap.org/?lat=53.354381&lon=-112.629411
 RR185 http://www.openstreetmap.org/?lat=53.341233&lon=-112.611429
 AB854_S http://www.openstreetmap.org/?lat=53.290086&lon=-112.440849
 AB854_N http://www.openstreetmap.org/?lat=53.283173&lon=-112.416430

--- a/hwy_data/AB/canabs/ab.ab834.wpt
+++ b/hwy_data/AB/canabs/ab.ab834.wpt
@@ -4,5 +4,7 @@ AB26_E http://www.openstreetmap.org/?lat=53.018067&lon=-112.635580
 TR480 http://www.openstreetmap.org/?lat=53.105055&lon=-112.635630
 AB617 http://www.openstreetmap.org/?lat=53.192352&lon=-112.635655
 TR500 http://www.openstreetmap.org/?lat=53.279595&lon=-112.635714
-AB14 http://www.openstreetmap.org/?lat=53.358393&lon=-112.635772
+*OldAB834_S http://www.openstreetmap.org/?lat=53.353335&lon=-112.635803&zoom=19
+AB14 http://www.openstreetmap.org/?lat=53.357747&lon=-112.637560
+*OldAB834_N http://www.openstreetmap.org/?lat=53.361013&lon=-112.635779
 AB626 http://www.openstreetmap.org/?lat=53.366875&lon=-112.635785

--- a/hwy_data/MB/canmb/mb.mb010.wpt
+++ b/hwy_data/MB/canmb/mb.mb010.wpt
@@ -16,6 +16,7 @@ MB349 http://www.openstreetmap.org/?lat=49.739009&lon=-99.961768
 MB110 http://www.openstreetmap.org/?lat=49.802500&lon=-99.961983
 RicAve http://www.openstreetmap.org/?lat=49.827520&lon=-99.961905
 MB1A http://www.openstreetmap.org/?lat=49.842264&lon=-99.961934
+PacAve http://www.openstreetmap.org/?lat=49.849518&lon=-99.961947
 MB459 http://www.openstreetmap.org/?lat=49.863709&lon=-99.961874
 MB1_W http://www.openstreetmap.org/?lat=49.886838&lon=-99.961939
 MB1_E http://www.openstreetmap.org/?lat=49.886869&lon=-99.939054

--- a/hwy_data/NB/cannbc/nb.nb105.wpt
+++ b/hwy_data/NB/cannbc/nb.nb105.wpt
@@ -1,4 +1,3 @@
-*JemRivBri_N http://www.openstreetmap.org/?lat=45.824897&lon=-66.119673
 NB2 http://www.openstreetmap.org/?lat=45.837354&lon=-66.180427
 UGagFry http://www.openstreetmap.org/?lat=45.851817&lon=-66.230051
 NB690 http://www.openstreetmap.org/?lat=45.888789&lon=-66.297530
@@ -14,7 +13,7 @@ GibSt http://www.openstreetmap.org/?lat=45.961876&lon=-66.625146
 UniSt_W http://www.openstreetmap.org/?lat=45.971423&lon=-66.635426
 NB148 http://www.openstreetmap.org/?lat=45.975813&lon=-66.633974
 WesSt http://www.openstreetmap.org/?lat=45.976785&lon=-66.637908
-2NatCro http://www.openstreetmap.org/?lat=45.987836&lon=-66.635765
+TwoNatCro http://www.openstreetmap.org/?lat=45.988015&lon=-66.635701
 BroDr http://www.openstreetmap.org/?lat=45.990268&lon=-66.651874
 NB620 http://www.openstreetmap.org/?lat=45.989631&lon=-66.665152
 SunDr http://www.openstreetmap.org/?lat=45.979227&lon=-66.698469

--- a/hwy_data/NB/cannbc/nb.nb105jem.wpt
+++ b/hwy_data/NB/cannbc/nb.nb105jem.wpt
@@ -10,4 +10,3 @@ ReaRd http://www.openstreetmap.org/?lat=45.853813&lon=-66.070922
 DeanRd http://www.openstreetmap.org/?lat=45.865108&lon=-66.097294
 +x04 http://www.openstreetmap.org/?lat=45.851055&lon=-66.123181
 NB695 http://www.openstreetmap.org/?lat=45.837389&lon=-66.112374
-*JemRivBri_S http://www.openstreetmap.org/?lat=45.828928&lon=-66.113497

--- a/updates.csv
+++ b/updates.csv
@@ -187,6 +187,7 @@ date;region;route;root;description
 2015-07-22;Bulgaria;E80;bgr.e80;Removed from N8 and relocated onto A4 between the former junction between the A3 and N8 east of Generalovo (labeled *N8_GenE) and the junction between the A4 and N8 next to the Turkish border
 2015-07-22;Bulgaria;E80;bgr.e80;Removed from N8 and N76 and relocated onto N5 and A4 between the junction between the N5 and N8 and the junction between the A4 and N76
 2015-07-22;Bulgaria;E85;bgr.e85;Removed from N5 and N8 and relocated onto A4 between the junction between the A4 and N5 and the junction between the A4 and N76
+2022-02-12;(Canada) Alberta;AB 14;ab.ab014;Curve straightened between waypoints *OldAB14_W and *OldAB14_E. Relocated southward.
 2020-10-03;(Canada) Alberta;AB 201 (South Calgary);ab.ab201swc;Route deleted. Merged into Southwest Calgary segment.
 2020-10-03;(Canada) Alberta;AB 201 (Southwest Calgary);ab.ab201swc;Extended counterclockwise along Tsuut'ina Trail from Exit 13 to Exit 9, thence along the former South Calgary segment to AB 2.
 2020-10-02;(Canada) Alberta;AB 63;ab.ab063;Extended northward from a point labeled *OldEnd at 57.261608°, -111.627790° to the end of pavement at 57.396732°, -111.626939°.
@@ -203,6 +204,8 @@ date;region;route;root;description
 2015-08-22;(Canada) Alberta;AB 58;ab.ab058;Removed from 98 Avenue and relocated onto AB35 and a northeastern bypass, between western & eastern closed intersections with 98 Avenue.
 2015-08-13;(Canada) British Columbia;TCH 1 Business (Chase BC);bc.tchbuscha;New route
 2018-03-28;(Canada) Manitoba;MB 17;mb.mb017;North end extended from 150 N to MB 224
+2022-02-12;(Canada) New Brunswick;NB 105 (Jemseg);nb.nb105jen;Truncated from the closed Jemseg River Bridge approach to NB 695.
+2022-02-12;(Canada) New Brunswick;NB 105 (Fredericton);nb.nb105;South end truncated from the closed Jemseg River Bridge approach to NB 2.
 2021-06-17;(Canada) New Brunswick;NB 101;nb.nb101;Extended at south end from Eagle Rock Road to NB 7.
 2021-06-17;(Canada) New Brunswick;NB 177;nb.nb177;North end removed from Eagle Rock Road between the NB 7 Exit 71 connector and NB 7 Exit 63, and relocated onto the connector to NB 7 Exit 71.
 2021-02-09;(Canada) New Brunswick;NB 176;nb.nb176;From a point labeled *OldNB176, south end removed from a northerly road to the old Black's Harbour Ferry Terminal and relocated southwestward toward the new Black's Harbour Ferry Terminal.


### PR DESCRIPTION
* **MB**: Add MB10 PacSt misbehaving parclo.
* **NB**: [Truncate both NB105 routes](https://www.gnb.ca/0113/maps/Mapbooks/maps-2021/map393.pdf).
* **AB**: AB14/384 realignment. Before connecting the two AB834 routes via the Tofield bypass, I've reached out for clarification to the person who added it to OSM.