### PR TITLE
QC: short TCH relocation

### DIFF
--- a/hwy_data/QC/canqc/qc.qc185.wpt
+++ b/hwy_data/QC/canqc/qc.qc185.wpt
@@ -1,10 +1,11 @@
 A-85_S http://www.openstreetmap.org/?lat=47.667399&lon=-68.979539
 ChSav http://www.openstreetmap.org/?lat=47.678012&lon=-69.022894
 RangVau_W http://www.openstreetmap.org/?lat=47.667645&lon=-69.051747
-RuePri_E http://www.openstreetmap.org/?lat=47.684293&lon=-69.075307
-*RteGerRoy_S http://www.openstreetmap.org/?lat=47.692034&lon=-69.118727
-60 +QC291 http://www.openstreetmap.org/?lat=47.693471&lon=-69.135828
-*RteGerRoy_N http://www.openstreetmap.org/?lat=47.694914&lon=-69.165108
+RuePri_E http://www.openstreetmap.org/?lat=47.684232&lon=-69.075375
+*RteGerRoy_A http://www.openstreetmap.org/?lat=47.688742&lon=-69.094401
+*RteGerRoy_B +RteGerRoy_S http://www.openstreetmap.org/?lat=47.692488&lon=-69.118734
+60 http://www.openstreetmap.org/?lat=47.693471&lon=-69.135828
+*RteGerRoy_C +RteGerRoy_N http://www.openstreetmap.org/?lat=47.694914&lon=-69.165108
 RuePri_W http://www.openstreetmap.org/?lat=47.687856&lon=-69.216281
 +X167769 http://www.openstreetmap.org/?lat=47.682964&lon=-69.239343
 ChTac http://www.openstreetmap.org/?lat=47.696369&lon=-69.276789

--- a/hwy_data/QC/cantch/qc.tchmai.wpt
+++ b/hwy_data/QC/cantch/qc.tchmai.wpt
@@ -161,10 +161,11 @@ A-20/85 +A-20(499) http://www.openstreetmap.org/?lat=47.790976&lon=-69.578289
 ChTac http://www.openstreetmap.org/?lat=47.696369&lon=-69.276789
 +X167769 http://www.openstreetmap.org/?lat=47.682964&lon=-69.239343
 RuePri_W http://www.openstreetmap.org/?lat=47.687856&lon=-69.216281
-*RteGerRoy_N http://www.openstreetmap.org/?lat=47.694914&lon=-69.165108
-60(185) +QC291 http://www.openstreetmap.org/?lat=47.693471&lon=-69.135828
-*RteGerRoy_S http://www.openstreetmap.org/?lat=47.692034&lon=-69.118727
-RuePri_E http://www.openstreetmap.org/?lat=47.684293&lon=-69.075307
+*RteGerRoy_C +RteGerRoy_N http://www.openstreetmap.org/?lat=47.694914&lon=-69.165108
+60(185) http://www.openstreetmap.org/?lat=47.693471&lon=-69.135828
+*RteGerRoy_B +RteGerRoy_S http://www.openstreetmap.org/?lat=47.692034&lon=-69.118727
+*RteGerRoy_A http://www.openstreetmap.org/?lat=47.688742&lon=-69.094401
+RuePri_E http://www.openstreetmap.org/?lat=47.684232&lon=-69.075375
 RangVau_W http://www.openstreetmap.org/?lat=47.667645&lon=-69.051747
 ChSav http://www.openstreetmap.org/?lat=47.678012&lon=-69.022894
 47(85) http://www.openstreetmap.org/?lat=47.667399&lon=-68.979539 


### PR DESCRIPTION
Another TCH segment relocated in eastern Quebec, to future A-85 freeway alignment.

Datacheck successful. Updates items in PR #6193.