### PR TITLE
MN cleanup

### DIFF
--- a/hwy_data/MN/usamn/mn.mn029.wpt
+++ b/hwy_data/MN/usamn/mn.mn029.wpt
@@ -28,7 +28,8 @@ CR54_W http://www.openstreetmap.org/?lat=45.643868&lon=-95.436516
 CR24 http://www.openstreetmap.org/?lat=45.655148&lon=-95.424457
 CR54_E http://www.openstreetmap.org/?lat=45.650303&lon=-95.394845
 MN28/104 http://www.openstreetmap.org/?lat=45.650258&lon=-95.390038
-MN55 http://www.openstreetmap.org/?lat=45.675242&lon=-95.386477
+160thSt http://www.openstreetmap.org/?lat=45.671861&lon=-95.386519
+*MN55 http://www.openstreetmap.org/?lat=45.676067&lon=-95.386562
 CR28_S http://www.openstreetmap.org/?lat=45.715363&lon=-95.387068
 CR88 http://www.openstreetmap.org/?lat=45.766565&lon=-95.384717
 CR4 http://www.openstreetmap.org/?lat=45.795103&lon=-95.387785

--- a/hwy_data/MN/usamn/mn.mn030.wpt
+++ b/hwy_data/MN/usamn/mn.mn030.wpt
@@ -84,8 +84,10 @@ CR9 http://www.openstreetmap.org/?lat=43.892156&lon=-92.798789
 CR13_E +CR13Dod http://www.openstreetmap.org/?lat=43.892156&lon=-92.738600
 CR3_C http://www.openstreetmap.org/?lat=43.891615&lon=-92.638242
 CR15_E http://www.openstreetmap.org/?lat=43.891862&lon=-92.578440
-CR8 http://www.openstreetmap.org/?lat=43.891816&lon=-92.528594
-US63_N http://www.openstreetmap.org/?lat=43.891692&lon=-92.486805
+CR8_S http://www.openstreetmap.org/?lat=43.891816&lon=-92.528594
+CR8_N http://www.openstreetmap.org/?lat=43.920666&lon=-92.528368
+US63/16 http://www.openstreetmap.org/?lat=43.917070&lon=-92.477213
+*90thSt +US63_N http://www.openstreetmap.org/?lat=43.891692&lon=-92.486805
 I-90 http://www.openstreetmap.org/?lat=43.885166&lon=-92.488124
 CR35 http://www.openstreetmap.org/?lat=43.862814&lon=-92.488554
 US63_S http://www.openstreetmap.org/?lat=43.855543&lon=-92.488511

--- a/hwy_data/MN/usamn/mn.mn055.wpt
+++ b/hwy_data/MN/usamn/mn.mn055.wpt
@@ -25,7 +25,8 @@ MN114_N http://www.openstreetmap.org/?lat=45.712967&lon=-95.530479
 MN114_S http://www.openstreetmap.org/?lat=45.707078&lon=-95.519493
 270thAve http://www.openstreetmap.org/?lat=45.697877&lon=-95.489860
 CR15 http://www.openstreetmap.org/?lat=45.696274&lon=-95.449219
-MN29 http://www.openstreetmap.org/?lat=45.675242&lon=-95.386477
+*MN29 http://www.openstreetmap.org/?lat=45.676067&lon=-95.386562
+160thSt_Gle http://www.openstreetmap.org/?lat=45.671981&lon=-95.382593
 14thAve http://www.openstreetmap.org/?lat=45.662797&lon=-95.380898
 MN28 http://www.openstreetmap.org/?lat=45.647933&lon=-95.369654
 CR18_W http://www.openstreetmap.org/?lat=45.585798&lon=-95.285347

--- a/hwy_data/MN/usamn/mn.mn056.wpt
+++ b/hwy_data/MN/usamn/mn.mn056.wpt
@@ -18,7 +18,7 @@ US14_E http://www.openstreetmap.org/?lat=44.018566&lon=-92.859181
 *635thSt http://www.openstreetmap.org/?lat=44.026782&lon=-92.892151
 US14/5 http://www.openstreetmap.org/?lat=44.033852&lon=-92.914617
 CRH +US14_W http://www.openstreetmap.org/?lat=44.041460&lon=-92.902386
-US14Bus http://www.openstreetmap.org/?lat=44.051810&lon=-92.899430
+CR34 +US14Bus http://www.openstreetmap.org/?lat=44.051810&lon=-92.899430
 CR16 http://www.openstreetmap.org/?lat=44.088124&lon=-92.899489
 CR24 http://www.openstreetmap.org/?lat=44.153452&lon=-92.899382
 CR11_N http://www.openstreetmap.org/?lat=44.211388&lon=-92.931397

--- a/hwy_data/MN/usamn/mn.mn092.wpt
+++ b/hwy_data/MN/usamn/mn.mn092.wpt
@@ -4,7 +4,7 @@ CR12_N http://www.openstreetmap.org/?lat=47.832302&lon=-96.127582
 +X163435 http://www.openstreetmap.org/?lat=47.831826&lon=-96.082091
 CR117 http://www.openstreetmap.org/?lat=47.818140&lon=-96.068273
 US59 http://www.openstreetmap.org/?lat=47.818587&lon=-95.999511
-MN222 http://www.openstreetmap.org/?lat=47.818990&lon=-95.858438
+CR5Okl http://www.openstreetmap.org/?lat=47.818990&lon=-95.858438
 CR8 http://www.openstreetmap.org/?lat=47.776238&lon=-95.857430
 277thSt http://www.openstreetmap.org/?lat=47.775329&lon=-95.816231
 CR6 http://www.openstreetmap.org/?lat=47.783173&lon=-95.730014
@@ -13,7 +13,7 @@ CR74 http://www.openstreetmap.org/?lat=47.775675&lon=-95.656886
 CR2 http://www.openstreetmap.org/?lat=47.761830&lon=-95.623069
 CR66 http://www.openstreetmap.org/?lat=47.760041&lon=-95.577707
 CR7 http://www.openstreetmap.org/?lat=47.736827&lon=-95.516660
-CR5 http://www.openstreetmap.org/?lat=47.693833&lon=-95.431023
+CR5Cle http://www.openstreetmap.org/?lat=47.693833&lon=-95.431023
 CR3/6 http://www.openstreetmap.org/?lat=47.673681&lon=-95.430315
 MN223 http://www.openstreetmap.org/?lat=47.645225&lon=-95.426517
 CR114 http://www.openstreetmap.org/?lat=47.596455&lon=-95.425894

--- a/hwy_data/MN/usamn/mn.mn092.wpt
+++ b/hwy_data/MN/usamn/mn.mn092.wpt
@@ -4,7 +4,7 @@ CR12_N http://www.openstreetmap.org/?lat=47.832302&lon=-96.127582
 +X163435 http://www.openstreetmap.org/?lat=47.831826&lon=-96.082091
 CR117 http://www.openstreetmap.org/?lat=47.818140&lon=-96.068273
 US59 http://www.openstreetmap.org/?lat=47.818587&lon=-95.999511
-CR5Okl http://www.openstreetmap.org/?lat=47.818990&lon=-95.858438
+CR5_Okl http://www.openstreetmap.org/?lat=47.818990&lon=-95.858438
 CR8 http://www.openstreetmap.org/?lat=47.776238&lon=-95.857430
 277thSt http://www.openstreetmap.org/?lat=47.775329&lon=-95.816231
 CR6 http://www.openstreetmap.org/?lat=47.783173&lon=-95.730014
@@ -13,7 +13,7 @@ CR74 http://www.openstreetmap.org/?lat=47.775675&lon=-95.656886
 CR2 http://www.openstreetmap.org/?lat=47.761830&lon=-95.623069
 CR66 http://www.openstreetmap.org/?lat=47.760041&lon=-95.577707
 CR7 http://www.openstreetmap.org/?lat=47.736827&lon=-95.516660
-CR5Cle http://www.openstreetmap.org/?lat=47.693833&lon=-95.431023
+CR5_Cle http://www.openstreetmap.org/?lat=47.693833&lon=-95.431023
 CR3/6 http://www.openstreetmap.org/?lat=47.673681&lon=-95.430315
 MN223 http://www.openstreetmap.org/?lat=47.645225&lon=-95.426517
 CR114 http://www.openstreetmap.org/?lat=47.596455&lon=-95.425894

--- a/hwy_data/MN/usamn/mn.mn222.wpt
+++ b/hwy_data/MN/usamn/mn.mn222.wpt
@@ -1,2 +1,0 @@
-MN92 http://www.openstreetmap.org/?lat=47.818990&lon=-95.858438
-CR5/53 http://www.openstreetmap.org/?lat=47.840353&lon=-95.858459

--- a/hwy_data/MN/usaus/mn.us014.wpt
+++ b/hwy_data/MN/usaus/mn.us014.wpt
@@ -114,12 +114,12 @@ CR7_Win http://www.openstreetmap.org/?lat=44.000378&lon=-91.468509
 +x12 http://www.openstreetmap.org/?lat=43.987566&lon=-91.435754
 CR3_Win http://www.openstreetmap.org/?lat=43.974434&lon=-91.426721
 +x13 http://www.openstreetmap.org/?lat=43.958395&lon=-91.398289
-CR101 http://www.openstreetmap.org/?lat=43.919288&lon=-91.363238
+CR12/101 http://www.openstreetmap.org/?lat=43.919288&lon=-91.363238
 I-90(269) http://www.openstreetmap.org/?lat=43.914713&lon=-91.363227
 I-90(270) http://www.openstreetmap.org/?lat=43.912780&lon=-91.361532
 I-90(272A) http://www.openstreetmap.org/?lat=43.890996&lon=-91.342585
 I-90(272B) http://www.openstreetmap.org/?lat=43.886086&lon=-91.337339
 I-90(276) +I-90(275) http://www.openstreetmap.org/?lat=43.859434&lon=-91.308285
 +x14 http://www.openstreetmap.org/?lat=43.842838&lon=-91.297996
-MN16 http://www.openstreetmap.org/?lat=43.825905&lon=-91.303720
+MN16_W +MN16 http://www.openstreetmap.org/?lat=43.825905&lon=-91.303720
 MN/WI http://www.openstreetmap.org/?lat=43.818806&lon=-91.273266

--- a/hwy_data/MN/usaus/mn.us061.wpt
+++ b/hwy_data/MN/usaus/mn.us061.wpt
@@ -1,12 +1,12 @@
 WI/MN +MN/WI http://www.openstreetmap.org/?lat=43.818806&lon=-91.273266
-MN16 http://www.openstreetmap.org/?lat=43.825905&lon=-91.303720
+MN16_W +MN16 http://www.openstreetmap.org/?lat=43.825905&lon=-91.303720
 +x01 http://www.openstreetmap.org/?lat=43.842838&lon=-91.297996
 I-90(276) +I-90(275) http://www.openstreetmap.org/?lat=43.859434&lon=-91.308285
 I-90(272B) http://www.openstreetmap.org/?lat=43.886086&lon=-91.337339
 I-90(272A) http://www.openstreetmap.org/?lat=43.890996&lon=-91.342585
 I-90(270) http://www.openstreetmap.org/?lat=43.912780&lon=-91.361532
 I-90(269) http://www.openstreetmap.org/?lat=43.914713&lon=-91.363227
-CR101 http://www.openstreetmap.org/?lat=43.919288&lon=-91.363238
+CR12/101 http://www.openstreetmap.org/?lat=43.919288&lon=-91.363238
 +x02 http://www.openstreetmap.org/?lat=43.958395&lon=-91.398289
 CR3 http://www.openstreetmap.org/?lat=43.974434&lon=-91.426721
 +x03 http://www.openstreetmap.org/?lat=43.987566&lon=-91.435754

--- a/hwy_data/MN/usaus/mn.us063.wpt
+++ b/hwy_data/MN/usaus/mn.us063.wpt
@@ -12,8 +12,8 @@ CR6 http://www.openstreetmap.org/?lat=43.848394&lon=-92.488489
 MN30_E http://www.openstreetmap.org/?lat=43.855543&lon=-92.488511
 CR35 http://www.openstreetmap.org/?lat=43.862814&lon=-92.488554
 I-90 +I-90(209) http://www.openstreetmap.org/?lat=43.885166&lon=-92.488124
-MN30_W http://www.openstreetmap.org/?lat=43.891692&lon=-92.486805
-CR16 http://www.openstreetmap.org/?lat=43.917070&lon=-92.477213
+*90thSt +MN30_W http://www.openstreetmap.org/?lat=43.891692&lon=-92.486805
+MN30/16 http://www.openstreetmap.org/?lat=43.917070&lon=-92.477213
 60thSt http://www.openstreetmap.org/?lat=43.936627&lon=-92.466388
 48thSt http://www.openstreetmap.org/?lat=43.953019&lon=-92.468437
 40thSt http://www.openstreetmap.org/?lat=43.963832&lon=-92.463523

--- a/hwy_data/MN/usausb/mn.us014busdod.wpt
+++ b/hwy_data/MN/usausb/mn.us014busdod.wpt
@@ -1,4 +1,0 @@
-MN56_N +US14_W http://www.openstreetmap.org/?lat=44.05181&lon=-92.89943
-CR7 http://www.openstreetmap.org/?lat=44.03273&lon=-92.85919
-CR34_E http://www.openstreetmap.org/?lat=44.02985&lon=-92.83910
-US14_E http://www.openstreetmap.org/?lat=44.023334&lon=-92.841361

--- a/hwy_data/_systems/usamn.csv
+++ b/hwy_data/_systems/usamn.csv
@@ -114,7 +114,6 @@ usamn;MN;MN210;;;;mn.mn210;
 usamn;MN;MN217;;;;mn.mn217;
 usamn;MN;MN219;;;;mn.mn219;
 usamn;MN;MN220;;;;mn.mn220;
-usamn;MN;MN222;;;;mn.mn222;
 usamn;MN;MN223;;;;mn.mn223;
 usamn;MN;MN226;;;;mn.mn226;
 usamn;MN;MN238;;;;mn.mn238;

--- a/hwy_data/_systems/usamn_con.csv
+++ b/hwy_data/_systems/usamn_con.csv
@@ -112,7 +112,6 @@ usamn;MN210;;;mn.mn210
 usamn;MN217;;;mn.mn217
 usamn;MN219;;;mn.mn219
 usamn;MN220;;;mn.mn220
-usamn;MN222;;;mn.mn222
 usamn;MN223;;;mn.mn223
 usamn;MN226;;;mn.mn226
 usamn;MN238;;;mn.mn238

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -104,7 +104,6 @@ usausb;WY;US14;Bus;She;Sheridan, WY;wy.us014busshe;
 usausb;SD;US14;Alt;Dea;Deadwood, SD;sd.us014altdea;
 usausb;SD;US14;Byp;Bro;Brookings, SD;sd.us014bypbro;
 usausb;SD;US14;Trk;Pie;Pierre, SD;sd.us014trkpie;
-usausb;MN;US14;Bus;Dod;Dodge Center, MN;mn.us014busdod;
 usausb;SC;US15;Bus;Har;Hartsville, SC;sc.us015bushar;
 usausb;NC;US15;Bus;Lau;Laurinburg, NC;nc.us015buslau;
 usausb;NC;US15;Bus;Dur;Durham, NC;nc.us015busdur;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -101,7 +101,6 @@ usausb;US14;Bus;Sheridan, WY;wy.us014busshe
 usausb;US14;Alt;Deadwood, SD;sd.us014altdea
 usausb;US14;Byp;Brookings, SD;sd.us014bypbro
 usausb;US14;Trk;Pierre, SD;sd.us014trkpie
-usausb;US14;Bus;Dodge Center, MN;mn.us014busdod
 usausb;US15;Bus;Hartsville, SC;sc.us015bushar
 usausb;US15;Bus;Laurinburg, NC;nc.us015buslau
 usausb;US15;Bus;Durham, NC;nc.us015busdur

--- a/updates.csv
+++ b/updates.csv
@@ -7493,6 +7493,9 @@ date;region;route;root;description
 2023-02-11;(USA) Minnesota;MN 274;;Deleted route
 2024-06-19;(USA) Minnesota;US 14;mn.us014;Route relocated onto Courtland bypass
 2024-06-19;(USA) Minnesota;MN 44 Business (Caledonia);mn.mn044buscal;New route
+2024-06-29;(USA) Minnesota;US 14 Busines (Dodge Center);;Deleted route
+2024-06-29;(USA) Minnesota;MN 222;;Deleted route
+2024-06-29;(USA) Minnesota;MN 30;mn.mn030;Route relocated north of Rochester Airport via CR 8/CR 16/US 63
 2018-05-05;(USA) Mississippi;I-269;ms.i269;Extended west to MS 305/Exit 9
 2018-04-11;(USA) Mississippi;US 278;ms.us278;Relocated onto Corridor V through southern Tupelo
 2017-04-24;(USA) Mississippi;I-22;ms.i022;New Route


### PR DESCRIPTION
BUS US 14 Dodge Center removed due to lack of signage.

MN 222 removed due to turnback.

MN 30 realigned north of Rochester Airport via CR 8/CR 16/US 63.