### PR TITLE
Removed designated minority name from CHN regions.csv

### DIFF
--- a/regions.csv
+++ b/regions.csv
@@ -92,8 +92,8 @@ CHN-BJ;Beijing;CHN;ASI;Municipality
 CHN-CQ;Chongqing;CHN;ASI;Municipality
 CHN-FJ;Fujian;CHN;ASI;Province
 CHN-GD;Guangdong;CHN;ASI;Province
-CHN-GS;Guansu;CHN;ASI;Province
-CHN-GX;Guanxi;CHN;ASI;Autonomous Region
+CHN-GS;Gansu;CHN;ASI;Province
+CHN-GX;Guangxi;CHN;ASI;Autonomous Region
 CHN-GZ;Guizhou;CHN;ASI;Province
 CHN-HA;Henan;CHN;ASI;Province
 CHN-HB;Hubai;CHN;ASI;Province

--- a/regions.csv
+++ b/regions.csv
@@ -93,7 +93,7 @@ CHN-CQ;Chongqing;CHN;ASI;Municipality
 CHN-FJ;Fujian;CHN;ASI;Province
 CHN-GD;Guangdong;CHN;ASI;Province
 CHN-GS;Guansu;CHN;ASI;Province
-CHN-GX;Guanxi Zhuang;CHN;ASI;Autonomous Region
+CHN-GX;Guanxi;CHN;ASI;Autonomous Region
 CHN-GZ;Guizhou;CHN;ASI;Province
 CHN-HA;Henan;CHN;ASI;Province
 CHN-HB;Hubai;CHN;ASI;Province
@@ -105,8 +105,8 @@ CHN-JL;Jilin;CHN;ASI;Province
 CHN-JS;Jiangsu;CHN;ASI;Province
 CHN-JX;Jiangxi;CHN;ASI;Province
 CHN-LN;Lianoning;CHN;ASI;Province
-CHN-NM;Nei Mongol;CHN;ASI;Autonomous Region
-CHN-NX;Ningxia Hui;CHN;ASI;Autonomous Region
+CHN-NM;Inner Monoglia;CHN;ASI;Autonomous Region
+CHN-NX;Ningxia;CHN;ASI;Autonomous Region
 CHN-QH;Qinghai;CHN;ASI;Province
 CHN-SC;Sichuan;CHN;ASI;Province
 CHN-SD;Shangong;CHN;ASI;Province
@@ -114,7 +114,7 @@ CHN-SH;Shanghai;CHN;ASI;Municipality
 CHN-SN;Shaanxi;CHN;ASI;Province
 CHN-SX;Shanxi;CHN;ASI;Province
 CHN-TJ;Tianjin;CHN;ASI;Municipality
-CHN-XJ;Xinjiang Uyghur;CHN;ASI;Autonomous Region
+CHN-XJ;Xinjiang;CHN;ASI;Autonomous Region
 CHN-XZ;Tibet;CHN;ASI;Autonomous Region
 CHN-YN;Yunnan;CHN;ASI;Province
 CHN-ZJ;Zhejiang;CHN;ASI;Province


### PR DESCRIPTION
NM,GX,XZ,NX, the 2nd "word" refers to the minority peoples that are the designated minority in these autonomous regions, and are not a part of the actual region name.