### PR TITLE
fl.fl417: used correct old exit number for closed FL-408 ramps

### DIFF
--- a/hwy_data/FL/usafl/fl.fl417.wpt
+++ b/hwy_data/FL/usafl/fl.fl417.wpt
@@ -21,7 +21,7 @@ I-4 http://www.openstreetmap.org/?lat=28.317397&lon=-81.559775
 30 http://www.openstreetmap.org/?lat=28.510078&lon=-81.247922
 +X004(FL417) http://www.openstreetmap.org/?lat=28.540596&lon=-81.251783
 33 http://www.openstreetmap.org/?lat=28.547403&lon=-81.258010
-*OldFL408 http://www.openstreetmap.org/?lat=28.558742&lon=-81.268294
+*33B http://www.openstreetmap.org/?lat=28.558742&lon=-81.268294
 34 http://www.openstreetmap.org/?lat=28.568368&lon=-81.266159
 37 http://www.openstreetmap.org/?lat=28.597329&lon=-81.249910
 +X006(FL417) http://www.openstreetmap.org/?lat=28.609343&lon=-81.257919


### PR DESCRIPTION
Forgot this 'ramp' had it's own exit number in the past.  Corrected this since nobody is using it yet at least.

https://forum.travelmapping.net/index.php?topic=5264.msg29722#msg29722