### PR TITLE
CA 58 updates

### DIFF
--- a/hwy_data/CA/usaca/ca.ca058.wpt
+++ b/hwy_data/CA/usaca/ca.ca058.wpt
@@ -34,7 +34,7 @@ CA33_N http://www.openstreetmap.org/?lat=35.308366&lon=-119.622241
 +x29 http://www.openstreetmap.org/?lat=35.349256&lon=-119.601030
 LokRd http://www.openstreetmap.org/?lat=35.398220&lon=-119.536502
 WasWay http://www.openstreetmap.org/?lat=35.399090&lon=-119.447640
-I-5 http://www.openstreetmap.org/?lat=35.398872&lon=-119.397353
+I-5(257) +I-5 http://www.openstreetmap.org/?lat=35.398872&lon=-119.397353
 CA43_N http://www.openstreetmap.org/?lat=35.398056&lon=-119.252075
 CA43_S http://www.openstreetmap.org/?lat=35.383484&lon=-119.252129
 NordAve http://www.openstreetmap.org/?lat=35.383461&lon=-119.198796

--- a/hwy_data/CA/usaca/ca.ca058wes.wpt
+++ b/hwy_data/CA/usaca/ca.ca058wes.wpt
@@ -1,4 +1,6 @@
-StoHwy http://www.openstreetmap.org/?lat=35.355272&lon=-119.175514
+I-5(253) http://www.openstreetmap.org/?lat=35.354944&lon=-119.336007
+CA43 http://www.openstreetmap.org/?lat=35.354362&lon=-119.252123
+StoHwy_E +StoHwy http://www.openstreetmap.org/?lat=35.355272&lon=-119.175514
 AllRd http://www.openstreetmap.org/?lat=35.361053&lon=-119.145522
 CalDr http://www.openstreetmap.org/?lat=35.361921&lon=-119.115950
 CofRd http://www.openstreetmap.org/?lat=35.366989&lon=-119.092100


### PR DESCRIPTION
Extends CA 58 (Westside Pkwy) west to I-5 over Stockdale Hwy; relabel of main CA 58 route's I-5 waypoint, ahead of planned 2023 switch of main route from Rosedale Hwy to Stockdale Hwy/Westside Pkwy corridor.

No Updates item needed, since usaca is a preview system.

Datacheck successful.