### PR TITLE
NY forum fixes

### DIFF
--- a/hwy_data/NY/usai/ny.i084.wpt
+++ b/hwy_data/NY/usai/ny.i084.wpt
@@ -24,7 +24,7 @@ PA/NY +0 http://www.openstreetmap.org/?lat=41.357794&lon=-74.695407
 +X07 http://www.openstreetmap.org/?lat=41.548546&lon=-73.740406
 +X08 http://www.openstreetmap.org/?lat=41.545848&lon=-73.717747
 58 +17 http://www.openstreetmap.org/?lat=41.508118&lon=-73.681382
-61 +18 http://www.openstreetmap.org/?lat=41.474201&lon=-73.648996
+61 http://www.openstreetmap.org/?lat=41.474201&lon=-73.648996
 65 http://www.openstreetmap.org/?lat=41.424848&lon=-73.626723
 68 +20 http://www.openstreetmap.org/?lat=41.390594&lon=-73.598130
 69 +21 http://www.openstreetmap.org/?lat=41.383597&lon=-73.582456

--- a/hwy_data/NY/usany/ny.ny003.wpt
+++ b/hwy_data/NY/usany/ny.ny003.wpt
@@ -35,7 +35,7 @@ NY178 http://www.openstreetmap.org/?lat=43.845423&lon=-76.196795
 BroRd http://www.openstreetmap.org/?lat=43.892790&lon=-76.128645
 WesBeaSP http://www.openstreetmap.org/?lat=43.903536&lon=-76.120341
 CR75_W +SmiRd http://www.openstreetmap.org/?lat=43.926969&lon=-76.107863
-CR75_E +DodAve http://www.openstreetmap.org/?lat=43.952915&lon=-76.082479
+CR75_E http://www.openstreetmap.org/?lat=43.952915&lon=-76.082479
 NY180 http://www.openstreetmap.org/?lat=43.957175&lon=-76.057556
 I-81 http://www.openstreetmap.org/?lat=43.975738&lon=-75.948486
 US11_S http://www.openstreetmap.org/?lat=43.976503&lon=-75.916847

--- a/hwy_data/NY/usany/ny.ny005.wpt
+++ b/hwy_data/NY/usany/ny.ny005.wpt
@@ -115,11 +115,11 @@ US20_Aub http://www.openstreetmap.org/?lat=42.935167&lon=-76.560486
 CheRidRd http://www.openstreetmap.org/?lat=42.977588&lon=-76.531534
 WeeSenRd http://www.openstreetmap.org/?lat=42.991904&lon=-76.531920
 SteRd http://www.openstreetmap.org/?lat=43.017262&lon=-76.501536
-NY31B http://www.openstreetmap.org/?lat=43.024118&lon=-76.486065
-SHamRd http://www.openstreetmap.org/?lat=43.031914&lon=-76.464372
-NY31C http://www.openstreetmap.org/?lat=43.034047&lon=-76.450446
+BruSt +NY31B http://www.openstreetmap.org/?lat=43.024118&lon=-76.486065
+HamRd http://www.openstreetmap.org/?lat=43.031914&lon=-76.464372
+ValDr http://www.openstreetmap.org/?lat=43.034047&lon=-76.450446
 NY317 http://www.openstreetmap.org/?lat=43.034478&lon=-76.448289
-NY368 http://www.openstreetmap.org/?lat=43.037638&lon=-76.406393
+HalRd http://www.openstreetmap.org/?lat=43.037638&lon=-76.406393
 NY321 http://www.openstreetmap.org/?lat=43.034643&lon=-76.365280
 NY174 http://www.openstreetmap.org/?lat=43.035113&lon=-76.322708
 NewRd http://www.openstreetmap.org/?lat=43.048804&lon=-76.304727
@@ -127,10 +127,10 @@ BenRd http://www.openstreetmap.org/?lat=43.054261&lon=-76.278291
 HinRd http://www.openstreetmap.org/?lat=43.054778&lon=-76.265802
 NY173_W http://www.openstreetmap.org/?lat=43.052740&lon=-76.249559
 NY695 http://www.openstreetmap.org/?lat=43.056440&lon=-76.235805
-WGenSt http://www.openstreetmap.org/?lat=43.048208&lon=-76.224926
+GenSt_W +WGenSt http://www.openstreetmap.org/?lat=43.048208&lon=-76.224926
 FayRd http://www.openstreetmap.org/?lat=43.047291&lon=-76.199133
 EmeAve http://www.openstreetmap.org/?lat=43.052489&lon=-76.187825
-WFaySt http://www.openstreetmap.org/?lat=43.052105&lon=-76.183480
+FaySt +WFaySt http://www.openstreetmap.org/?lat=43.052105&lon=-76.183480
 GedSt http://www.openstreetmap.org/?lat=43.053656&lon=-76.170546
 WestSt http://www.openstreetmap.org/?lat=43.053291&lon=-76.158704
 SalSt http://www.openstreetmap.org/?lat=43.051271&lon=-76.152171

--- a/hwy_data/NY/usany/ny.ny012.wpt
+++ b/hwy_data/NY/usany/ny.ny012.wpt
@@ -76,7 +76,7 @@ OBrRd http://www.openstreetmap.org/?lat=43.825580&lon=-75.577612
 CR25 http://www.openstreetmap.org/?lat=43.858039&lon=-75.637310
 CatSt http://www.openstreetmap.org/?lat=43.893161&lon=-75.673184
 FleRd http://www.openstreetmap.org/?lat=43.909794&lon=-75.702606
-CR69 +SwiRd http://www.openstreetmap.org/?lat=43.916753&lon=-75.742021
+CR69 http://www.openstreetmap.org/?lat=43.916753&lon=-75.742021
 CR67 +BroDr http://www.openstreetmap.org/?lat=43.933120&lon=-75.866261
 NY126 http://www.openstreetmap.org/?lat=43.965515&lon=-75.874929
 NY3_E http://www.openstreetmap.org/?lat=43.967384&lon=-75.881506

--- a/hwy_data/NY/usany/ny.ny035.wpt
+++ b/hwy_data/NY/usany/ny.ny035.wpt
@@ -3,7 +3,7 @@ DivSt +US6_Pee http://www.openstreetmap.org/?lat=41.291673&lon=-73.919878
 US6_E http://www.openstreetmap.org/?lat=41.291891&lon=-73.915291
 CroRd_W http://www.openstreetmap.org/?lat=41.289037&lon=-73.915211
 BearMtnPkwy_W +BearMtPkwy_W http://www.openstreetmap.org/?lat=41.293173&lon=-73.870547
-BearMtnPkwy_E +BearMtPkwy_E http://www.openstreetmap.org/?lat=41.290786&lon=-73.835056
+BearMtnPkwy_E http://www.openstreetmap.org/?lat=41.290786&lon=-73.835056
 TacStaPkwy http://www.openstreetmap.org/?lat=41.292254&lon=-73.821516
 NY132 http://www.openstreetmap.org/?lat=41.294188&lon=-73.808202
 GraSprRd http://www.openstreetmap.org/?lat=41.294515&lon=-73.799844

--- a/hwy_data/NY/usany/ny.ny079.wpt
+++ b/hwy_data/NY/usany/ny.ny079.wpt
@@ -32,9 +32,9 @@ NY26/206 http://www.openstreetmap.org/?lat=42.329404&lon=-75.964065
 BulCreRd http://www.openstreetmap.org/?lat=42.301710&lon=-75.911922
 AleRd http://www.openstreetmap.org/?lat=42.263547&lon=-75.877934
 NY12_S http://www.openstreetmap.org/?lat=42.239416&lon=-75.845490
-OldNY79 http://www.openstreetmap.org/?lat=42.241700&lon=-75.841289
+OldNY79_W http://www.openstreetmap.org/?lat=42.241700&lon=-75.841289
 NY12_N http://www.openstreetmap.org/?lat=42.248532&lon=-75.827605
-PigHillRd http://www.openstreetmap.org/?lat=42.246475&lon=-75.825416
+OldNY79_E +PigHillRd http://www.openstreetmap.org/?lat=42.246475&lon=-75.825416
 CR205 http://www.openstreetmap.org/?lat=42.246902&lon=-75.809312
 NY369 http://www.openstreetmap.org/?lat=42.242572&lon=-75.794806
 SqiHillRd http://www.openstreetmap.org/?lat=42.248745&lon=-75.781846

--- a/hwy_data/NY/usany/ny.ny100.wpt
+++ b/hwy_data/NY/usany/ny.ny100.wpt
@@ -7,7 +7,7 @@ NY100A http://www.openstreetmap.org/?lat=41.019044&lon=-73.798385
 NY119_E http://www.openstreetmap.org/?lat=41.036350&lon=-73.779073
 I-287_S +I-287(5) http://www.openstreetmap.org/?lat=41.040388&lon=-73.785875
 NY119_W http://www.openstreetmap.org/?lat=41.041388&lon=-73.791046
-I-287_N +I-287 http://www.openstreetmap.org/?lat=41.044846&lon=-73.790445
+I-287_N http://www.openstreetmap.org/?lat=41.044846&lon=-73.790445
 LegDr http://www.openstreetmap.org/?lat=41.069251&lon=-73.780618
 NY100A/100C http://www.openstreetmap.org/?lat=41.072729&lon=-73.799908
 LakAve http://www.openstreetmap.org/?lat=41.079963&lon=-73.796561

--- a/hwy_data/NY/usany/ny.ny116.wpt
+++ b/hwy_data/NY/usany/ny.ny116.wpt
@@ -1,6 +1,7 @@
 US202 http://www.openstreetmap.org/?lat=41.331210&lon=-73.680775
 DeaBriRd http://www.openstreetmap.org/?lat=41.331820&lon=-73.679128
 CenWay http://www.openstreetmap.org/?lat=41.327386&lon=-73.672600
+I-684 http://www.openstreetmap.org/?lat=41.326521&lon=-73.657880
 NY22_S http://www.openstreetmap.org/?lat=41.326650&lon=-73.656185
 NY22_N http://www.openstreetmap.org/?lat=41.327576&lon=-73.655670
 +X01 http://www.openstreetmap.org/?lat=41.336814&lon=-73.626380

--- a/hwy_data/NY/usany/ny.ny156.wpt
+++ b/hwy_data/NY/usany/ny.ny156.wpt
@@ -7,5 +7,5 @@ LewRd http://www.openstreetmap.org/?lat=42.694291&lon=-74.057508
 MainSt http://www.openstreetmap.org/?lat=42.700788&lon=-74.033926
 +X02 http://www.openstreetmap.org/?lat=42.660052&lon=-73.997598
 CR307 http://www.openstreetmap.org/?lat=42.657896&lon=-73.990023
-CR208 +SchRd http://www.openstreetmap.org/?lat=42.652057&lon=-73.938482
+CR208 http://www.openstreetmap.org/?lat=42.652057&lon=-73.938482
 NY85A http://www.openstreetmap.org/?lat=42.649290&lon=-73.935102

--- a/hwy_data/NY/usaus/ny.us009.wpt
+++ b/hwy_data/NY/usaus/ny.us009.wpt
@@ -147,7 +147,7 @@ SimHillRd http://www.openstreetmap.org/?lat=44.162253&lon=-73.610673
 NY9N_EliN http://www.openstreetmap.org/?lat=44.212510&lon=-73.598228
 NY9N_EliS http://www.openstreetmap.org/?lat=44.216355&lon=-73.590417
 SteWooRd http://www.openstreetmap.org/?lat=44.246837&lon=-73.567535
-CR12 +StoRd http://www.openstreetmap.org/?lat=44.284163&lon=-73.562779
+CR12 http://www.openstreetmap.org/?lat=44.284163&lon=-73.562779
 CR14 http://www.openstreetmap.org/?lat=44.334682&lon=-73.543728
 +X44 http://www.openstreetmap.org/?lat=44.362821&lon=-73.540721
 +X45 http://www.openstreetmap.org/?lat=44.387060&lon=-73.508014

--- a/updates.csv
+++ b/updates.csv
@@ -6503,7 +6503,7 @@ date;region;route;root;description
 2015-11-02;(USA) New Mexico;US 380;nm.us380;Swapped locations of labels US285Trk and US70/285
 2015-11-02;(USA) New Mexico;US 70 Truck (Roswell);nm.us070trkros;Removed from southern part of relief route on the west side of Roswell and relocated onto northern part
 2023-10-21;(USA) New York;NY 12;ny.ny012;Waypoint NY79_E moved about 0.9 mi northeast from the OldNY79 waypoint to a new Chenango River bridge approach.
-2023-10-21;(USA) New York;NY 79;ny.ny079;Removed from "Old Route 79", a truss bridge over the Chenango River, and Pigeon Hill Road, and relocated onto NY 12 and a new Chenango River bridge about 0.6 mi northeast of the existing one, between waypoint OldNY79 and Pigeon Hill Road.
+2023-10-21;(USA) New York;NY 79;ny.ny079;Removed from "Old Route 79" including a truss bridge over the Chenango River and relocated onto NY 12 and a new Chenango River bridge about 0.6 mi northeast of the existing one, between waypoints OldNY79_W and OldNY79_E.
 2023-10-08;(USA) New York;LaSalle Expressway;ny.lasexpy;West end removed from Niagara Scenic Parkway and extended west to connect directly to I-190 at exit 21A.
 2023-09-21;(USA) New York;NY 63;ny.ny063;Relocated northward between waypoints *OldNY63_S & *OldNY63_N to reflect a circa 2008 realignment.
 2023-09-21;(USA) New York;NY 364;ny.ny364;NY245_S and NY245_N point labels swapped.


### PR DESCRIPTION
https://forum.travelmapping.net/index.php?topic=5857.msg33026#msg33026
`+PigHillRd` is retained as an AltLabel, only in use by @jteresco, in case you feel like updating to the primary label.

---

https://forum.travelmapping.net/index.php?topic=5889
https://forum.travelmapping.net/index.php?topic=5890