### PR TITLE
OK 66B & 136 relocations

### DIFF
--- a/hwy_data/OK/usaok/ok.ok066.wpt
+++ b/hwy_data/OK/usaok/ok.ok066.wpt
@@ -38,8 +38,8 @@ HiwRd http://www.openstreetmap.org/?lat=35.666989&lon=-97.300544
 +X001 http://www.openstreetmap.org/?lat=35.659737&lon=-97.288356
 AshSt http://www.openstreetmap.org/?lat=35.667094&lon=-97.194543
 HarRd http://www.openstreetmap.org/?lat=35.666641&lon=-97.159009
-OK66B_W http://www.openstreetmap.org/?lat=35.679139&lon=-97.093906
-OK102 http://www.openstreetmap.org/?lat=35.680411&lon=-97.088156
+*OldOK66B http://www.openstreetmap.org/?lat=35.679139&lon=-97.093906
+OK66B/102 +OK102 http://www.openstreetmap.org/?lat=35.680411&lon=-97.088156
 OK66B_E http://www.openstreetmap.org/?lat=35.681056&lon=-97.052987
 I-44(158) http://www.openstreetmap.org/?lat=35.680969&lon=-97.046700
 US177 http://www.openstreetmap.org/?lat=35.681021&lon=-97.017260

--- a/hwy_data/OK/usaok/ok.ok066b.wpt
+++ b/hwy_data/OK/usaok/ok.ok066b.wpt
@@ -1,4 +1,5 @@
-OK66_W http://www.openstreetmap.org/?lat=35.679139&lon=-97.093906
+OK66_W http://www.openstreetmap.org/?lat=35.680411&lon=-97.088156
+N3320 http://www.openstreetmap.org/?lat=35.682277&lon=-97.088191
 HicAve http://www.openstreetmap.org/?lat=35.693918&lon=-97.069895
 AshAve http://www.openstreetmap.org/?lat=35.694511&lon=-97.062471
 OK66_E http://www.openstreetmap.org/?lat=35.681056&lon=-97.052987

--- a/hwy_data/OK/usaok/ok.ok136.wpt
+++ b/hwy_data/OK/usaok/ok.ok136.wpt
@@ -1,8 +1,5 @@
 TX/OK http://www.openstreetmap.org/?lat=36.499460&lon=-101.477280
-RdII_E http://www.openstreetmap.org/?lat=36.500443&lon=-101.477687
-RdII_W http://www.openstreetmap.org/?lat=36.502340&lon=-101.492579
-+X001 http://www.openstreetmap.org/?lat=36.556947&lon=-101.492257
-+X002 http://www.openstreetmap.org/?lat=36.565254&lon=-101.475863
+RdEE http://www.openstreetmap.org/?lat=36.565545&lon=-101.475059
 RdAA http://www.openstreetmap.org/?lat=36.616768&lon=-101.474833
 US412_E http://www.openstreetmap.org/?lat=36.677377&lon=-101.474404
 US54_E http://www.openstreetmap.org/?lat=36.677833&lon=-101.474694

--- a/updates.csv
+++ b/updates.csv
@@ -6870,6 +6870,7 @@ date;region;route;root;description
 2015-12-03;(USA) Ohio;OH 762;oh.oh762;Route extended at east end from US23 to Rickenbacker Parkway
 2015-12-03;(USA) Ohio;OH 794;oh.oh794;Route deleted
 2024-01-06;(USA) Oklahoma;OK 66B;ok.ok066b;From waypoint N3320, removed from a demolished west-southwesterly road and relocated due south to OK 66.
+2024-01-06;(USA) Oklahoma;OK 136;ok.ok136;Removed from Road II, Mile 30 & Road EE and relocated onto a direct north-south road between the Texas state line and Road EE.
 2023-10-16;(USA) Oklahoma;US 270;ok.us270;Removed from Chickasaw Ave in Wister and relocated onto a 2-lane southwestern bypass and bridge crossing Caston Creek about 0.3 mi to the south.
 2023-09-30;(USA) Oklahoma;OK 7;ok.ok007;Removed from Medcalf Rd and US 81 and relocated onto the Duncan Bypass.
 2022-11-17;(USA) Oklahoma;OK 344;ok.ok344;Extended northward from Exit 2 to US 64/412.

--- a/updates.csv
+++ b/updates.csv
@@ -6869,6 +6869,7 @@ date;region;route;root;description
 2015-12-03;(USA) Ohio;OH 684;oh.oh684;Route added
 2015-12-03;(USA) Ohio;OH 762;oh.oh762;Route extended at east end from US23 to Rickenbacker Parkway
 2015-12-03;(USA) Ohio;OH 794;oh.oh794;Route deleted
+2024-01-06;(USA) Oklahoma;OK 66B;ok.ok066b;From waypoint N3320, removed from a demolished west-southwesterly road and relocated due south to OK 66.
 2023-10-16;(USA) Oklahoma;US 270;ok.us270;Removed from Chickasaw Ave in Wister and relocated onto a 2-lane southwestern bypass and bridge crossing Caston Creek about 0.3 mi to the south.
 2023-09-30;(USA) Oklahoma;OK 7;ok.ok007;Removed from Medcalf Rd and US 81 and relocated onto the Duncan Bypass.
 2022-11-17;(USA) Oklahoma;OK 344;ok.ok344;Extended northward from Exit 2 to US 64/412.


### PR DESCRIPTION
https://forum.travelmapping.net/index.php?topic=5955
https://forum.travelmapping.net/index.php?topic=6020

`2024-01-06;(USA) Oklahoma;OK 66B;ok.ok066b;From waypoint N3320, removed from a demolished west-southwesterly road and relocated due south to OK 66.`
Ping @mapcat @ua747sp 

`2024-01-06;(USA) Oklahoma;OK 136;ok.ok136;Removed from Road II, Mile 30 & Road EE and relocated onto a direct north-south road between the Texas state line and Road EE.`
Ping @mapcat @theweatherman561 @ovoss