### PR TITLE
CA 47 minor revisions

### DIFF
--- a/hwy_data/CA/usaca/ca.ca047.wpt
+++ b/hwy_data/CA/usaca/ca.ca047.wpt
@@ -1,7 +1,7 @@
 1A http://www.openstreetmap.org/?lat=33.748847&lon=-118.290911
 1C http://www.openstreetmap.org/?lat=33.749567&lon=-118.281062
-FerSt http://www.openstreetmap.org/?lat=33.748960&lon=-118.263048
+1B http://www.openstreetmap.org/?lat=33.748960&lon=-118.263048
 NavyWay http://www.openstreetmap.org/?lat=33.753969&lon=-118.251755
 I-710 +SeaFwy_E http://www.openstreetmap.org/?lat=33.758460&lon=-118.238520
 4 http://www.openstreetmap.org/?lat=33.761172&lon=-118.238945
-CA103 http://www.openstreetmap.org/?lat=33.774652&lon=-118.240120
+5 +CA103 http://www.openstreetmap.org/?lat=33.774652&lon=-118.240120


### PR DESCRIPTION
Includes exit number relabels (labels in use preserved) discussed on forum. Does not include extending CA 47 west of I-110.

Datacheck successful.