### PR TITLE
Update ca.ca058.wpt

### DIFF
--- a/hwy_data/CA/usaca/ca.ca058.wpt
+++ b/hwy_data/CA/usaca/ca.ca058.wpt
@@ -35,16 +35,15 @@ CA33_N http://www.openstreetmap.org/?lat=35.308366&lon=-119.622241
 LokRd http://www.openstreetmap.org/?lat=35.398220&lon=-119.536502
 WasWay http://www.openstreetmap.org/?lat=35.399090&lon=-119.447640
 I-5(257) +I-5 http://www.openstreetmap.org/?lat=35.398872&lon=-119.397353
-CA43_N http://www.openstreetmap.org/?lat=35.398056&lon=-119.252075
-CA43_S http://www.openstreetmap.org/?lat=35.383484&lon=-119.252129
-NordAve http://www.openstreetmap.org/?lat=35.383461&lon=-119.198796
-AllRd http://www.openstreetmap.org/?lat=35.383581&lon=-119.145549
-CalDr http://www.openstreetmap.org/?lat=35.383478&lon=-119.109960
-CofRd http://www.openstreetmap.org/?lat=35.383426&lon=-119.092194
-MohSt http://www.openstreetmap.org/?lat=35.383312&lon=-119.065447
-CA99(26) http://www.openstreetmap.org/?lat=35.383106&lon=-119.044515
-CA99(25) http://www.openstreetmap.org/?lat=35.368331&lon=-119.041833
-CA99(24) http://www.openstreetmap.org/?lat=35.352674&lon=-119.039505
+I-5(253) http://www.openstreetmap.org/?lat=35.354944&lon=-119.336007
+CA43 http://www.openstreetmap.org/?lat=35.354362&lon=-119.252123
+StoHwy_E +StoHwy http://www.openstreetmap.org/?lat=35.355272&lon=-119.175514
+AllRd http://www.openstreetmap.org/?lat=35.361053&lon=-119.145522
+CalDr http://www.openstreetmap.org/?lat=35.361921&lon=-119.115950
+CofRd http://www.openstreetmap.org/?lat=35.366989&lon=-119.092100
+MohSt http://www.openstreetmap.org/?lat=35.371544&lon=-119.065914
+TruAve http://www.openstreetmap.org/?lat=35.370455&lon=-119.058130
+110 +CA99(24) http://www.openstreetmap.org/?lat=35.352674&lon=-119.039505
 111 http://www.openstreetmap.org/?lat=35.352569&lon=-119.020064
 112 http://www.openstreetmap.org/?lat=35.352411&lon=-119.003005
 113 http://www.openstreetmap.org/?lat=35.352411&lon=-118.985313


### PR DESCRIPTION
For reroute of CA 58 in the Bakersfield area, completed 2/17. 

.csv changes to delete ca.ca58wes and ca.wespkwy (both absorbed by new CA 58 alignment), make both deleted routes as alt names for ca.ca058, and add Updates entries, to follow in separate pull requests later today.