### PR TITLE
US 66 Historic (Chicago): Fixing I-55BL/IL 29 Broken Concurrency.

### DIFF
--- a/hwy_data/IL/usaush/il.us066hischi.wpt
+++ b/hwy_data/IL/usaush/il.us066hischi.wpt
@@ -8,7 +8,7 @@ IL157_S http://www.openstreetmap.org/?lat=38.761780&lon=-90.009227
 +157X01 http://www.openstreetmap.org/?lat=38.781421&lon=-89.979143
 +157X02 http://www.openstreetmap.org/?lat=38.801156&lon=-89.975624
 IL143/159 http://www.openstreetmap.org/?lat=38.811341&lon=-89.955776
-BucSt +IL159_S http://www.openstreetmap.org/?lat=38.811791&lon=-89.953051
+BucSt http://www.openstreetmap.org/?lat=38.811791&lon=-89.953051
 IL143_E http://www.openstreetmap.org/?lat=38.812727&lon=-89.947300
 +157X03 http://www.openstreetmap.org/?lat=38.827071&lon=-89.941077
 +157X04 http://www.openstreetmap.org/?lat=38.834927&lon=-89.910479
@@ -52,7 +52,7 @@ CookSt_W http://www.openstreetmap.org/?lat=39.794392&lon=-89.648695
 CookSt_E http://www.openstreetmap.org/?lat=39.794339&lon=-89.643752
 CapAve http://www.openstreetmap.org/?lat=39.798184&lon=-89.643674
 IL97 http://www.openstreetmap.org/?lat=39.803294&lon=-89.643159
-IL29_S http://www.openstreetmap.org/?lat=39.830818&lon=-89.636078
+IL29_S http://www.openstreetmap.org/?lat=39.831004&lon=-89.636469
 IL4/29 http://www.openstreetmap.org/?lat=39.845482&lon=-89.632645
 DirPky http://www.openstreetmap.org/?lat=39.857376&lon=-89.615178
 IL124 http://www.openstreetmap.org/?lat=39.896041&lon=-89.601789


### PR DESCRIPTION
Fix from https://github.com/TravelMapping/HighwayData/pull/5657

Side note: DirPky should be changed to DirPkwy on I-55BL and US66HisChi