### PR TITLE
US 30: Realigned east of WV/PA and west of PA 168 between *OldUS30_A and *OldUS30_B.

### DIFF
--- a/hwy_data/PA/usapa/pa.pa420.wpt
+++ b/hwy_data/PA/usapa/pa.pa420.wpt
@@ -1,7 +1,7 @@
 PA291 http://www.openstreetmap.org/?lat=39.866709&lon=-75.300674
 I-95 http://www.openstreetmap.org/?lat=39.870881&lon=-75.301301
 US13 http://www.openstreetmap.org/?lat=39.882497&lon=-75.306033
-MacBlvd  +PA420AltTrkRid_S http://www.openstreetmap.org/?lat=39.895841&lon=-75.315219
+MacBlvd +PA420AltTrkRid_S http://www.openstreetmap.org/?lat=39.895841&lon=-75.315219
 PA420AltTrkPro_N http://www.openstreetmap.org/?lat=39.908162&lon=-75.327458
-BalPike +BalPk http://www.openstreetmap.org/?lat=39.916937&lon=-75.333485
+BalPike http://www.openstreetmap.org/?lat=39.916937&lon=-75.333485
 PA320 http://www.openstreetmap.org/?lat=39.933867&lon=-75.352360

--- a/hwy_data/PA/usaus/pa.us030.wpt
+++ b/hwy_data/PA/usaus/pa.us030.wpt
@@ -1,4 +1,6 @@
 WV/PA http://www.openstreetmap.org/?lat=40.592267&lon=-80.519008
+*OldUS30_A http://www.openstreetmap.org/?lat=40.592399&lon=-80.510959
+*OldUS30_B http://www.openstreetmap.org/?lat=40.588019&lon=-80.498070
 PA168 http://www.openstreetmap.org/?lat=40.579163&lon=-80.481299
 PitGraRd http://www.openstreetmap.org/?lat=40.582726&lon=-80.464176
 PA151 http://www.openstreetmap.org/?lat=40.569139&lon=-80.444837
@@ -162,7 +164,7 @@ PA997_N http://www.openstreetmap.org/?lat=39.906076&lon=-77.518617
 PA233 http://www.openstreetmap.org/?lat=39.906368&lon=-77.478024
 PA234 http://www.openstreetmap.org/?lat=39.897578&lon=-77.425675
 CasRd http://www.openstreetmap.org/?lat=39.893759&lon=-77.355549
-OldUS30 +OldRt30 http://www.openstreetmap.org/?lat=39.866964&lon=-77.318146
+OldUS30_C +OldRt30 +OldUS30 http://www.openstreetmap.org/?lat=39.866964&lon=-77.318146
 SemRidRd http://www.openstreetmap.org/?lat=39.834625&lon=-77.244827
 US15Bus http://www.openstreetmap.org/?lat=39.830917&lon=-77.231140
 PA116_E http://www.openstreetmap.org/?lat=39.830960&lon=-77.226774

--- a/updates.csv
+++ b/updates.csv
@@ -5930,6 +5930,7 @@ date;region;route;root;description
 2017-09-06;(USA) Oregon;OR 99;or.or099;Restored route from I-5 onto Yoncalla-Drain routing.
 2017-09-06;(USA) Oregon;OR 99W;or.or099w;Truncated route from I-5(306) to I-5(294) to reflect signage and prepare for Oregon Highways dataset.
 2017-09-06;(USA) Oregon;OR 126;or.or126;Moved route from Bus 97 to US 97 in Redmond.
+2022-10-04;(USA) Pennsylvania;US 30;pa.us030;Realigned east of WV/PA and PA 168 between *OldUS30_A and *OldUS30_B.
 2022-08-28;(USA) Pennsylvania;Betsy Ross Bridge;pa.betrossbri;Extended west from I-95 to Adams Ave/Aramingo Ave along the Aramingo Ave Connector.
 2022-07-07;(USA) Pennsylvania;PA 405;pa.pa405;Extended south from its previous end at the old alignment of PA 147 (now *OldPA147) to follow the old alignment of PA 147 south to PA 61 in Sunbury.
 2022-07-07;(USA) Pennsylvania;PA 147;pa.pa147;Realigned between PA61_S and *OldPA147 to follow PA 61, US 15, and the newly opened northern section of the Central Susquehanna Valley Thruway (CSVT).  The old routing is now just PA 61 to Sunbury, and an extended PA 405 north of there.

--- a/updates.csv
+++ b/updates.csv
@@ -5930,7 +5930,7 @@ date;region;route;root;description
 2017-09-06;(USA) Oregon;OR 99;or.or099;Restored route from I-5 onto Yoncalla-Drain routing.
 2017-09-06;(USA) Oregon;OR 99W;or.or099w;Truncated route from I-5(306) to I-5(294) to reflect signage and prepare for Oregon Highways dataset.
 2017-09-06;(USA) Oregon;OR 126;or.or126;Moved route from Bus 97 to US 97 in Redmond.
-2022-10-04;(USA) Pennsylvania;US 30;pa.us030;Realigned east of WV/PA and PA 168 between *OldUS30_A and *OldUS30_B.
+2022-10-04;(USA) Pennsylvania;US 30;pa.us030;Realigned east of WV/PA and west of PA 168 between *OldUS30_A and *OldUS30_B.
 2022-08-28;(USA) Pennsylvania;Betsy Ross Bridge;pa.betrossbri;Extended west from I-95 to Adams Ave/Aramingo Ave along the Aramingo Ave Connector.
 2022-07-07;(USA) Pennsylvania;PA 405;pa.pa405;Extended south from its previous end at the old alignment of PA 147 (now *OldPA147) to follow the old alignment of PA 147 south to PA 61 in Sunbury.
 2022-07-07;(USA) Pennsylvania;PA 147;pa.pa147;Realigned between PA61_S and *OldPA147 to follow PA 61, US 15, and the newly opened northern section of the Central Susquehanna Valley Thruway (CSVT).  The old routing is now just PA 61 to Sunbury, and an extended PA 405 north of there.


### PR DESCRIPTION
https://forum.travelmapping.net/index.php?topic=5213.0

Also removed unused alternate label on PA 420.