### PR TITLE
NY79 new Chenango River bridge

### DIFF
--- a/hwy_data/NY/usany/ny.ny012.wpt
+++ b/hwy_data/NY/usany/ny.ny012.wpt
@@ -3,7 +3,8 @@ NY12A http://www.openstreetmap.org/?lat=42.168302&lon=-75.887632
 BroRd http://www.openstreetmap.org/?lat=42.190436&lon=-75.881324
 CR96 http://www.openstreetmap.org/?lat=42.198415&lon=-75.861132
 NY79_W http://www.openstreetmap.org/?lat=42.239416&lon=-75.845490
-NY79_E http://www.openstreetmap.org/?lat=42.241799&lon=-75.841198
+OldNY79 http://www.openstreetmap.org/?lat=42.241700&lon=-75.841289
+NY79_E http://www.openstreetmap.org/?lat=42.248532&lon=-75.827605
 OakGroDr http://www.openstreetmap.org/?lat=42.251218&lon=-75.823646
 CR2 http://www.openstreetmap.org/?lat=42.302801&lon=-75.802574
 NY41/206 http://www.openstreetmap.org/?lat=42.331932&lon=-75.774078

--- a/hwy_data/NY/usany/ny.ny079.wpt
+++ b/hwy_data/NY/usany/ny.ny079.wpt
@@ -32,8 +32,10 @@ NY26/206 http://www.openstreetmap.org/?lat=42.329404&lon=-75.964065
 BulCreRd http://www.openstreetmap.org/?lat=42.301710&lon=-75.911922
 AleRd http://www.openstreetmap.org/?lat=42.263547&lon=-75.877934
 NY12_S http://www.openstreetmap.org/?lat=42.239416&lon=-75.845490
-NY12_N http://www.openstreetmap.org/?lat=42.241799&lon=-75.841198
-StiRd http://www.openstreetmap.org/?lat=42.246902&lon=-75.809312
+OldNY79 http://www.openstreetmap.org/?lat=42.241700&lon=-75.841289
+NY12_N http://www.openstreetmap.org/?lat=42.248532&lon=-75.827605
+PigHillRd http://www.openstreetmap.org/?lat=42.246475&lon=-75.825416
+CR205 http://www.openstreetmap.org/?lat=42.246902&lon=-75.809312
 NY369 http://www.openstreetmap.org/?lat=42.242572&lon=-75.794806
 SqiHillRd http://www.openstreetmap.org/?lat=42.248745&lon=-75.781846
 CR221 http://www.openstreetmap.org/?lat=42.241343&lon=-75.720949

--- a/updates.csv
+++ b/updates.csv
@@ -6502,6 +6502,8 @@ date;region;route;root;description
 2015-11-20;(USA) New Mexico;US 70;nm.us070;In Lordsburg, route moved from I-10 between exits 22 and 24, and Main St. (NM 494), north to Motel Dr. (I-10BL)
 2015-11-02;(USA) New Mexico;US 380;nm.us380;Swapped locations of labels US285Trk and US70/285
 2015-11-02;(USA) New Mexico;US 70 Truck (Roswell);nm.us070trkros;Removed from southern part of relief route on the west side of Roswell and relocated onto northern part
+2023-10-21;(USA) New York;NY 12;ny.ny012;Waypoint NY79_E moved about 0.9 mi northeast from the OldNY79 waypoint to a new Chenango River bridge approach.
+2023-10-21;(USA) New York;NY 79;ny.ny079;Removed from "Old Route 79", a truss bridge over the Chenango River, and Pigeon Hill Road, and relocated onto NY 12 and a new Chenango River bridge about 0.6 mi northeast of the existing one, between waypoint OldNY79 and Pigeon Hill Road.
 2023-10-08;(USA) New York;LaSalle Expressway;ny.lasexpy;West end removed from Niagara Scenic Parkway and extended west to connect directly to I-190 at exit 21A.
 2023-09-21;(USA) New York;NY 63;ny.ny063;Relocated northward between waypoints *OldNY63_S & *OldNY63_N to reflect a circa 2008 realignment.
 2023-09-21;(USA) New York;NY 364;ny.ny364;NY245_S and NY245_N point labels swapped.


### PR DESCRIPTION
https://forum.travelmapping.net/index.php?topic=5857

**NY12:**
Waypoint NY79_E moved about 0.9 mi northeast from the OldNY79 waypoint to a new Chenango River bridge approach.
Ping @travmapdantheman @drebbin37

**NY79:**
Removed from "Old Route 79", a truss bridge over the Chenango River, and Pigeon Hill Road, and relocated onto NY 12 and a new Chenango River bridge about 0.6 mi northeast of the existing one, between waypoint OldNY79 and Pigeon Hill Road.
Ping @jteresco @bmacs001 @cl994 @travmapdantheman @drebbin37 @Duke87ofST @ajfroggie @Markkos1992 @dlainhart @vdeane