### PR TITLE
US 30:  GreRd_A>-TolHillRd.  GreRd_B>-GreRd.

### DIFF
--- a/hwy_data/PA/usaus/pa.us030.wpt
+++ b/hwy_data/PA/usaus/pa.us030.wpt
@@ -64,7 +64,7 @@ EdnaRd http://www.openstreetmap.org/?lat=40.310123&lon=-79.656627
 LowAve http://www.openstreetmap.org/?lat=40.310740&lon=-79.619258
 AgnRd http://www.openstreetmap.org/?lat=40.310591&lon=-79.601199
 PA66 http://www.openstreetmap.org/?lat=40.307822&lon=-79.596360
-GreRd_A http://www.openstreetmap.org/?lat=40.306519&lon=-79.575037
+TolHillRd http://www.openstreetmap.org/?lat=40.306519&lon=-79.575037
 +X01AB http://www.openstreetmap.org/?lat=40.307793&lon=-79.568720
 PitSt_W http://www.openstreetmap.org/?lat=40.303702&lon=-79.563114
 PA136 http://www.openstreetmap.org/?lat=40.296651&lon=-79.557951
@@ -205,7 +205,7 @@ US222/272 http://www.openstreetmap.org/?lat=40.068398&lon=-76.303066
 US222_N http://www.openstreetmap.org/?lat=40.067253&lon=-76.288118
 PA23_E http://www.openstreetmap.org/?lat=40.060353&lon=-76.277223
 PA23_W http://www.openstreetmap.org/?lat=40.055042&lon=-76.267758
-GreRd_B +GreRd http://www.openstreetmap.org/?lat=40.050121&lon=-76.256018
+GreRd +GreRd_B http://www.openstreetmap.org/?lat=40.050121&lon=-76.256018
 PA340_W http://www.openstreetmap.org/?lat=40.040378&lon=-76.245670
 PA462_E http://www.openstreetmap.org/?lat=40.032159&lon=-76.240737
 PA896 http://www.openstreetmap.org/?lat=40.022453&lon=-76.192911


### PR DESCRIPTION
Since TolHillRd (https://www.google.com/maps/@40.3063778,-79.5751976,3a,75y,89.82h,84.87t/data=!3m6!1e1!3m4!1soWIkob1zIZdxqjtYB64vbg!2e0!7i16384!8i8192) can be used in place of GreRd_A, I thought it was best to change GreRd_B back to GreRd.