### PR TITLE
Update qc.qc185.wpt

### DIFF
--- a/hwy_data/QC/canqc/qc.qc185.wpt
+++ b/hwy_data/QC/canqc/qc.qc185.wpt
@@ -3,10 +3,4 @@ ChSav http://www.openstreetmap.org/?lat=47.678012&lon=-69.022894
 RangVau_W http://www.openstreetmap.org/?lat=47.667645&lon=-69.051747
 RuePri http://www.openstreetmap.org/?lat=47.684232&lon=-69.075375
 *RteGerRoy_A http://www.openstreetmap.org/?lat=47.688742&lon=-69.094401
-*RteGerRoy_B http://www.openstreetmap.org/?lat=47.692488&lon=-69.118734
-60 http://www.openstreetmap.org/?lat=47.693471&lon=-69.135828
-*RteGerRoy_C http://www.openstreetmap.org/?lat=47.694914&lon=-69.165108
-66 http://www.openstreetmap.org/?lat=47.688879&lon=-69.215927
-*RteGerRoy_D http://www.openstreetmap.org/?lat=47.685835&lon=-69.247132
-ChTac http://www.openstreetmap.org/?lat=47.697429&lon=-69.276180
-A-85_N http://www.openstreetmap.org/?lat=47.702311&lon=-69.289033
+


### PR DESCRIPTION
QC 185 truncated from closed intersection *A-85_N south to closed intersection *RteGerRoy_A (endpoint of former QC 185 freeway segment, now absorbed into northern A-85 segment).