### PR TITLE
Update vt.vt074.wpt

### DIFF
--- a/hwy_data/VT/usavt/vt.vt074.wpt
+++ b/hwy_data/VT/usavt/vt.vt074.wpt
@@ -1,4 +1,4 @@
-NY/VT http://www.openstreetmap.org/?lat=43.855303&lon=-73.376527
+TicFry +NY/VT http://www.openstreetmap.org/?lat=43.855303&lon=-73.376527
 VT73 http://www.openstreetmap.org/?lat=43.856541&lon=-73.366967
 BarHillRd http://www.openstreetmap.org/?lat=43.855864&lon=-73.354109
 HemHillRd http://www.openstreetmap.org/?lat=43.870588&lon=-73.333944


### PR DESCRIPTION
Label change to the Ticonderoga Ferry to match NY 74.