### PR TITLE
PA Changes 7-25-2023

### DIFF
--- a/hwy_data/PA/usapa/pa.pa056.wpt
+++ b/hwy_data/PA/usapa/pa.pa056.wpt
@@ -10,7 +10,7 @@ MelRd http://www.openstreetmap.org/?lat=40.598735&lon=-79.687062
 BonShoRd http://www.openstreetmap.org/?lat=40.619299&lon=-79.652397
 PA356_N http://www.openstreetmap.org/?lat=40.619761&lon=-79.635330
 PA356_S http://www.openstreetmap.org/?lat=40.616041&lon=-79.626870
-LeeHillRd_E  +LeeHillRd http://www.openstreetmap.org/?lat=40.617448&lon=-79.621536
+LeeHillRd_E http://www.openstreetmap.org/?lat=40.617448&lon=-79.621536
 TowCenDr http://www.openstreetmap.org/?lat=40.608968&lon=-79.610697
 HydeParkRd http://www.openstreetmap.org/?lat=40.606166&lon=-79.604262
 LonSt http://www.openstreetmap.org/?lat=40.599979&lon=-79.577950

--- a/hwy_data/PA/usapa/pa.pa065.wpt
+++ b/hwy_data/PA/usapa/pa.pa065.wpt
@@ -18,7 +18,6 @@ StaSt http://www.openstreetmap.org/?lat=40.640294&lon=-80.232047
 11thSt http://www.openstreetmap.org/?lat=40.659731&lon=-80.239463
 CroRunRd http://www.openstreetmap.org/?lat=40.670640&lon=-80.244430
 3rdAve_S http://www.openstreetmap.org/?lat=40.679865&lon=-80.249679
-+X(9thSt) +9thAve http://www.openstreetmap.org/?lat=40.684547&lon=-80.253850
 3rdAve_N http://www.openstreetmap.org/?lat=40.691365&lon=-80.260156
 PA51_S http://www.openstreetmap.org/?lat=40.695367&lon=-80.265384
 BriAve http://www.openstreetmap.org/?lat=40.699666&lon=-80.279481

--- a/hwy_data/PA/usapa/pa.pa087.wpt
+++ b/hwy_data/PA/usapa/pa.pa087.wpt
@@ -12,10 +12,10 @@ DunRd http://www.openstreetmap.org/?lat=41.388344&lon=-76.792642
 +X6 http://www.openstreetmap.org/?lat=41.403646&lon=-76.753889
 +X7 http://www.openstreetmap.org/?lat=41.404976&lon=-76.713726
 OgdRd http://www.openstreetmap.org/?lat=41.411564&lon=-76.705709
-+X7A http://www.openstreetmap.org/?lat=41.438916&lon=-76.712248
-HopRd +JacRd http://www.openstreetmap.org/?lat=41.443941&lon=-76.707031
+JacRd_W http://www.openstreetmap.org/?lat=41.437882&lon=-76.712614
+HopRd http://www.openstreetmap.org/?lat=41.443941&lon=-76.707031
 ElkCreRd http://www.openstreetmap.org/?lat=41.454441&lon=-76.689744
-+X8 http://www.openstreetmap.org/?lat=41.459423&lon=-76.682752
+JacRd_E http://www.openstreetmap.org/?lat=41.459403&lon=-76.681803
 +X9 http://www.openstreetmap.org/?lat=41.455907&lon=-76.672018
 +X10 http://www.openstreetmap.org/?lat=41.462708&lon=-76.643929
 +X11 http://www.openstreetmap.org/?lat=41.486041&lon=-76.629247

--- a/hwy_data/PA/usaus/pa.us022.wpt
+++ b/hwy_data/PA/usaus/pa.us022.wpt
@@ -71,7 +71,7 @@ PhiSt http://www.openstreetmap.org/?lat=40.457217&lon=-79.017701
 PA403 http://www.openstreetmap.org/?lat=40.455093&lon=-79.010153
 WehRd http://www.openstreetmap.org/?lat=40.444732&lon=-78.972119
 DisMouRd http://www.openstreetmap.org/?lat=40.434335&lon=-78.911820
-ChiHillRd +VieSt http://www.openstreetmap.org/?lat=40.446522&lon=-78.881906
+ChiHillRd http://www.openstreetmap.org/?lat=40.446522&lon=-78.881906
 ForCorRd http://www.openstreetmap.org/?lat=40.450721&lon=-78.862782
 PA271 http://www.openstreetmap.org/?lat=40.449960&lon=-78.839468
 OgdSt http://www.openstreetmap.org/?lat=40.446763&lon=-78.799634

--- a/hwy_data/PA/usaus/pa.us062.wpt
+++ b/hwy_data/PA/usaus/pa.us062.wpt
@@ -1,6 +1,6 @@
 OH/PA http://www.openstreetmap.org/?lat=41.220127&lon=-80.519174
 US62BusSha_S http://www.openstreetmap.org/?lat=41.221255&lon=-80.518388
-PA718/760 +PA60 +PA718 http://www.openstreetmap.org/?lat=41.226797&lon=-80.507115
+PA718/760 +PA60 http://www.openstreetmap.org/?lat=41.226797&lon=-80.507115
 ConBlvd http://www.openstreetmap.org/?lat=41.230940&lon=-80.504570
 PA518 http://www.openstreetmap.org/?lat=41.230472&lon=-80.493383
 PineHolBlvd http://www.openstreetmap.org/?lat=41.225592&lon=-80.482900

--- a/hwy_data/PA/usaus/pa.us422.wpt
+++ b/hwy_data/PA/usaus/pa.us422.wpt
@@ -60,9 +60,9 @@ US119 +US119_S http://www.openstreetmap.org/?lat=40.585190&lon=-79.155904
 PA954 http://www.openstreetmap.org/?lat=40.583850&lon=-79.134814
 +X3A http://www.openstreetmap.org/?lat=40.590018&lon=-79.102214
 +X4 http://www.openstreetmap.org/?lat=40.605264&lon=-79.074636
-CheRidRd_A http://www.openstreetmap.org/?lat=40.606164&lon=-79.047977
+CheRidRd http://www.openstreetmap.org/?lat=40.606164&lon=-79.047977
 PA553 http://www.openstreetmap.org/?lat=40.608463&lon=-79.041867
-CheRidRd_B http://www.openstreetmap.org/?lat=40.604254&lon=-79.015686
+CheRidRdExt http://www.openstreetmap.org/?lat=40.604254&lon=-79.015686
 HarRd http://www.openstreetmap.org/?lat=40.598030&lon=-79.011078
 PA259 http://www.openstreetmap.org/?lat=40.579644&lon=-78.998287
 NoloRd http://www.openstreetmap.org/?lat=40.572093&lon=-78.960114


### PR DESCRIPTION
Fixed labels on US 422:  https://forum.travelmapping.net/index.php?topic=5639.0


Removed unused alternate labels on PA 56, PA 65, PA 87, US 22, and US 62.

Other notes:

PA 65: Removed shaping point that was holding the unused alternate label.
PA 87:  Changed shaping points to JacRd_W and JacRd_E (Jacks Rd).