### PR TITLE
TX211 new segment

### DIFF
--- a/hwy_data/TX/usatx/tx.tx211.wpt
+++ b/hwy_data/TX/usatx/tx.tx211.wpt
@@ -1,2 +1,7 @@
 US90 http://www.openstreetmap.org/?lat=29.374822&lon=-98.765138
 FM1957 http://www.openstreetmap.org/?lat=29.421278&lon=-98.782631
++X626266 http://www.openstreetmap.org/?lat=29.467308&lon=-98.808227
+FM471 http://www.openstreetmap.org/?lat=29.522744&lon=-98.805848
++X600240 http://www.openstreetmap.org/?lat=29.532999&lon=-98.810188
+TobTrl http://www.openstreetmap.org/?lat=29.602370&lon=-98.777856
+TX16 http://www.openstreetmap.org/?lat=29.618470&lon=-98.785061

--- a/hwy_data/TX/usatx/tx.tx211gov.wpt
+++ b/hwy_data/TX/usatx/tx.tx211gov.wpt
@@ -1,4 +1,0 @@
-FM471 http://www.openstreetmap.org/?lat=29.522744&lon=-98.805848
-+X600240 http://www.openstreetmap.org/?lat=29.532999&lon=-98.810188
-TobTrl http://www.openstreetmap.org/?lat=29.602370&lon=-98.777856
-TX16 http://www.openstreetmap.org/?lat=29.618470&lon=-98.785061

--- a/hwy_data/_systems/usatx.csv
+++ b/hwy_data/_systems/usatx.csv
@@ -231,8 +231,7 @@ usatx;TX;TX206;;;;tx.tx206;
 usatx;TX;TX207;;;;tx.tx207;
 usatx;TX;TX208;;;;tx.tx208;
 usatx;TX;TX208;Bus;Col;Colorado City;tx.tx208buscol;
-usatx;TX;TX211;;;;tx.tx211;
-usatx;TX;TX211;;Gov;Government Canyon;tx.tx211gov;
+usatx;TX;TX211;;;;tx.tx211;TX211Gov
 usatx;TX;TX213;;;;tx.tx213;
 usatx;TX;TX214;;;;tx.tx214;
 usatx;TX;TX214;Bus;Fri;Friona;tx.tx214busfri;

--- a/hwy_data/_systems/usatx_con.csv
+++ b/hwy_data/_systems/usatx_con.csv
@@ -231,8 +231,7 @@ usatx;TX206;;;tx.tx206
 usatx;TX207;;;tx.tx207
 usatx;TX208;;;tx.tx208
 usatx;TX208;Bus;Colorado City;tx.tx208buscol
-usatx;TX211;;(Main);tx.tx211
-usatx;TX211;;Government Canyon;tx.tx211gov
+usatx;TX211;;;tx.tx211
 usatx;TX213;;;tx.tx213
 usatx;TX214;;;tx.tx214
 usatx;TX214;Bus;Friona;tx.tx214busfri

--- a/updates.csv
+++ b/updates.csv
@@ -6263,6 +6263,8 @@ date;region;route;root;description
 2015-11-29;(USA) Tennessee;US 641;tn.us641;Extended southward from the former ending intersection with I-40 along TN 69 & TN 114 to a new southern terminus at US 64
 2015-10-25;(USA) Tennessee;I-269;tn.i269;Route added
 2015-10-25;(USA) Tennessee;I-269 Future (Memphis, TN);tn.i269futmem;Extended southward from the interchange with TN 57 to a newly opened interchange with I-269 (Exit 2)
+2022-12-04;(USA) Texas;TX 211;tx.tx211;Extended northward from FM 1957 to FM 471, then over the former Government Canyon segment to TX 16.
+2022-12-04;(USA) Texas;TX 211 (Government Canyon);tx.tx211;Deleted, merged into main TX 211 route.
 2022-11-03;(USA) Texas;TX 249;tx.tx249;Extended northward from FM 1774 north of Todd Mission to TX 105.
 2022-09-20;(USA) Texas;US 77 Business (Yoakum);tx.us077altbusyoa;renamed to US 77 Alternate Business.
 2022-09-20;(USA) Texas;US 183 Truck (Cisco);tx.us183trkcis;Route added.


### PR DESCRIPTION
Amended 898fb3b66fc530da25de7e802b934659dd7fc3e4
https://www.bexar.org/ArchiveCenter/ViewFile/Item/5054
> On Monday, November 14, 2022, the long anticipated section of State Highway (SH) 211 between
Potranco Road (FM 1957) and Culebra Road (FM 471) officially opened to motorists in far west Bexar
County. The corridor links two existing sections of SH 211 now allowing seamless travel between
Bandera Road (SH 16) and Highway 90.