### PR TITLE
NS107 extension

### DIFF
--- a/hwy_data/NS/cannsf/ns.ns107.wpt
+++ b/hwy_data/NS/cannsf/ns.ns107.wpt
@@ -1,3 +1,8 @@
+NS102 http://www.openstreetmap.org/?lat=44.755526&lon=-63.645344
++X1 http://www.openstreetmap.org/?lat=44.746165&lon=-63.632829
+11 http://www.openstreetmap.org/?lat=44.731067&lon=-63.636197
++X00 http://www.openstreetmap.org/?lat=44.720035&lon=-63.622212
+12A http://www.openstreetmap.org/?lat=44.725187&lon=-63.598059
 12 +JohnSavAve http://www.openstreetmap.org/?lat=44.723372&lon=-63.582253
 13 http://www.openstreetmap.org/?lat=44.732741&lon=-63.562914
 +X01 http://www.openstreetmap.org/?lat=44.739948&lon=-63.552489

--- a/updates.csv
+++ b/updates.csv
@@ -643,6 +643,7 @@ date;region;route;root;description
 2021-12-03;(Canada) Northwest Territories;NT 9;nt.nt009;New route
 2017-12-08;(Canada) Northwest Territories;NT 10;nt.nt010;New route
 2017-12-08;(Canada) Northwest Territories;NT 1;nt.nt001;West end truncated from Wrigley village centre, to Tulita winter road entrance southeast of Wrigley
+2025-02-10;(Canada) Nova Scotia;NS 107;ns.ns107;Extended west from Exit 12 to NS 102.
 2023-07-12;(Canada) Nova Scotia;NS 4 (New Glasgow);ns.ns004ngl;Removed from "Old Highway 4" between Rossfield Rd and Barneys River Rd, relocated northwestward onto a NS104 (exit 29) connector to point *OldNS104_Bar, extended eastward over the former NS 104 alignment to point *OldNS104_Mar, northeastward via a direct transition into the former NS 4 (Antigonish) route at point *OldNS4, then eastward over the former Antigonish route to NS 316.
 2023-07-12;(Canada) Nova Scotia;NS 4 (Antigonish);ns.ns004ngl;Route deleted, and merged into NS 4 (New Glasgow) east of point *OldNS4. Segment between *OldNS4 and Strathglass Rd demolished.
 2023-07-12;(Canada) Nova Scotia;NS 104;ns.ns104;Removed from NS 4 (New Glasgow) and demolished roadway, and relocated southward onto a 4-lane divided highway between Exit 29 and a point labeled *OldNS104_Gle.


### PR DESCRIPTION
Found a couple YouTube videos that confirmed
* Burnside is another half of Exit 12.
  If this were Connecticut or something, maybe I'd relabel the points 12A & 12B for a nice unbroken alphanumeric sequence.
  But this is Nova Scotia, where it's very common to have Exit 42A come *before* Exit 42. So leaving all existing points as-is.
* The Anderson Lake Connector is Exit 11.
  When the videos were shot a month or 2 ago, this wasn't open. Ramps were blocked off with [orange barrels](https://www.youtube.com/watch?v=8KB7LrKDfMo) & unplowed. IIUC it's not connected to anything else yet; no buildings.
 Adding it as a visible point now anyway, in order to get the shaping points right and not have to take a `+` off later. And to keep people from asking, "Hey, why's there no point here?" ;P
Maybe come spring they'll pull a TXDOT and open it for U-turn movements. *Shrug.*