### PR TITLE
ME26 relocated onto ME26A in Gray

### DIFF
--- a/hwy_data/CT/usasf/ct.cttpk.wpt
+++ b/hwy_data/CT/usasf/ct.cttpk.wpt
@@ -1,4 +1,4 @@
 I-395 http://www.openstreetmap.org/?lat=41.764973&lon=-71.871696
-SquRockRd http://www.openstreetmap.org/?lat=41.766629&lon=-71.869504
-RossRd http://www.openstreetmap.org/?lat=41.771728&lon=-71.857788
+1 +SquRockRd http://www.openstreetmap.org/?lat=41.766629&lon=-71.869504
+1A http://www.openstreetmap.org/?lat=41.771728&lon=-71.857788
 US6 http://www.openstreetmap.org/?lat=41.791921&lon=-71.797681

--- a/hwy_data/ME/usame/me.me004.wpt
+++ b/hwy_data/ME/usame/me.me004.wpt
@@ -42,10 +42,10 @@ FalRd http://www.openstreetmap.org/?lat=43.824806&lon=-70.388632
 DutHillRd http://www.openstreetmap.org/?lat=43.831988&lon=-70.382243
 ME115_W http://www.openstreetmap.org/?lat=43.850870&lon=-70.383911
 RamRd http://www.openstreetmap.org/?lat=43.879726&lon=-70.355335
-ME26A_N http://www.openstreetmap.org/?lat=43.883039&lon=-70.338914
+ME26_N +ME26A_N http://www.openstreetmap.org/?lat=43.883039&lon=-70.338914
 I-95(63) http://www.openstreetmap.org/?lat=43.883538&lon=-70.336157
 ME26_S http://www.openstreetmap.org/?lat=43.885247&lon=-70.330664
-ME26_N http://www.openstreetmap.org/?lat=43.885871&lon=-70.330353
+ShaRd http://www.openstreetmap.org/?lat=43.885871&lon=-70.330353
 MayRd http://www.openstreetmap.org/?lat=43.917371&lon=-70.317521
 MorRd http://www.openstreetmap.org/?lat=43.927954&lon=-70.310161
 GloHillRd http://www.openstreetmap.org/?lat=43.939617&lon=-70.303268

--- a/hwy_data/ME/usame/me.me026.wpt
+++ b/hwy_data/ME/usame/me.me026.wpt
@@ -9,12 +9,14 @@ CanRd http://www.openstreetmap.org/?lat=43.690692&lon=-70.277765
 ME100_S http://www.openstreetmap.org/?lat=43.699737&lon=-70.288146
 WasAve_N http://www.openstreetmap.org/?lat=43.701618&lon=-70.289009
 LamSt http://www.openstreetmap.org/?lat=43.715287&lon=-70.292217
-I-95 http://www.openstreetmap.org/?lat=43.732660&lon=-70.296342
+I-95(53) http://www.openstreetmap.org/?lat=43.732660&lon=-70.296342
 FalRd http://www.openstreetmap.org/?lat=43.746719&lon=-70.298445
 BlaRd http://www.openstreetmap.org/?lat=43.815493&lon=-70.313686
-US202_W http://www.openstreetmap.org/?lat=43.885247&lon=-70.330664
-US202_E http://www.openstreetmap.org/?lat=43.885871&lon=-70.330353
-ME26A_N http://www.openstreetmap.org/?lat=43.898801&lon=-70.343528
+US202/4_E +US202_W +ME26_S http://www.openstreetmap.org/?lat=43.885247&lon=-70.330664
+I-95(63) +I-95 http://www.openstreetmap.org/?lat=43.883538&lon=-70.336157
+US202/4_W http://www.openstreetmap.org/?lat=43.883039&lon=-70.338914
++X26A http://www.openstreetmap.org/?lat=43.895745&lon=-70.345572
+ShaRd +ME26A_N +ME26_N http://www.openstreetmap.org/?lat=43.898801&lon=-70.343528
 NRayRd http://www.openstreetmap.org/?lat=43.918666&lon=-70.355651
 SabRd_S http://www.openstreetmap.org/?lat=43.944036&lon=-70.349482
 SabRd_N http://www.openstreetmap.org/?lat=43.971403&lon=-70.363382

--- a/hwy_data/ME/usame/me.me026agra.wpt
+++ b/hwy_data/ME/usame/me.me026agra.wpt
@@ -1,5 +1,0 @@
-ME26_S http://www.openstreetmap.org/?lat=43.885247&lon=-70.330664
-I-95 http://www.openstreetmap.org/?lat=43.883538&lon=-70.336157
-US202_W http://www.openstreetmap.org/?lat=43.883039&lon=-70.338914
-+X00001 http://www.openstreetmap.org/?lat=43.895882&lon=-70.345631
-ME26_N http://www.openstreetmap.org/?lat=43.898801&lon=-70.343528

--- a/hwy_data/ME/usame/me.me100.wpt
+++ b/hwy_data/ME/usame/me.me100.wpt
@@ -16,7 +16,7 @@ I-95(53) http://www.openstreetmap.org/?lat=43.732660&lon=-70.296342
 FalRd http://www.openstreetmap.org/?lat=43.746719&lon=-70.298445
 BlaRd http://www.openstreetmap.org/?lat=43.815493&lon=-70.313686
 US202_W http://www.openstreetmap.org/?lat=43.885247&lon=-70.330664
-ME26_N http://www.openstreetmap.org/?lat=43.885871&lon=-70.330353
+ShaRd +ME26_N http://www.openstreetmap.org/?lat=43.885871&lon=-70.330353
 MayRd http://www.openstreetmap.org/?lat=43.917371&lon=-70.317521
 MorRd http://www.openstreetmap.org/?lat=43.927954&lon=-70.310161
 GloHillRd http://www.openstreetmap.org/?lat=43.939617&lon=-70.303268

--- a/hwy_data/ME/usame/me.me115.wpt
+++ b/hwy_data/ME/usame/me.me115.wpt
@@ -3,7 +3,7 @@ FalRd http://www.openstreetmap.org/?lat=43.838195&lon=-70.421172
 +x0 http://www.openstreetmap.org/?lat=43.841662&lon=-70.403422
 US202_W http://www.openstreetmap.org/?lat=43.850870&lon=-70.383911
 RamRd http://www.openstreetmap.org/?lat=43.879726&lon=-70.355335
-ME26A_N http://www.openstreetmap.org/?lat=43.883039&lon=-70.338914
+ME26_N +ME26A_N http://www.openstreetmap.org/?lat=43.883039&lon=-70.338914
 I-95 http://www.openstreetmap.org/?lat=43.883538&lon=-70.336157
 US202_E http://www.openstreetmap.org/?lat=43.885247&lon=-70.330664
 BroSt http://www.openstreetmap.org/?lat=43.885614&lon=-70.327204

--- a/hwy_data/ME/usaus/me.us202.wpt
+++ b/hwy_data/ME/usaus/me.us202.wpt
@@ -38,10 +38,10 @@ FalRd http://www.openstreetmap.org/?lat=43.824806&lon=-70.388632
 DutHillRd http://www.openstreetmap.org/?lat=43.831988&lon=-70.382243
 ME115_W http://www.openstreetmap.org/?lat=43.850870&lon=-70.383911
 RamRd http://www.openstreetmap.org/?lat=43.879726&lon=-70.355335
-ME26A_N http://www.openstreetmap.org/?lat=43.883039&lon=-70.338914
+ME26_N +ME26A_N http://www.openstreetmap.org/?lat=43.883039&lon=-70.338914
 I-95(63) http://www.openstreetmap.org/?lat=43.883538&lon=-70.336157
 ME26_S http://www.openstreetmap.org/?lat=43.885247&lon=-70.330664
-ME26_N http://www.openstreetmap.org/?lat=43.885871&lon=-70.330353
+ShaRd http://www.openstreetmap.org/?lat=43.885871&lon=-70.330353
 MayRd http://www.openstreetmap.org/?lat=43.917371&lon=-70.317521
 MorRd http://www.openstreetmap.org/?lat=43.927954&lon=-70.310161
 GloHillRd http://www.openstreetmap.org/?lat=43.939617&lon=-70.303268

--- a/hwy_data/_systems/usame.csv
+++ b/hwy_data/_systems/usame.csv
@@ -26,7 +26,6 @@ usame;ME;ME24;Bus;Bru;Brunswick;me.me024busbru;
 usame;ME;ME25;;;;me.me025;
 usame;ME;ME25;Bus;Wes;Westbrook;me.me025buswes;
 usame;ME;ME26;;;;me.me026;
-usame;ME;ME26A;;Gra;Gray;me.me026agra;
 usame;ME;ME27;;;;me.me027;
 usame;ME;ME32;;;;me.me032;
 usame;ME;ME35;;;;me.me035;

--- a/hwy_data/_systems/usame_con.csv
+++ b/hwy_data/_systems/usame_con.csv
@@ -26,7 +26,6 @@ usame;ME24;Bus;Brunswick;me.me024busbru
 usame;ME25;;;me.me025
 usame;ME25;Bus;Westbrook;me.me025buswes
 usame;ME26;;;me.me026
-usame;ME26A;;Gray;me.me026agra
 usame;ME27;;;me.me027
 usame;ME32;;;me.me032
 usame;ME35;;;me.me035

--- a/updates.csv
+++ b/updates.csv
@@ -7254,6 +7254,10 @@ date;region;route;root;description
 2017-06-19;(USA) Louisiana;I-49 (Belcher);la.i049bel;Extended south from exit 215 to exit 211
 2015-10-10;(USA) Louisiana;US 371;la.us371;Removed from LA 177 and US84 and relocated onto a new two-lane east-west roadway between the LA 177 north split and the US 84 / LA 1 junction
 2015-09-03;(USA) Louisiana;I-49 (Belcher);la.i049bel;Extended north from exit 234 to the Arkansas state line
+2024-07-04;(USA) Maine;US 202;me.us202;Waypoint ME26_N moved from Shaker Rd to Maine Wildlife Parkway.
+2024-07-04;(USA) Maine;ME 4;me.me004;Waypoint ME26_N moved from Shaker Rd to Maine Wildlife Parkway.
+2024-07-04;(USA) Maine;ME 26;me.me026;Removed from Main St & Shaker Rd and relocated onto West Gray Rd & Maine Wildlife Parkway from the junction of routes 202, 4, 100 & 115 to Shaker Rd. Waypoint I-95 is now an alternate label for I-95(63) rather than the existing location at I-95(53).
+2024-07-04;(USA) Maine;ME 26A (Gray);me.me026;Deleted. redesignated as ME 26.
 2023-10-09;(USA) Maine;US 201;me.us201;SB alignment removed from ME11 and Main St in Waterville, and relocated onto existing NB alignment on Front St, which now carries two-way-traffic.
 2021-01-28;(USA) Maine;Paradise Hill Road, Acadia NP;me.parhillrd;North end truncated from ME 3 to Visitor Center Rd.
 2019-08-30;(USA) Maine;US 2;me.us002;Waypoint label ME232 moved from Church Street to the 2015 Martin Memorial Bridge.


### PR DESCRIPTION
**ME26 broken for:**
Based8 Cw9 dharwood JamesMD mapcat tckma terescoj w9tam wadsteckel
Ping @mapcat @tckma317 @jteresco

**Ping @USRoute220**
In making the new route of ME26 backwards-compatible with old .list entries for ME26A, I had to either:
* Keep the `I-95` point label at its existing location at Exit 53, breaking that point for the six people using it on ME26A, or
* Move plain `I-95` to Exit 63 and avoid breaking those six lists, breaking only SK220.list intead.

I chose the latter option as the lesser evil. You'll want to change `ME ME26 FalRd I-95` to `ME ME26 FalRd I-95(53)`.

**Ping @jteresco**
Label `ME26_N` has moved on both US202 & ME4. You'll want to use `ShaRd` instead.
Next time you go to Sunday River... well, I imagine'd that probably be via NH US2 rather than Southern Maine. :grin: