### PR TITLE
AR I-49 exits: tripling down on the dumb

### DIFF
--- a/hwy_data/AR/usaar/ar.ar072.wpt
+++ b/hwy_data/AR/usaar/ar.ar072.wpt
@@ -5,10 +5,10 @@ BeaRd http://www.openstreetmap.org/?lat=36.426761&lon=-94.525277
 AR59_N http://www.openstreetmap.org/?lat=36.424164&lon=-94.453225
 AR59_S http://www.openstreetmap.org/?lat=36.421350&lon=-94.453311
 +X213953 http://www.openstreetmap.org/?lat=36.414510&lon=-94.415649
-I-49(287) +AR549(287) http://www.openstreetmap.org/?lat=36.432397&lon=-94.369264
+I-49(100) +I-49(287) +AR549(287) http://www.openstreetmap.org/?lat=36.432397&lon=-94.369264
 AR279_S http://www.openstreetmap.org/?lat=36.431779&lon=-94.333629
 AR279_N http://www.openstreetmap.org/?lat=36.431468&lon=-94.325218
-I-49(284) +AR549(284) http://www.openstreetmap.org/?lat=36.423134&lon=-94.320374
+I-49(97) +I-49(284) +AR549(284) http://www.openstreetmap.org/?lat=36.423134&lon=-94.320374
 +X730361 http://www.openstreetmap.org/?lat=36.418097&lon=-94.306376
 AR102B http://www.openstreetmap.org/?lat=36.380481&lon=-94.279429
 ElmTreeRd http://www.openstreetmap.org/?lat=36.370513&lon=-94.248593

--- a/hwy_data/AR/usai/ar.i049.wpt
+++ b/hwy_data/AR/usai/ar.i049.wpt
@@ -35,10 +35,10 @@
 +x87 http://www.openstreetmap.org/?lat=36.374131&lon=-94.168797
 88 http://www.openstreetmap.org/?lat=36.381547&lon=-94.175357
 +x90 http://www.openstreetmap.org/?lat=36.399800&lon=-94.185104
-93 http://www.openstreetmap.org/?lat=36.414583&lon=-94.221810
+91 +93 http://www.openstreetmap.org/?lat=36.414583&lon=-94.221810
 +x282 http://www.openstreetmap.org/?lat=36.411479&lon=-94.279910
-99 http://www.openstreetmap.org/?lat=36.423134&lon=-94.320374
+97 +99 http://www.openstreetmap.org/?lat=36.423134&lon=-94.320374
 +x285 http://www.openstreetmap.org/?lat=36.421818&lon=-94.344685
-102 +287 http://www.openstreetmap.org/?lat=36.432397&lon=-94.369264
-104 +289 http://www.openstreetmap.org/?lat=36.464889&lon=-94.378744
+100 +287 http://www.openstreetmap.org/?lat=36.432397&lon=-94.369264
+102 +289 http://www.openstreetmap.org/?lat=36.464889&lon=-94.378744
 AR/MO http://www.openstreetmap.org/?lat=36.499536&lon=-94.382664

--- a/hwy_data/AR/usaus/ar.us071.wpt
+++ b/hwy_data/AR/usaus/ar.us071.wpt
@@ -124,7 +124,7 @@ I-49(87) http://www.openstreetmap.org/?lat=36.363751&lon=-94.175743
 +x49(87) http://www.openstreetmap.org/?lat=36.374131&lon=-94.168797
 I-49(88) http://www.openstreetmap.org/?lat=36.381547&lon=-94.175357
 +x49(90) http://www.openstreetmap.org/?lat=36.399800&lon=-94.185104
-I-49(93) http://www.openstreetmap.org/?lat=36.414583&lon=-94.221810
+I-49(91) +I-49(93) http://www.openstreetmap.org/?lat=36.414583&lon=-94.221810
 RioRd http://www.openstreetmap.org/?lat=36.445822&lon=-94.239039
 AR340 http://www.openstreetmap.org/?lat=36.475691&lon=-94.248034
 AR/MO http://www.openstreetmap.org/?lat=36.499339&lon=-94.269487

--- a/updates.csv
+++ b/updates.csv
@@ -5299,6 +5299,7 @@ date;region;route;root;description
 2017-05-17;(USA) Arizona;Sky Harbor Boulevard;az.skyharblvd;New Route
 2015-08-03;(USA) Arizona;I-11 Future (Hoover Dam);az.i011futhoo;New Route
 2015-08-03;(USA) Arizona;I-11 Future (Kingman);az.i011futkin;New Route
+2023-10-12;(USA) Arkansas;I-49;ar.i049;Northernmost 4 exits renumbered downward by 2 miles. Exit 102 moved from the northern AR 72 junction (now exit 100) to CR 34.
 2023-10-01;(USA) Arkansas;AR 5 (Little Rock);ar.ar005lit;Extended from old west end at AR 7 southward to US 70.
 2023-09-21;(USA) Arkansas;AR 17 (Brinkley);ar.ar017;South end truncated from Butler Lane to Morgan Loop Road.
 2023-09-17;(USA) Arkansas;US 67 Business (Walnut Ridge);ar.us067buswal;South end extended from the US 412 West split at 4th and Main to AR 34/367.


### PR DESCRIPTION
https://www.aaroads.com/forum/index.php?topic=3324.msg2843458#msg2843458
Northernmost 4 exits renumbered downward by 2 miles. Exit 102 moved from the northern AR 72 junction (now exit 100) to CR 34.

Ping @theRadison