### PR TITLE
PA 118, PA 231, PA 590, PA 837, and PA 982 Minor Revisions

### DIFF
--- a/hwy_data/PA/usapa/pa.pa118.wpt
+++ b/hwy_data/PA/usapa/pa.pa118.wpt
@@ -2,7 +2,6 @@ PA405 http://www.openstreetmap.org/?lat=41.241239&lon=-76.724267
 ClaRd http://www.openstreetmap.org/?lat=41.231959&lon=-76.706100
 NeuRd http://www.openstreetmap.org/?lat=41.228697&lon=-76.663097
 MorTowExt http://www.openstreetmap.org/?lat=41.214238&lon=-76.646145
-+X1 http://www.openstreetmap.org/?lat=41.218791&lon=-76.636513
 DaiFarmRd http://www.openstreetmap.org/?lat=41.219183&lon=-76.631323
 FunRd http://www.openstreetmap.org/?lat=41.230823&lon=-76.610946
 BeaRunRd http://www.openstreetmap.org/?lat=41.241205&lon=-76.596328

--- a/hwy_data/PA/usapa/pa.pa231.wpt
+++ b/hwy_data/PA/usapa/pa.pa231.wpt
@@ -17,10 +17,10 @@ US40_E http://www.openstreetmap.org/?lat=40.117867&lon=-80.410373
 CTRidRd http://www.openstreetmap.org/?lat=40.134217&lon=-80.417001
 CunRd http://www.openstreetmap.org/?lat=40.141250&lon=-80.441849
 CraRd http://www.openstreetmap.org/?lat=40.152549&lon=-80.443313
-RamRd http://www.openstreetmap.org/?lat=40.171239&lon=-80.450767
-JanRd http://www.openstreetmap.org/?lat=40.173508&lon=-80.455544
-BacRd http://www.openstreetmap.org/?lat=40.179236&lon=-80.457808
-+X2 http://www.openstreetmap.org/?lat=40.184892&lon=-80.448509
+RamRd http://www.openstreetmap.org/?lat=40.171190&lon=-80.451406
+JanRd http://www.openstreetmap.org/?lat=40.173520&lon=-80.455448
+BacRd http://www.openstreetmap.org/?lat=40.179000&lon=-80.457880
++X2 http://www.openstreetmap.org/?lat=40.184890&lon=-80.448372
 PA221 http://www.openstreetmap.org/?lat=40.195155&lon=-80.448337
 PA331_E http://www.openstreetmap.org/?lat=40.196292&lon=-80.448225
 BruRunRd_W http://www.openstreetmap.org/?lat=40.195110&lon=-80.451143

--- a/hwy_data/PA/usapa/pa.pa590.wpt
+++ b/hwy_data/PA/usapa/pa.pa590.wpt
@@ -1,11 +1,9 @@
 PA435 http://www.openstreetmap.org/?lat=41.381003&lon=-75.546804
 +X1 http://www.openstreetmap.org/?lat=41.370843&lon=-75.537121
 ResRd http://www.openstreetmap.org/?lat=41.374969&lon=-75.514151
-+X1A http://www.openstreetmap.org/?lat=41.382615&lon=-75.506630
 MarRd_A http://www.openstreetmap.org/?lat=41.397057&lon=-75.479652
 WimRd http://www.openstreetmap.org/?lat=41.396908&lon=-75.468030
-+X2 http://www.openstreetmap.org/?lat=41.393590&lon=-75.451167
-+X3 http://www.openstreetmap.org/?lat=41.388930&lon=-75.448608
+WalRd http://www.openstreetmap.org/?lat=41.388431&lon=-75.446211
 PA690 http://www.openstreetmap.org/?lat=41.392781&lon=-75.436909
 PA348 http://www.openstreetmap.org/?lat=41.404819&lon=-75.427526
 PA191/196 http://www.openstreetmap.org/?lat=41.403700&lon=-75.398287
@@ -32,10 +30,7 @@ WelLakeRd http://www.openstreetmap.org/?lat=41.503761&lon=-75.089673
 WesRd http://www.openstreetmap.org/?lat=41.497632&lon=-75.069964
 TowRd_E http://www.openstreetmap.org/?lat=41.473474&lon=-75.040492
 RowRd http://www.openstreetmap.org/?lat=41.475769&lon=-75.036404
-+X5A http://www.openstreetmap.org/?lat=41.481590&lon=-75.031589
-+X6 http://www.openstreetmap.org/?lat=41.486346&lon=-75.027188
-+X6A http://www.openstreetmap.org/?lat=41.487247&lon=-75.025501
-+X6B http://www.openstreetmap.org/?lat=41.487110&lon=-75.023741
++X6A http://www.openstreetmap.org/?lat=41.487311&lon=-75.025509
 +X6C http://www.openstreetmap.org/?lat=41.483965&lon=-75.004695
 +X7 http://www.openstreetmap.org/?lat=41.481012&lon=-75.000521
 +X8 http://www.openstreetmap.org/?lat=41.487443&lon=-74.994076

--- a/hwy_data/PA/usapa/pa.pa837.wpt
+++ b/hwy_data/PA/usapa/pa.pa837.wpt
@@ -2,7 +2,7 @@ PA88_A +PA88 http://www.openstreetmap.org/?lat=40.172133&lon=-79.915573
 +X0AA http://www.openstreetmap.org/?lat=40.169114&lon=-79.891666
 DonRd http://www.openstreetmap.org/?lat=40.173584&lon=-79.885009
 +X0AAA http://www.openstreetmap.org/?lat=40.169229&lon=-79.881101
-VanDeiHwy  +MonBri http://www.openstreetmap.org/?lat=40.165962&lon=-79.864404
+VanDeiHwy http://www.openstreetmap.org/?lat=40.165962&lon=-79.864404
 3rdSt_W http://www.openstreetmap.org/?lat=40.174684&lon=-79.857092
 MelAve_S http://www.openstreetmap.org/?lat=40.174484&lon=-79.856183
 6thSt http://www.openstreetmap.org/?lat=40.177793&lon=-79.855226

--- a/hwy_data/PA/usapa/pa.pa982.wpt
+++ b/hwy_data/PA/usapa/pa.pa982.wpt
@@ -18,7 +18,7 @@ LigSt http://www.openstreetmap.org/?lat=40.300210&lon=-79.371111
 PA982Trk_S +OldDerRd http://www.openstreetmap.org/?lat=40.319408&lon=-79.345716
 CheSt http://www.openstreetmap.org/?lat=40.339673&lon=-79.315383
 PitSt http://www.openstreetmap.org/?lat=40.350230&lon=-79.316896
-PizBarnRd http://www.openstreetmap.org/?lat=40.361267&lon=-79.310313
+PizBarnRd http://www.openstreetmap.org/?lat=40.361379&lon=-79.310238
 GarHillRd http://www.openstreetmap.org/?lat=40.406922&lon=-79.335086
 StrRd http://www.openstreetmap.org/?lat=40.412085&lon=-79.342985
 US22/119 http://www.openstreetmap.org/?lat=40.421368&lon=-79.344630


### PR DESCRIPTION
PA 118:  Removed +X1.
PA 231:  Point relocations.
PA 590:  Removed shaping points.  Replaced +X2 with Walker Rd (WalRd).
PA 837: Removed unused alternate label.
PA 982: Relocated PizBarnRd.