### PR TITLE
Added waypoints at major intersections

### DIFF
--- a/hwy_data/NV/usanv/nv.nv431.wpt
+++ b/hwy_data/NV/usanv/nv.nv431.wpt
@@ -1,17 +1,26 @@
 NV28 http://www.openstreetmap.org/?lat=39.251294&lon=-119.973026
-JupDr http://www.openstreetmap.org/?lat=39.274543&lon=-119.943798
+ColDr http://www.openstreetmap.org/?lat=39.262456&lon=-119.956922
+CouClubDr http://www.openstreetmap.org/?lat=39.274162&lon=-119.947247
+FaiBlvd http://www.openstreetmap.org/?lat=39.268537&lon=-119.936044
 +X01 http://www.openstreetmap.org/?lat=39.262825&lon=-119.929730
 OldMtHwy http://www.openstreetmap.org/?lat=39.283717&lon=-119.934552
+IncLakeRd http://www.openstreetmap.org/?lat=39.300790&lon=-119.920144
 FR051 http://www.openstreetmap.org/?lat=39.310191&lon=-119.901459
-+X02 http://www.openstreetmap.org/?lat=39.322544&lon=-119.902189
+MtRoseSum http://www.openstreetmap.org/?lat=39.313243&lon=-119.897034
++X02 http://www.openstreetmap.org/?lat=39.315583&lon=-119.904185
++X03 http://www.openstreetmap.org/?lat=39.322544&lon=-119.902189
 AtoRd http://www.openstreetmap.org/?lat=39.329613&lon=-119.887238
 SliMtnHwy http://www.openstreetmap.org/?lat=39.326434&lon=-119.876373
++X04 http://www.openstreetmap.org/?lat=39.332675&lon=-119.867958
 SkyTavRd http://www.openstreetmap.org/?lat=39.338094&lon=-119.872851
++X05 http://www.openstreetmap.org/?lat=39.340110&lon=-119.877099
++X06 http://www.openstreetmap.org/?lat=39.338907&lon=-119.865415
 MtnHavLn http://www.openstreetmap.org/?lat=39.344093&lon=-119.860314
 CR312 http://www.openstreetmap.org/?lat=39.337457&lon=-119.861763
-+X03 http://www.openstreetmap.org/?lat=39.338801&lon=-119.847920
++X07 http://www.openstreetmap.org/?lat=39.338801&lon=-119.847920
 DouFirDr http://www.openstreetmap.org/?lat=39.354588&lon=-119.855599
 TimDr http://www.openstreetmap.org/?lat=39.376397&lon=-119.839084
 ThoCrkRd http://www.openstreetmap.org/?lat=39.391783&lon=-119.790660
+WedPkwy http://www.openstreetmap.org/?lat=39.392432&lon=-119.767397
 I-580/395 +US395_N http://www.openstreetmap.org/?lat=39.396904&lon=-119.758102
 US395Alt +US395_S http://www.openstreetmap.org/?lat=39.402830&lon=-119.746198


### PR DESCRIPTION
Preemptively added waypoints at several major roads and trailheads using local knowledge. Renamed and relocated "JupDr" to "CouClubDr". Waypoint "MtRoseSum" can probably eventually replace "FR051"; added as new waypoint because "FR051" is currently in use.