### PR TITLE
Update ca.us395.wpt

### DIFF
--- a/hwy_data/CA/usaus/ca.us395.wpt
+++ b/hwy_data/CA/usaus/ca.us395.wpt
@@ -33,10 +33,11 @@ LitLakeRd http://www.openstreetmap.org/?lat=35.937902&lon=-117.905992
 GillStaRd http://www.openstreetmap.org/?lat=36.045759&lon=-117.947572
 SHaiRd http://www.openstreetmap.org/?lat=36.140139&lon=-117.974245
 LakRd http://www.openstreetmap.org/?lat=36.184918&lon=-117.978466
-NHaiRd http://www.openstreetmap.org/?lat=36.231878&lon=-117.982086
-CA190 http://www.openstreetmap.org/?lat=36.282163&lon=-118.006124
-WhiSt http://www.openstreetmap.org/?lat=36.322769&lon=-118.026566
-CarSt http://www.openstreetmap.org/?lat=36.324185&lon=-118.025951
+*OldUS395_S http://www.openstreetmap.org/?lat=36.221074&lon=-117.980086
++X821464 http://www.openstreetmap.org/?lat=36.280918&lon=-118.027496
+CryGeyRd http://www.openstreetmap.org/?lat=36.302564&lon=-118.027708
+LakeSt http://www.openstreetmap.org/?lat=36.320219&lon=-118.027759
+AshCrkRd http://www.openstreetmap.org/?lat=36.380142&lon=-118.023792
 CotRd http://www.openstreetmap.org/?lat=36.443553&lon=-118.034706
 BarRd http://www.openstreetmap.org/?lat=36.482796&lon=-118.034985
 +x5 http://www.openstreetmap.org/?lat=36.506566&lon=-118.032174


### PR DESCRIPTION
Relocation of US 395 west of Death Valley, to bypass of Olancha and Cartago. Updates entry to follow in separate pull request.