### PR TITLE
Deleting US 202 ALT TRUCK (North Wales) and US 19 TRUCK (Pittsburgh) Revisions

### DIFF
--- a/hwy_data/PA/usapa/pa.pa063.wpt
+++ b/hwy_data/PA/usapa/pa.pa063.wpt
@@ -16,7 +16,7 @@ TowAve http://www.openstreetmap.org/?lat=40.249388&lon=-75.334923
 PA463 http://www.openstreetmap.org/?lat=40.263080&lon=-75.319382
 PA363 http://www.openstreetmap.org/?lat=40.248377&lon=-75.295224
 BroSt http://www.openstreetmap.org/?lat=40.241539&lon=-75.283730
-US202AltTrk_S http://www.openstreetmap.org/?lat=40.228905&lon=-75.262487
+NorWalRd  +US202AltTrk_S http://www.openstreetmap.org/?lat=40.228905&lon=-75.262487
 US202Bus http://www.openstreetmap.org/?lat=40.220203&lon=-75.247952
 US202 http://www.openstreetmap.org/?lat=40.218682&lon=-75.245455
 PA309 http://www.openstreetmap.org/?lat=40.205976&lon=-75.224555

--- a/hwy_data/PA/usaus/pa.us019.wpt
+++ b/hwy_data/PA/usaus/pa.us019.wpt
@@ -75,6 +75,7 @@ HigAve http://www.openstreetmap.org/?lat=40.522288&lon=-80.034411
 ThrDegRd http://www.openstreetmap.org/?lat=40.544608&lon=-80.035934
 SewOakRd http://www.openstreetmap.org/?lat=40.545252&lon=-80.035956
 IngRd http://www.openstreetmap.org/?lat=40.582031&lon=-80.038123
+PineCreRd http://www.openstreetmap.org/?lat=40.586809&lon=-80.045099
 US19Trk_N http://www.openstreetmap.org/?lat=40.588205&lon=-80.045861
 ChuRd http://www.openstreetmap.org/?lat=40.624747&lon=-80.053985
 ChaDr http://www.openstreetmap.org/?lat=40.629340&lon=-80.056617

--- a/hwy_data/PA/usaus/pa.us202.wpt
+++ b/hwy_data/PA/usaus/pa.us202.wpt
@@ -33,7 +33,7 @@ JohHwy http://www.openstreetmap.org/?lat=40.131945&lon=-75.328585
 GerPike +GerPk http://www.openstreetmap.org/?lat=40.141769&lon=-75.312561
 SweRd_C http://www.openstreetmap.org/?lat=40.152174&lon=-75.305126
 PA73 http://www.openstreetmap.org/?lat=40.166992&lon=-75.290278
-US202AltTrk_S http://www.openstreetmap.org/?lat=40.179492&lon=-75.277848
+MorRd http://www.openstreetmap.org/?lat=40.179492&lon=-75.277848
 SumPike http://www.openstreetmap.org/?lat=40.202074&lon=-75.255395
 US202Bus http://www.openstreetmap.org/?lat=40.217184&lon=-75.246896
 PA63 http://www.openstreetmap.org/?lat=40.218682&lon=-75.245455

--- a/hwy_data/PA/usausb/pa.us019trkpit.wpt
+++ b/hwy_data/PA/usausb/pa.us019trkpit.wpt
@@ -20,9 +20,11 @@ I-279(3) http://www.openstreetmap.org/?lat=40.474171&lon=-80.006154
 I-279(4A) http://www.openstreetmap.org/?lat=40.485394&lon=-80.008546
 I-279(4) http://www.openstreetmap.org/?lat=40.494375&lon=-80.011775
 NelRunRd http://www.openstreetmap.org/?lat=40.498051&lon=-80.012867
-ViewAve http://www.openstreetmap.org/?lat=40.500027&lon=-80.012508
+WestViewAve +ViewAve http://www.openstreetmap.org/?lat=40.500027&lon=-80.012508
 BabBlvd http://www.openstreetmap.org/?lat=40.513997&lon=-80.004158
+RPMallDr http://www.openstreetmap.org/?lat=40.542045&lon=-80.013093
 PeeRd http://www.openstreetmap.org/?lat=40.554452&lon=-80.021300
 DunAve http://www.openstreetmap.org/?lat=40.568477&lon=-80.023926
 IngRd http://www.openstreetmap.org/?lat=40.583363&lon=-80.030615
+PineCreRd http://www.openstreetmap.org/?lat=40.586827&lon=-80.041740
 US19_N http://www.openstreetmap.org/?lat=40.588205&lon=-80.045861

--- a/hwy_data/PA/usausb/pa.us202alttrknor.wpt
+++ b/hwy_data/PA/usausb/pa.us202alttrknor.wpt
@@ -1,6 +1,0 @@
-US202_S http://www.openstreetmap.org/?lat=40.179492&lon=-75.277848
-NorWalRd_S http://www.openstreetmap.org/?lat=40.192641&lon=-75.294526
-MainSt http://www.openstreetmap.org/?lat=40.210896&lon=-75.278280
-PA63_W http://www.openstreetmap.org/?lat=40.228905&lon=-75.262487
-US202Bus http://www.openstreetmap.org/?lat=40.220203&lon=-75.247952
-US202_N http://www.openstreetmap.org/?lat=40.218682&lon=-75.245455

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -863,7 +863,6 @@ usausb;UT;US191;Bus;Hel;Helper, UT;ut.us191bushel;
 usausb;MT;US191;Bus;Lew;Lewiston, MT;mt.us191buslew;
 usausb;ME;US201;Alt;Sko;Skowhegan, ME;me.us201altsko;
 usausb;PA;US202;Bus;Mon;Montgomeryville, PA;pa.us202busmon;
-usausb;PA;US202;AltTrk;Nor;North Wales, PA;pa.us202alttrknor;
 usausb;NY;US202;Alt;Gar;Garrison, NY;ny.us202altgar;
 usausb;NJ;US206;Byp;Hil;Hillsborough, NJ;nj.us206byphil;
 usausb;PA;US209;Bus;Str;Stroudsburg, PA;pa.us209busstr;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -852,7 +852,6 @@ usausb;US191;Bus;Helper, UT;ut.us191bushel
 usausb;US191;Bus;Lewiston, MT;mt.us191buslew
 usausb;US201;Alt;Skowhegan, ME;me.us201altsko
 usausb;US202;Bus;Montgomeryville, PA;pa.us202busmon
-usausb;US202;AltTrk;North Wales, PA;pa.us202alttrknor
 usausb;US202;Alt;Garrison, NY;ny.us202altgar
 usausb;US206;Byp;Hillsborough, NJ;nj.us206byphil
 usausb;US209;Bus;Stroudsburg, PA;pa.us209busstr

--- a/updates.csv
+++ b/updates.csv
@@ -6277,6 +6277,7 @@ date;region;route;root;description
 2017-09-06;(USA) Oregon;OR 99;or.or099;Restored route from I-5 onto Yoncalla-Drain routing.
 2017-09-06;(USA) Oregon;OR 99W;or.or099w;Truncated route from I-5(306) to I-5(294) to reflect signage and prepare for Oregon Highways dataset.
 2017-09-06;(USA) Oregon;OR 126;or.or126;Moved route from Bus 97 to US 97 in Redmond.
+2023-02-13;(USA) Pennsylvania;US 202 Alternate Truck (North Wales);;Route deleted.
 2023-01-11;(USA) Pennsylvania;PA 863;pa.pa863;Slightly realigned and truncated from US 222 to a nearby intersection with Schantz Rd. 
 2022-12-06;(USA) Pennsylvania;PA 902;pa.pa902;Realigned slightly east between BriSt and PA443 onto new bridge.
 2022-10-23;(USA) Pennsylvania;PA 96 Truck (Manns Choice);;Route deleted.


### PR DESCRIPTION
https://forum.travelmapping.net/index.php?topic=5286.0

Other Changes:
US 19:  Added Pine Creek Rd (PineCreRd).  
US 19 TRUCK (Pittsburgh):  ViewAve>-WestViewAve.  Added Ross Park Mall Dr (RPMallDr) and Pine Creek Rd (PineCreRd).
US 202:  US202AltTrk_S>-MorRd
PA 63:  US202AltTrk_S>-NorWalRd