### PR TITLE
Sapulpa 2024-01-29

### DIFF
--- a/hwy_data/OK/usaok/ok.ok033.wpt
+++ b/hwy_data/OK/usaok/ok.ok033.wpt
@@ -63,5 +63,4 @@ OK48 http://www.openstreetmap.org/?lat=36.003146&lon=-96.387091
 N3750 http://www.openstreetmap.org/?lat=35.988355&lon=-96.335335
 I-44 http://www.openstreetmap.org/?lat=35.987313&lon=-96.193972
 OK66_W http://www.openstreetmap.org/?lat=35.985646&lon=-96.191182
-OK117 http://www.openstreetmap.org/?lat=35.992626&lon=-96.141336
-US75Alt http://www.openstreetmap.org/?lat=35.998598&lon=-96.114278
+OK117 +US75Alt http://www.openstreetmap.org/?lat=35.992626&lon=-96.141336

--- a/hwy_data/OK/usaok/ok.ok066.wpt
+++ b/hwy_data/OK/usaok/ok.ok066.wpt
@@ -70,9 +70,10 @@ OK48_N http://www.openstreetmap.org/?lat=35.882687&lon=-96.385288
 290thAve http://www.openstreetmap.org/?lat=35.937571&lon=-96.226244
 MapDr http://www.openstreetmap.org/?lat=35.954092&lon=-96.208756
 OK33_W http://www.openstreetmap.org/?lat=35.985646&lon=-96.191182
-OK117 http://www.openstreetmap.org/?lat=35.992626&lon=-96.141336
-US75Alt +US75Alt_S http://www.openstreetmap.org/?lat=35.998598&lon=-96.114278
-OK117A http://www.openstreetmap.org/?lat=35.999032&lon=-96.098828
+DewAve_W +OK117 http://www.openstreetmap.org/?lat=35.992626&lon=-96.141336
+US75Alt http://www.openstreetmap.org/?lat=35.988494&lon=-96.113892
+OK117_E http://www.openstreetmap.org/?lat=35.988389&lon=-96.098785
+DewAve_E +OK117A +US75Alt_S http://www.openstreetmap.org/?lat=35.999032&lon=-96.098828
 FraRd http://www.openstreetmap.org/?lat=36.012589&lon=-96.098742
 OK364 http://www.openstreetmap.org/?lat=36.029080&lon=-96.089087
 81stSt http://www.openstreetmap.org/?lat=36.046626&lon=-96.078358

--- a/hwy_data/OK/usaok/ok.ok117.wpt
+++ b/hwy_data/OK/usaok/ok.ok117.wpt
@@ -1,5 +1,5 @@
-OK33/66 http://www.openstreetmap.org/?lat=35.992626&lon=-96.141336
+OK33 +OK33/66 http://www.openstreetmap.org/?lat=35.992626&lon=-96.141336
 US75Alt http://www.openstreetmap.org/?lat=35.988494&lon=-96.113892
-OK117A http://www.openstreetmap.org/?lat=35.988389&lon=-96.098785
+OK66_E +OK117A http://www.openstreetmap.org/?lat=35.988389&lon=-96.098785
 49thAve http://www.openstreetmap.org/?lat=35.988424&lon=-96.047416
 US75 http://www.openstreetmap.org/?lat=35.988320&lon=-96.011753

--- a/hwy_data/OK/usaok/ok.ok117a.wpt
+++ b/hwy_data/OK/usaok/ok.ok117a.wpt
@@ -1,2 +1,2 @@
 OK117 http://www.openstreetmap.org/?lat=35.988389&lon=-96.098785
-OK66 +US75Alt http://www.openstreetmap.org/?lat=35.999032&lon=-96.098828
+DewAve +OK66 +US75Alt http://www.openstreetmap.org/?lat=35.999032&lon=-96.098828

--- a/hwy_data/OK/usausb/ok.us075altsap.wpt
+++ b/hwy_data/OK/usausb/ok.us075altsap.wpt
@@ -6,5 +6,5 @@ HecRd http://www.openstreetmap.org/?lat=35.842542&lon=-96.068852
 OK67 http://www.openstreetmap.org/?lat=35.944720&lon=-96.063734
 DugRd http://www.openstreetmap.org/?lat=35.966413&lon=-96.084495
 TeelRd http://www.openstreetmap.org/?lat=35.973863&lon=-96.110930
-OK117 http://www.openstreetmap.org/?lat=35.988494&lon=-96.113892
-OK33/66 +US75_N http://www.openstreetmap.org/?lat=35.998598&lon=-96.114278
+OK66 +OK117 http://www.openstreetmap.org/?lat=35.988494&lon=-96.113892
+OK97 +OK33/66 +US75_N http://www.openstreetmap.org/?lat=35.998598&lon=-96.114278

--- a/updates.csv
+++ b/updates.csv
@@ -6869,6 +6869,8 @@ date;region;route;root;description
 2015-12-03;(USA) Ohio;OH 684;oh.oh684;Route added
 2015-12-03;(USA) Ohio;OH 762;oh.oh762;Route extended at east end from US23 to Rickenbacker Parkway
 2015-12-03;(USA) Ohio;OH 794;oh.oh794;Route deleted
+2024-01-29;(USA) Oklahoma;OK 33;ok.ok033;East end truncated from US 75 Alt and OK 97 to OK 117.
+2024-01-29;(USA) Oklahoma;OK 66;ok.ok066;Removed from Dewey Ave and relocated onto OK 117 & OK 117A (Mission St) between waypoints DewAve_W & DewAve_E.
 2024-01-06;(USA) Oklahoma;OK 66B;ok.ok066b;From waypoint N3320, removed from a demolished west-southwesterly road and relocated due south to OK 66.
 2024-01-06;(USA) Oklahoma;OK 136;ok.ok136;Removed from Road II, Mile 30 & Road EE and relocated onto a direct north-south road between the Texas state line and Road EE.
 2023-10-16;(USA) Oklahoma;US 270;ok.us270;Removed from Chickasaw Ave in Wister and relocated onto a 2-lane southwestern bypass and bridge crossing Caston Creek about 0.3 mi to the south.


### PR DESCRIPTION
https://forum.travelmapping.net/index.php?topic=5496
**OK33:** East end truncated from US 75 Alt and OK 97 to OK 117.
**OK66:** Removed from Dewey Ave and relocated onto OK 117 & OK 117A (Mission St) between waypoints DewAve_W & DewAve_E.

Ping @dietrichmd @bejacob _@mapcat @si404_ @bhoward @ozarkman417 _@theradison @scott5114_ @ua747sp
...and a few others. Something's changed at GitHub and now my script won't pull usernames 100% of the time. :(