### PR TITLE
Update qc.qc117.wpt

### DIFF
--- a/hwy_data/QC/canqc/qc.qc117.wpt
+++ b/hwy_data/QC/canqc/qc.qc117.wpt
@@ -25,7 +25,7 @@ BoulLacStF http://www.openstreetmap.org/?lat=45.824816&lon=-74.051263
 RueSta http://www.openstreetmap.org/?lat=45.873302&lon=-74.077184
 RueLouMor http://www.openstreetmap.org/?lat=45.878284&lon=-74.089788
 ChSteAnne http://www.openstreetmap.org/?lat=45.883866&lon=-74.101996
-ChMou http://www.openstreetmap.org/?lat=45.893775&lon=-74.121811
+ChMou_Pie http://www.openstreetmap.org/?lat=45.893775&lon=-74.121811
 ChGare http://www.openstreetmap.org/?lat=45.904658&lon=-74.137963
 ChMontGab http://www.openstreetmap.org/?lat=45.920705&lon=-74.145593
 A-15(67) http://www.openstreetmap.org/?lat=45.941825&lon=-74.126189


### PR DESCRIPTION
Fixed duplicate label error, for new point not in use.