### PR TITLE
PA Revisions 8-7-2023

### DIFF
--- a/hwy_data/PA/usapa/pa.pa066.wpt
+++ b/hwy_data/PA/usapa/pa.pa066.wpt
@@ -37,7 +37,7 @@ CCDamRd http://www.openstreetmap.org/?lat=40.711724&lon=-79.525437
 OldPA66 http://www.openstreetmap.org/?lat=40.730865&lon=-79.535045
 ChuRd http://www.openstreetmap.org/?lat=40.754163&lon=-79.527476
 PleDr http://www.openstreetmap.org/?lat=40.764846&lon=-79.527548
-PA128 http://www.openstreetmap.org/?lat=40.779654&lon=-79.521234
+PA128 http://www.openstreetmap.org/?lat=40.779654&lon=-79.521352
 US422/28 +US422/28_W http://www.openstreetmap.org/?lat=40.795025&lon=-79.513842
 +X3 http://www.openstreetmap.org/?lat=40.793620&lon=-79.497499
 US422/422Bus http://www.openstreetmap.org/?lat=40.804203&lon=-79.489528

--- a/hwy_data/PA/usapa/pa.pa068.wpt
+++ b/hwy_data/PA/usapa/pa.pa068.wpt
@@ -2,9 +2,9 @@ OH/PA http://www.openstreetmap.org/?lat=40.642582&lon=-80.518997
 SmiFerRd http://www.openstreetmap.org/?lat=40.647430&lon=-80.502558
 PA168_N http://www.openstreetmap.org/?lat=40.643158&lon=-80.464146
 PA168_S http://www.openstreetmap.org/?lat=40.629759&lon=-80.434985
-+X0 http://www.openstreetmap.org/?lat=40.649959&lon=-80.409974
+WolfRunRd http://www.openstreetmap.org/?lat=40.645570&lon=-80.413892
 EngRd http://www.openstreetmap.org/?lat=40.652006&lon=-80.397815
-+X0A http://www.openstreetmap.org/?lat=40.656972&lon=-80.371253
+BarHillRd http://www.openstreetmap.org/?lat=40.655895&lon=-80.378455
 I-376 http://www.openstreetmap.org/?lat=40.683020&lon=-80.333737
 PA51_N http://www.openstreetmap.org/?lat=40.698794&lon=-80.295242
 PA51/65 +PA18/65 http://www.openstreetmap.org/?lat=40.700246&lon=-80.288569
@@ -62,7 +62,7 @@ HucRidRd http://www.openstreetmap.org/?lat=41.110893&lon=-79.459562
 FivePoiRd http://www.openstreetmap.org/?lat=41.121392&lon=-79.433443
 BodRd http://www.openstreetmap.org/?lat=41.139241&lon=-79.416092
 +X3 http://www.openstreetmap.org/?lat=41.143635&lon=-79.402630
-*OldTownRd http://www.openstreetmap.org/?lat=41.151407&lon=-79.403662
+OldTownRd http://www.openstreetmap.org/?lat=41.151049&lon=-79.403713
 BroRd_B http://www.openstreetmap.org/?lat=41.153012&lon=-79.398794
 I-80 http://www.openstreetmap.org/?lat=41.185824&lon=-79.394339
 US322 http://www.openstreetmap.org/?lat=41.214718&lon=-79.385643

--- a/hwy_data/PA/usapa/pa.pa128.wpt
+++ b/hwy_data/PA/usapa/pa.pa128.wpt
@@ -18,4 +18,4 @@ BunHillRd http://www.openstreetmap.org/?lat=40.760431&lon=-79.553652
 RossAve http://www.openstreetmap.org/?lat=40.760385&lon=-79.542362
 HillRd http://www.openstreetmap.org/?lat=40.764102&lon=-79.535549
 17thSt http://www.openstreetmap.org/?lat=40.778730&lon=-79.522632
-PA66 http://www.openstreetmap.org/?lat=40.779654&lon=-79.521234
+PA66 http://www.openstreetmap.org/?lat=40.779654&lon=-79.521352

--- a/hwy_data/PA/usapa/pa.pa168.wpt
+++ b/hwy_data/PA/usapa/pa.pa168.wpt
@@ -11,7 +11,7 @@ ShiHillRd http://www.openstreetmap.org/?lat=40.621496&lon=-80.425026
 PA68_E +PA68_N http://www.openstreetmap.org/?lat=40.629759&lon=-80.434985
 PA68_W +PA68_S http://www.openstreetmap.org/?lat=40.643158&lon=-80.464146
 WooAve http://www.openstreetmap.org/?lat=40.643361&lon=-80.463020
-WesDr http://www.openstreetmap.org/?lat=40.659865&lon=-80.477638
+WesDr http://www.openstreetmap.org/?lat=40.659932&lon=-80.477584
 TusRd_E http://www.openstreetmap.org/?lat=40.682902&lon=-80.480336
 TusRd_W http://www.openstreetmap.org/?lat=40.680007&lon=-80.490915
 +X1 http://www.openstreetmap.org/?lat=40.693937&lon=-80.481851

--- a/hwy_data/PA/usapa/pa.pa333.wpt
+++ b/hwy_data/PA/usapa/pa.pa333.wpt
@@ -3,7 +3,6 @@ PA103 http://www.openstreetmap.org/?lat=40.582241&lon=-77.576635
 +X1 http://www.openstreetmap.org/?lat=40.583361&lon=-77.568562
 +X3 http://www.openstreetmap.org/?lat=40.572841&lon=-77.554432
 +X3A http://www.openstreetmap.org/?lat=40.576443&lon=-77.538570
-+X3B http://www.openstreetmap.org/?lat=40.580603&lon=-77.531848
 +X4 http://www.openstreetmap.org/?lat=40.598806&lon=-77.487551
 +X5 http://www.openstreetmap.org/?lat=40.606842&lon=-77.445457
 +X6 http://www.openstreetmap.org/?lat=40.599775&lon=-77.446747
@@ -14,14 +13,13 @@ LicSt_W http://www.openstreetmap.org/?lat=40.570818&lon=-77.405765
 MowSt_N http://www.openstreetmap.org/?lat=40.570792&lon=-77.404679
 PA35_N http://www.openstreetmap.org/?lat=40.566311&lon=-77.404744
 PA35_S http://www.openstreetmap.org/?lat=40.560504&lon=-77.410593
-McLRd +LicSt http://www.openstreetmap.org/?lat=40.546829&lon=-77.416502
+McLRd http://www.openstreetmap.org/?lat=40.546717&lon=-77.415923
 PA75_N http://www.openstreetmap.org/?lat=40.528785&lon=-77.392180
 PA75_S http://www.openstreetmap.org/?lat=40.525148&lon=-77.391171
 ButShopRd http://www.openstreetmap.org/?lat=40.518234&lon=-77.386394
 ResRd http://www.openstreetmap.org/?lat=40.513263&lon=-77.374850
 +X9 http://www.openstreetmap.org/?lat=40.530677&lon=-77.345982
 TusRd http://www.openstreetmap.org/?lat=40.519830&lon=-77.334180
-+X10 http://www.openstreetmap.org/?lat=40.536687&lon=-77.278001
 +X11 http://www.openstreetmap.org/?lat=40.551354&lon=-77.237792
 MainSt_W http://www.openstreetmap.org/?lat=40.564367&lon=-77.237164
 MainSt_E http://www.openstreetmap.org/?lat=40.564985&lon=-77.232586


### PR DESCRIPTION
PA 66: Recentered at PA 128.
PA 68: Replaced +X0 with WolfRunRd.  Replaced +X0A with Barclay Hill Rd (BarHillRd).  Relocated and removed asterisk from OldTownRd.
PA 168: Relocated WesDr.
PA 333: Removed shaping points and unused alternate label.  Relocated McLRd.