### PR TITLE
AR161Nor -> AR161Jac; trunc S

### DIFF
--- a/hwy_data/AR/usaar/ar.ar161jac.wpt
+++ b/hwy_data/AR/usaar/ar.ar161jac.wpt
@@ -1,7 +1,3 @@
-US70 http://www.openstreetmap.org/?lat=34.766938&lon=-92.199470
-I-40 http://www.openstreetmap.org/?lat=34.778831&lon=-92.203488
-FaiDr http://www.openstreetmap.org/?lat=34.788653&lon=-92.200836
-TraRd http://www.openstreetmap.org/?lat=34.811956&lon=-92.175903
 AR440 http://www.openstreetmap.org/?lat=34.823985&lon=-92.151647
 AR294 http://www.openstreetmap.org/?lat=34.852505&lon=-92.115783
 2ndSt http://www.openstreetmap.org/?lat=34.867713&lon=-92.109732

--- a/hwy_data/AR/usaus/ar.us070.wpt
+++ b/hwy_data/AR/usaus/ar.us070.wpt
@@ -63,7 +63,7 @@ AR365_N http://www.openstreetmap.org/?lat=34.756511&lon=-92.273569
 MainSt +MainSt_Lit http://www.openstreetmap.org/?lat=34.756140&lon=-92.268462
 I-30(141B) +US70_E http://www.openstreetmap.org/?lat=34.755978&lon=-92.262363
 US165 http://www.openstreetmap.org/?lat=34.754342&lon=-92.220697
-AR161 http://www.openstreetmap.org/?lat=34.766938&lon=-92.199470
+JacHwy http://www.openstreetmap.org/?lat=34.766938&lon=-92.199470
 I-440 http://www.openstreetmap.org/?lat=34.771018&lon=-92.161860
 AR391_N http://www.openstreetmap.org/?lat=34.777831&lon=-92.128708
 AR391_S http://www.openstreetmap.org/?lat=34.777602&lon=-92.128193

--- a/hwy_data/_systems/usaar.csv
+++ b/hwy_data/_systems/usaar.csv
@@ -335,7 +335,7 @@ usaar;AR;AR160;;Sma;Smackover;ar.ar160sma;
 usaar;AR;AR160;;Her;Hermitage;ar.ar160her;
 usaar;AR;AR160;;Por;Portland;ar.ar160por;
 usaar;AR;AR161;;;England;ar.ar161;
-usaar;AR;AR161;;Nor;North Little Rock;ar.ar161nor;
+usaar;AR;AR161;;Jac;Jacksonville;ar.ar161jac;AR161Nor
 usaar;AR;AR162;;Ced;Cedarville;ar.ar162ced;
 usaar;AR;AR162;;;Van Buren;ar.ar162;
 usaar;AR;AR163;;;;ar.ar163;

--- a/hwy_data/_systems/usaar_con.csv
+++ b/hwy_data/_systems/usaar_con.csv
@@ -334,7 +334,7 @@ usaar;AR160;;Smackover;ar.ar160sma
 usaar;AR160;;Hermitage;ar.ar160her
 usaar;AR160;;Portland;ar.ar160por
 usaar;AR161;;England;ar.ar161
-usaar;AR161;;North Little Rock;ar.ar161nor
+usaar;AR161;;Jacksonville;ar.ar161jac
 usaar;AR162;;Cedarville;ar.ar162ced
 usaar;AR162;;Van Buren;ar.ar162
 usaar;AR163;;;ar.ar163

--- a/updates.csv
+++ b/updates.csv
@@ -4499,6 +4499,7 @@ date;region;route;root;description
 2017-05-17;(USA) Arizona;Sky Harbor Boulevard;az.skyharblvd;New Route
 2015-08-03;(USA) Arizona;I-11 Future (Hoover Dam);az.i011futhoo;New Route
 2015-08-03;(USA) Arizona;I-11 Future (Kingman);az.i011futkin;New Route
+2022-12-04;(USA) Arkansas;AR 161 (North Little Rock);ar.ar161jac;South end truncated from US 70 to AR 440. Renamed to AR 161 (Jacksonville).
 2022-07-17;(USA) Arkansas;US 63 Business (Pine Bluff);ar.ar463pin;Renamed AR 463 (Pine Bluff).
 2022-05-24;(USA) Arkansas;US 70;ar.us070;Removed from I-30 between exits 129 & 141B and relocated onto I-430, former AR 5 on Stagecoach Rd & Colonel Glenn Rd, and former US 70 Business on Asher Ave, Roosevelt Rd, Broadway St, W Broadway St & E Broadway St.
 2022-05-24;(USA) Arkansas;US 70 Business (Little Rock);ar.us070;Route deleted. University Ave no longer part of State Highway System. Portion north of University Ave now included as part of mainline US 70.


### PR DESCRIPTION
Ping @mapcat
https://www.ardot.gov/wp-content/uploads/2021/03/Admin-Cir.-2021-02-Minutes-of-the-Dec.-9-AHC-Meeting.pdf
Technically, it's truncated to the Jacksonville city limits, but that's close to the AR440 interchange and it's only signed N from there.