### PR TITLE
US 9, DE 18, DE 23, and DE 404 Updates

### DIFF
--- a/hwy_data/DE/usade/de.de018.wpt
+++ b/hwy_data/DE/usade/de.de018.wpt
@@ -7,7 +7,6 @@ WesChuRd http://www.openstreetmap.org/?lat=38.707683&lon=-75.627407
 ElksRd http://www.openstreetmap.org/?lat=38.695475&lon=-75.604407
 US13 http://www.openstreetmap.org/?lat=38.699582&lon=-75.589226
 DE404_W http://www.openstreetmap.org/?lat=38.709998&lon=-75.564823
-SanRd http://www.openstreetmap.org/?lat=38.709064&lon=-75.561382
 CovRd http://www.openstreetmap.org/?lat=38.710293&lon=-75.531336
 StaForRd http://www.openstreetmap.org/?lat=38.693645&lon=-75.484196
 VauRd http://www.openstreetmap.org/?lat=38.697715&lon=-75.412669

--- a/hwy_data/DE/usade/de.de023.wpt
+++ b/hwy_data/DE/usade/de.de023.wpt
@@ -6,8 +6,9 @@ DE5/24 http://www.openstreetmap.org/?lat=38.635757&lon=-75.194094
 CanRd http://www.openstreetmap.org/?lat=38.652172&lon=-75.216772
 DE5_N http://www.openstreetmap.org/?lat=38.663338&lon=-75.222603
 HolRd http://www.openstreetmap.org/?lat=38.675409&lon=-75.221712
+StoRd http://www.openstreetmap.org/?lat=38.691799&lon=-75.215994
 HopRd http://www.openstreetmap.org/?lat=38.698701&lon=-75.215591
 FisRd http://www.openstreetmap.org/?lat=38.722743&lon=-75.205321
-DE1D_S  +DE1D/24Alt http://www.openstreetmap.org/?lat=38.746936&lon=-75.175922
+DE1D_S +DE1D/24Alt http://www.openstreetmap.org/?lat=38.746936&lon=-75.175922
 US9/404 http://www.openstreetmap.org/?lat=38.747410&lon=-75.176209
 DE1 http://www.openstreetmap.org/?lat=38.748482&lon=-75.173768

--- a/hwy_data/DE/usade/de.de404.wpt
+++ b/hwy_data/DE/usade/de.de404.wpt
@@ -7,14 +7,13 @@ US13_N http://www.openstreetmap.org/?lat=38.759530&lon=-75.593568
 US13Bus_N http://www.openstreetmap.org/?lat=38.756924&lon=-75.593812
 US13_S http://www.openstreetmap.org/?lat=38.723036&lon=-75.590342
 DE18_W http://www.openstreetmap.org/?lat=38.709998&lon=-75.564823
-SanRd http://www.openstreetmap.org/?lat=38.709064&lon=-75.561382
 CovRd http://www.openstreetmap.org/?lat=38.710293&lon=-75.531336
 StaForRd http://www.openstreetmap.org/?lat=38.693645&lon=-75.484196
 VauRd http://www.openstreetmap.org/?lat=38.697715&lon=-75.412669
 US113 http://www.openstreetmap.org/?lat=38.698506&lon=-75.400779
 BedSt_N http://www.openstreetmap.org/?lat=38.697550&lon=-75.394484
 US9_W http://www.openstreetmap.org/?lat=38.690051&lon=-75.385869
-SandHillRd http://www.openstreetmap.org/?lat=38.699191&lon=-75.368322
+SandHillRd http://www.openstreetmap.org/?lat=38.699352&lon=-75.368029
 US9TrkGeo_E http://www.openstreetmap.org/?lat=38.706471&lon=-75.342734
 DE30 http://www.openstreetmap.org/?lat=38.714198&lon=-75.316671
 DE5 http://www.openstreetmap.org/?lat=38.724852&lon=-75.285651

--- a/hwy_data/DE/usaus/de.us009.wpt
+++ b/hwy_data/DE/usaus/de.us009.wpt
@@ -6,7 +6,7 @@ TynRd http://www.openstreetmap.org/?lat=38.633592&lon=-75.460284
 OldFurRd http://www.openstreetmap.org/?lat=38.652089&lon=-75.430369
 US113 http://www.openstreetmap.org/?lat=38.681961&lon=-75.395911
 DE18/404 +DE404_W http://www.openstreetmap.org/?lat=38.690051&lon=-75.385869
-SandHillRd http://www.openstreetmap.org/?lat=38.699191&lon=-75.368322
+SandHillRd http://www.openstreetmap.org/?lat=38.699352&lon=-75.368029
 US9TrkGeo_E http://www.openstreetmap.org/?lat=38.706471&lon=-75.342734
 DE30 http://www.openstreetmap.org/?lat=38.714198&lon=-75.316671
 DE5 http://www.openstreetmap.org/?lat=38.724852&lon=-75.285651

--- a/updates.csv
+++ b/updates.csv
@@ -4277,6 +4277,7 @@ date;region;route;root;description
 2017-06-07;(USA) Connecticut;CT 2A;ct.ct002a;Relabeled exits from sequential to mileage-based, all numbered exits changed
 2016-02-12;(USA) Connecticut;Milford Parkway;ct.milpkwy;Route added
 2015-12-16;(USA) Connecticut;I-395;ct.i395;Relabeled exits from sequential to mileage-based, all numbers changed
+2022-02-22;(USA) Delaware;DE 23;de.de023;Slightly realigned between Stockley Rd (StoRd) and Hopkins Rd (HopRd) due to roundabout at new Anchors Run Subdivision between these two points.
 2020-06-20;(USA) Delaware;DE 54 Alternate (Bethany Beach);;Route deleted.
 2020-06-20;(USA) Delaware;DE 24 Alternate (Zoar);;Route deleted.
 2019-08-25;(USA) Delaware;DE 34;;Route deleted.
@@ -4286,7 +4287,7 @@ date;region;route;root;description
 2019-02-05;(USA) Delaware;DE 896 Alternate (St Georges);;Route deleted.
 2019-01-12;(USA) Delaware;US 301;de.us301;Route completely realigned onto tolled freeway from MD/DE line to DE 1.  It was removed from Middletown-Warwick Rd and concurrencies with DE 15, DE 299, DE 71, and DE 896 to its former northern terminus at US 40.
 2018-03-26;(USA) Delaware;DE 273;de.de273;East end truncated from 6th St to DE 9/141.
-2018-01-07;(USA) Delaware;DE 16;de.de016;East end extended from DE 1, along Broadkill Rd., to Broadkill Beach
+2018-01-07;(USA) Delaware;DE 16;de.de016;East end extended from DE 1, along Broadkill Rd., to Broadkill Beach.
 2017-12-19;(USA) Delaware;DE 15;de.de015;Removed from a demolished roadway directly connecting waypoints *OldDE15_A and *OldDE15_B, and relocated onto a northwesterly relocation of Wyoming Mill Rd and Hazlettville Rd via an intersection with Westover Dr. Removed from a demolished roadway directly connecting *OldDE15_C and the entrance to Charles E. Price Memorial Park, and relocated eastward via a roundabout at St Annes Church Rd. Removed from a demolished roadway directly connecting waypoints *OldDE15_D and *OldDE15_E, and relocated onto a northwesterly relocation of Levels Rd and Middletown Warwick Rd (US 301).
 2017-12-19;(USA) Delaware;DE 299;de.de299;Removed from a demolished east-west section (approx. 0.1 mi) of Warwick Rd and US 301, and relocated onto a northerly extension of Warwick Rd, parallel to and west of the under-construction US 301 divided freeway, and Levels Rd between a waypoint labelled *OldDE299 and US 301.
 2021-09-22;(USA) Florida;US 221;fl.us221;Removed from Jefferson Street in Perry between the intersections Jefferson Street/Wright Road & Jefferson Street/US 27, and relocated onto a new route following US 27 over to US 19 and then up to Wright Road (former CR 359A) and then back to the original US 221 alignment north of Perry. Old section is now just Jefferson Street.


### PR DESCRIPTION
US 9: Relocated Sand Hill Rd.
DE 18: Removed SanRd.
DE 23.  Added Stockley Rd (StoRd).  (Slightly realigned between Stockley Rd (StoRd) and Hopkins Rd (HopRd) due to roundabout at new Anchors Run Subdivision between these two points.)
DE 404: Removed SanRd and relocated Sand Hill Rd.