### PR TITLE
I-80/US 220:  Added Exit 163.

### DIFF
--- a/hwy_data/PA/usai/pa.i080.wpt
+++ b/hwy_data/PA/usai/pa.i080.wpt
@@ -64,7 +64,7 @@ OH/PA +0 http://www.openstreetmap.org/?lat=41.184734&lon=-80.519158
 +X09A http://www.openstreetmap.org/?lat=40.965285&lon=-77.786164
 158 http://www.openstreetmap.org/?lat=40.955854&lon=-77.769599
 161 http://www.openstreetmap.org/?lat=40.944833&lon=-77.720160
-+X(163) http://www.openstreetmap.org/?lat=40.961694&lon=-77.670379
+163 http://www.openstreetmap.org/?lat=40.961694&lon=-77.670379
 +X113 http://www.openstreetmap.org/?lat=40.970437&lon=-77.638321
 +X114 http://www.openstreetmap.org/?lat=41.017022&lon=-77.582788
 173 http://www.openstreetmap.org/?lat=41.031127&lon=-77.519207

--- a/hwy_data/PA/usapa/pa.pa026.wpt
+++ b/hwy_data/PA/usapa/pa.pa026.wpt
@@ -93,8 +93,8 @@ I-99(81) http://www.openstreetmap.org/?lat=40.889526&lon=-77.732735
 I-99(83) http://www.openstreetmap.org/?lat=40.915312&lon=-77.741618
 MusLn http://www.openstreetmap.org/?lat=40.938460&lon=-77.730723
 JacRd_S http://www.openstreetmap.org/?lat=40.940046&lon=-77.728966
-I-80 http://www.openstreetmap.org/?lat=40.944833&lon=-77.720160
-+X(I-80)) http://www.openstreetmap.org/?lat=40.967373&lon=-77.674979
+I-80(161) +I-80 http://www.openstreetmap.org/?lat=40.944833&lon=-77.720160
+I-80(163) http://www.openstreetmap.org/?lat=40.967373&lon=-77.674979
 JacRd_N http://www.openstreetmap.org/?lat=40.988337&lon=-77.638275
 +X6 http://www.openstreetmap.org/?lat=40.989819&lon=-77.642484
 SlaRd http://www.openstreetmap.org/?lat=40.996656&lon=-77.640735

--- a/hwy_data/PA/usaus/pa.us220.wpt
+++ b/hwy_data/PA/usaus/pa.us220.wpt
@@ -51,7 +51,7 @@ I-99(83) http://www.openstreetmap.org/?lat=40.915312&lon=-77.741618
 MusLn http://www.openstreetmap.org/?lat=40.938460&lon=-77.730723
 JacRd_S http://www.openstreetmap.org/?lat=40.940046&lon=-77.728966
 I-80(161) http://www.openstreetmap.org/?lat=40.944833&lon=-77.720160
-+X(I-80(163)) http://www.openstreetmap.org/?lat=40.961694&lon=-77.670379
+I-80(163) http://www.openstreetmap.org/?lat=40.961694&lon=-77.670379
 +X113 http://www.openstreetmap.org/?lat=40.970437&lon=-77.638321
 +X114 http://www.openstreetmap.org/?lat=41.017022&lon=-77.582788
 I-80(173) http://www.openstreetmap.org/?lat=41.031127&lon=-77.519207


### PR DESCRIPTION
https://forum.travelmapping.net/index.php?topic=5280.0

PA 26 will need to be checked for a future recentering.

On a more serious note, when PA 26 is presumably rerouted off of Jacksonville Rd during the I-80/I-99 interchange project, I am going to have to deal with a label nightmare.  Why PennDOT did not just reroute PA 26 onto I-80 and the Jacksonville Rd connector now from Exit 163 is beyond my brain.