### PR TITLE
TX US77BusDri

### DIFF
--- a/hwy_data/TX/usatxf2/tx.fm0665.wpt
+++ b/hwy_data/TX/usatxf2/tx.fm0665.wpt
@@ -4,7 +4,8 @@ FM1931 http://www.openstreetmap.org/?lat=27.729993&lon=-98.040930
 FM1930 http://www.openstreetmap.org/?lat=27.726736&lon=-97.984893
 FM70 http://www.openstreetmap.org/?lat=27.717481&lon=-97.908236
 FM666 http://www.openstreetmap.org/?lat=27.697928&lon=-97.832571
-US77 http://www.openstreetmap.org/?lat=27.674540&lon=-97.748583
+US77Bus http://www.openstreetmap.org/?lat=27.674540&lon=-97.748583
+US77 http://www.openstreetmap.org/?lat=27.672557&lon=-97.741432
 CR75 http://www.openstreetmap.org/?lat=27.664184&lon=-97.711051
 FM892 http://www.openstreetmap.org/?lat=27.672251&lon=-97.668318
 CR69 http://www.openstreetmap.org/?lat=27.672273&lon=-97.652106

--- a/hwy_data/TX/usaus/tx.us077.wpt
+++ b/hwy_data/TX/usaus/tx.us077.wpt
@@ -76,7 +76,9 @@ FM257 http://www.openstreetmap.org/?lat=27.582480&lon=-97.786662
 FM70 http://www.openstreetmap.org/?lat=27.592916&lon=-97.783052
 US77BusKin_N http://www.openstreetmap.org/?lat=27.608048&lon=-97.782789
 FM3354 http://www.openstreetmap.org/?lat=27.621607&lon=-97.776826
-FM665 http://www.openstreetmap.org/?lat=27.674540&lon=-97.748583
+Us77BusDri_S http://www.openstreetmap.org/?lat=27.654673&lon=-97.758563
+FM665 http://www.openstreetmap.org/?lat=27.672557&lon=-97.741432
+US77BusDri_N http://www.openstreetmap.org/?lat=27.700398&lon=-97.731317
 FM2826 http://www.openstreetmap.org/?lat=27.739807&lon=-97.699968
 CR36 http://www.openstreetmap.org/?lat=27.768894&lon=-97.676573
 US77BusRob_S http://www.openstreetmap.org/?lat=27.775553&lon=-97.668406

--- a/hwy_data/TX/usausb/tx.us077busdri.wpt
+++ b/hwy_data/TX/usausb/tx.us077busdri.wpt
@@ -1,0 +1,3 @@
+US77_S http://www.openstreetmap.org/?lat=27.654673&lon=-97.758563
+FM665 http://www.openstreetmap.org/?lat=27.674540&lon=-97.748583
+US77_N http://www.openstreetmap.org/?lat=27.700398&lon=-97.731317

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -634,6 +634,7 @@ usausb;TX;US77;Bus;Bro;Brownsville, TX;tx.us077busbro;
 usausb;TX;US77;Bus;Har;Harlingen, TX;tx.us077bushar;
 usausb;TX;US77;Bus;Ray;Raymondville, TX;tx.us077busray;
 usausb;TX;US77;Bus;Kin;Kingsville, TX;tx.us077buskin;
+usausb;TX;US77;Bus;Dri;Driscoll, TX;tx.us077busdri;
 usausb;TX;US77;Bus;Rob;Robstown, TX;tx.us077busrob;
 usausb;TX;US77;Bus;Sin;Sinton, TX;tx.us077bussin;
 usausb;TX;US77;Bus;Vic;Victoria, TX;tx.us077busvic;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -625,6 +625,7 @@ usausb;US77;Bus;Brownsville, TX;tx.us077busbro
 usausb;US77;Bus;Harlingen, TX;tx.us077bushar
 usausb;US77;Bus;Raymondville, TX;tx.us077busray
 usausb;US77;Bus;Kingsville, TX;tx.us077buskin
+usausb;US77;Bus;Driscoll, TX;tx.us077busdri
 usausb;US77;Bus;Robstown, TX;tx.us077busrob
 usausb;US77;Bus;Sinton, TX;tx.us077bussin
 usausb;US77;Bus;Victoria, TX;tx.us077busvic

--- a/updates.csv
+++ b/updates.csv
@@ -5760,6 +5760,8 @@ date;region;route;root;description
 2015-11-29;(USA) Tennessee;US 641;tn.us641;Extended southward from the former ending intersection with I-40 along TN 69 & TN 114 to a new southern terminus at US 64
 2015-10-25;(USA) Tennessee;I-269;tn.i269;Route added
 2015-10-25;(USA) Tennessee;I-269 Future (Memphis, TN);tn.i269futmem;Extended southward from the interchange with TN 57 to a newly opened interchange with I-269 (Exit 2)
+2022-02-24;(USA) Texas;US 77;tx.us077;Removed from US 77 Business (Driscoll) and relocated eastward onto the Driscoll Bypass.
+2022-02-24;(USA) Texas;US 77 Business (Driscoll);tx.us077busdri;Route added.
 2022-02-21;(USA) Texas;I-35;tx.i035;Extended southward from US 83 / TX 359 to Hidalgo St.
 2022-02-10;(USA) Texas;US 290 Business (Cypress);tx.us290buscyp;Route added.
 2022-02-10;(USA) Texas;TX Loop 354;;Route deleted.


### PR DESCRIPTION
Northbound US77 has been on the bypass since November, with the NB ramp to US77Bus [reported open](https://www.aaroads.com/forum/index.php?topic=3624.msg2699727#msg2699727) in January.
Don't know about the current southbound situation, but figure this is far enough along to make the change.
Hopefully, [the project will be completed in April](https://www.zachryconstructioncorp.com/Projects/Transportation/US-77-Driscoll-Bypass/) and we can have an I-69 extension then.

**This update affects:**
@TXStormchaser @bejacob @Duke87ofST @mrpoodlepants @jonfmorse @mapcat @ovoss @ryangentry @ua747sp