### PR TITLE
CT additions & fixes

### DIFF
--- a/hwy_data/CT/usact/ct.ct017.wpt
+++ b/hwy_data/CT/usact/ct.ct017.wpt
@@ -15,8 +15,10 @@ MainStExt http://www.openstreetmap.org/?lat=41.553937&lon=-72.645008
 CT9(13) http://www.openstreetmap.org/?lat=41.556408&lon=-72.642412
 CT9(14) http://www.openstreetmap.org/?lat=41.560639&lon=-72.646129
 CT9(15) http://www.openstreetmap.org/?lat=41.563300&lon=-72.647921
-CT66_W http://www.openstreetmap.org/?lat=41.562327&lon=-72.650979
-HarAve http://www.openstreetmap.org/?lat=41.566048&lon=-72.653167
+CT9(16) http://www.openstreetmap.org/?lat=41.567860&lon=-72.650582
+CT66_W +HarAve http://www.openstreetmap.org/?lat=41.566048&lon=-72.653167
++X111324 http://www.openstreetmap.org/?lat=41.567280&lon=-72.654423
+LowMainSt http://www.openstreetmap.org/?lat=41.571291&lon=-72.642009
 CT17A_S http://www.openstreetmap.org/?lat=41.573195&lon=-72.640577
 AirAve http://www.openstreetmap.org/?lat=41.569130&lon=-72.631050
 CT66_E http://www.openstreetmap.org/?lat=41.575627&lon=-72.606411

--- a/hwy_data/CT/usact/ct.ct066.wpt
+++ b/hwy_data/CT/usact/ct.ct066.wpt
@@ -5,8 +5,10 @@ CT147 http://www.openstreetmap.org/?lat=41.534585&lon=-72.731262
 CT217 http://www.openstreetmap.org/?lat=41.547478&lon=-72.700766
 CT157 http://www.openstreetmap.org/?lat=41.554909&lon=-72.673450
 CT3 http://www.openstreetmap.org/?lat=41.558955&lon=-72.661166
-CT17_S http://www.openstreetmap.org/?lat=41.562327&lon=-72.650979
-HarAve http://www.openstreetmap.org/?lat=41.566048&lon=-72.653167
+WasSt_E http://www.openstreetmap.org/?lat=41.562327&lon=-72.650979
+CT17_S +HarAve http://www.openstreetmap.org/?lat=41.566048&lon=-72.653167
++X111324 http://www.openstreetmap.org/?lat=41.567280&lon=-72.654423
+LowMainSt http://www.openstreetmap.org/?lat=41.571291&lon=-72.642009
 CT17A http://www.openstreetmap.org/?lat=41.573195&lon=-72.640577
 AirAve http://www.openstreetmap.org/?lat=41.569130&lon=-72.631050
 CT17_N http://www.openstreetmap.org/?lat=41.575627&lon=-72.606411

--- a/hwy_data/CT/usact/ct.ct068.wpt
+++ b/hwy_data/CT/usact/ct.ct068.wpt
@@ -1,4 +1,5 @@
 CT63 http://www.openstreetmap.org/?lat=41.499383&lon=-73.055139
+UniSt http://www.openstreetmap.org/?lat=41.501969&lon=-73.045794
 UniCityRd http://www.openstreetmap.org/?lat=41.505651&lon=-73.031568
 CT69 http://www.openstreetmap.org/?lat=41.502642&lon=-72.979082
 CookRd http://www.openstreetmap.org/?lat=41.498716&lon=-72.955897

--- a/hwy_data/CT/usact/ct.ct073.wpt
+++ b/hwy_data/CT/usact/ct.ct073.wpt
@@ -1,3 +1,4 @@
 CT63 http://www.openstreetmap.org/?lat=41.590923&lon=-73.106343
 BucSt http://www.openstreetmap.org/?lat=41.587176&lon=-73.084407
+AurSt http://www.openstreetmap.org/?lat=41.571022&lon=-73.060187
 CT8 http://www.openstreetmap.org/?lat=41.566347&lon=-73.058116

--- a/hwy_data/CT/usact/ct.ct157.wpt
+++ b/hwy_data/CT/usact/ct.ct157.wpt
@@ -1,4 +1,6 @@
 CT68 http://www.openstreetmap.org/?lat=41.474613&lon=-72.727309
 CT147_S http://www.openstreetmap.org/?lat=41.500006&lon=-72.715706
 CT147_N http://www.openstreetmap.org/?lat=41.508877&lon=-72.715818
+JacHillRd http://www.openstreetmap.org/?lat=41.515890&lon=-72.712294
+WadSt http://www.openstreetmap.org/?lat=41.537848&lon=-72.683862
 CT66 http://www.openstreetmap.org/?lat=41.554909&lon=-72.673450

--- a/hwy_data/CT/usaus/ct.us005.wpt
+++ b/hwy_data/CT/usaus/ct.us005.wpt
@@ -17,6 +17,7 @@ CT71 http://www.openstreetmap.org/?lat=41.498131&lon=-72.809914
 CT150_N http://www.openstreetmap.org/?lat=41.505106&lon=-72.810345
 EMainSt http://www.openstreetmap.org/?lat=41.533696&lon=-72.792138
 I-691 http://www.openstreetmap.org/?lat=41.542794&lon=-72.785685
+BriSt http://www.openstreetmap.org/?lat=41.548279&lon=-72.782257
 CT15_S +CT15_Mer http://www.openstreetmap.org/?lat=41.562417&lon=-72.775369
 NColSt http://www.openstreetmap.org/?lat=41.577867&lon=-72.767644
 SprBroRd http://www.openstreetmap.org/?lat=41.599444&lon=-72.753975

--- a/updates.csv
+++ b/updates.csv
@@ -4265,6 +4265,7 @@ date;region;route;root;description
 2015-08-03;(USA) Colorado;Northwest Parkway;co.nwpkwy;New Route
 2015-08-03;(USA) Colorado;Pena Boulevard;co.penablvd;New Route
 2015-08-03;(USA) Colorado;US 287 Business (Berthoud);;Route deleted
+2022-04-11;(USA) Connecticut;CT 17;ct.ct017;Corrected to follow Saint John's Square instead of Washington Street between CT 9 and CT 66.
 2021-02-08;(USA) Connecticut;CT 148;ct.ct148;Split into two segments at the Chester-Hadlyme Ferry.
 2021-02-08;(USA) Connecticut;CT 148 (Lyme);ct.ct148lym;Route added.
 2021-02-08;(USA) Connecticut;CT 160;ct.ct160;Split into two segments at the Rocky Hill-Glastonbury Ferry.


### PR DESCRIPTION
[CT: US 5, CT 73, and CT 157 Point Requests](https://forum.travelmapping.net/index.php?topic=4878)
[CT 17 in Middletown](https://forum.travelmapping.net/index.php?topic=4879)

This fixes the routing of CT17 in Middletown to follow Saint John's Square instead of Washington Street between CT 9 and CT 66.

It relocates the `CT CT17 CT66_W` point in use by:
@dave1693 @neilbert @ua747sp

and the `CT CT66 CT17_S` point in use by:
@bejacob @dave1693 @dgolub @njroadhorse @USRoute220