### PR TITLE
US 395 Business, Alfred Harrell Highway, CA 108 Business typo

### DIFF
--- a/hwy_data/CA/usaca/ca.ca190dea.wpt
+++ b/hwy_data/CA/usaca/ca.ca190dea.wpt
@@ -1,6 +1,6 @@
 US395 http://www.openstreetmap.org/?lat=36.230118&lon=-117.985466
 *OldUS395_S http://www.openstreetmap.org/?lat=36.233443&lon=-117.982779
-OldUS395_N http://www.openstreetmap.org/?lat=36.282163&lon=-118.006124
+US395Bus_N +OldUS395_N http://www.openstreetmap.org/?lat=36.282163&lon=-118.006124
 LavaLakeRd http://www.openstreetmap.org/?lat=36.324299&lon=-117.947719
 CA136 http://www.openstreetmap.org/?lat=36.430010&lon=-117.824378
 +x6 http://www.openstreetmap.org/?lat=36.378104&lon=-117.802963

--- a/hwy_data/CA/usasf/ca.alfharhwy.wpt
+++ b/hwy_data/CA/usasf/ca.alfharhwy.wpt
@@ -1,0 +1,11 @@
+PanDr http://www.openstreetmap.org/?lat=35.411718&lon=-118.971462
++X1 http://www.openstreetmap.org/?lat=35.415233&lon=-118.966570
+ChiGraLoop http://www.openstreetmap.org/?lat=35.416947&lon=-118.959274
+FaiRd http://www.openstreetmap.org/?lat=35.421738&lon=-118.948975
++X2 http://www.openstreetmap.org/?lat=35.427866&lon=-118.934416
+GooRd http://www.openstreetmap.org/?lat=35.436032&lon=-118.931980
++X3 http://www.openstreetmap.org/?lat=35.444423&lon=-118.935875
++X4 http://www.openstreetmap.org/?lat=35.447377&lon=-118.934137
++X5 http://www.openstreetmap.org/?lat=35.447893&lon=-118.930510
++X6 http://www.openstreetmap.org/?lat=35.446206&lon=-118.926959
+HartMemPark http://www.openstreetmap.org/?lat=35.445568&lon=-118.921798

--- a/hwy_data/CA/usaus/ca.us395.wpt
+++ b/hwy_data/CA/usaus/ca.us395.wpt
@@ -34,7 +34,7 @@ GillStaRd http://www.openstreetmap.org/?lat=36.045759&lon=-117.947572
 SHaiRd http://www.openstreetmap.org/?lat=36.140139&lon=-117.974245
 LakRd http://www.openstreetmap.org/?lat=36.184918&lon=-117.978466
 *OldUS395_S http://www.openstreetmap.org/?lat=36.221074&lon=-117.980086
-US395Bus/CA190 +CA190 http://www.openstreetmap.org/?lat=36.230118&lon=-117.985466
+US395Bus/190 +CA190 http://www.openstreetmap.org/?lat=36.230118&lon=-117.985466
 +X821464 http://www.openstreetmap.org/?lat=36.280918&lon=-118.027496
 CryGeyRd http://www.openstreetmap.org/?lat=36.302564&lon=-118.027708
 US395BusOla_N +LakeSt http://www.openstreetmap.org/?lat=36.320219&lon=-118.027759

--- a/hwy_data/CA/usaus/ca.us395.wpt
+++ b/hwy_data/CA/usaus/ca.us395.wpt
@@ -22,7 +22,7 @@ GarRd http://www.openstreetmap.org/?lat=35.433383&lon=-117.671707
 +x3 http://www.openstreetmap.org/?lat=35.453888&lon=-117.654305
 SeaStaRd http://www.openstreetmap.org/?lat=35.473375&lon=-117.653908
 BouRd http://www.openstreetmap.org/?lat=35.542385&lon=-117.688894
-US395Bus_S http://www.openstreetmap.org/?lat=35.551004&lon=-117.713678
+US395BusRid_S +US395Bus_S http://www.openstreetmap.org/?lat=35.551004&lon=-117.713678
 BowRd http://www.openstreetmap.org/?lat=35.607609&lon=-117.762698
 US395Bus/178 http://www.openstreetmap.org/?lat=35.651447&lon=-117.800705
 BroRd http://www.openstreetmap.org/?lat=35.669674&lon=-117.818885
@@ -34,10 +34,10 @@ GillStaRd http://www.openstreetmap.org/?lat=36.045759&lon=-117.947572
 SHaiRd http://www.openstreetmap.org/?lat=36.140139&lon=-117.974245
 LakRd http://www.openstreetmap.org/?lat=36.184918&lon=-117.978466
 *OldUS395_S http://www.openstreetmap.org/?lat=36.221074&lon=-117.980086
-CA190 http://www.openstreetmap.org/?lat=36.230118&lon=-117.985466
+US395Bus/CA190 +CA190 http://www.openstreetmap.org/?lat=36.230118&lon=-117.985466
 +X821464 http://www.openstreetmap.org/?lat=36.280918&lon=-118.027496
 CryGeyRd http://www.openstreetmap.org/?lat=36.302564&lon=-118.027708
-LakeSt http://www.openstreetmap.org/?lat=36.320219&lon=-118.027759
+US395BusOla_N +LakeSt http://www.openstreetmap.org/?lat=36.320219&lon=-118.027759
 AshCrkRd http://www.openstreetmap.org/?lat=36.380142&lon=-118.023792
 CotRd http://www.openstreetmap.org/?lat=36.443553&lon=-118.034706
 BarRd http://www.openstreetmap.org/?lat=36.482796&lon=-118.034985

--- a/hwy_data/CA/usausb/ca.us395busola.wpt
+++ b/hwy_data/CA/usausb/ca.us395busola.wpt
@@ -1,0 +1,8 @@
+US395_S http://www.openstreetmap.org/?lat=36.230118&lon=-117.985466
+*OldUS395_S http://www.openstreetmap.org/?lat=36.233443&lon=-117.982779
+CA190_E http://www.openstreetmap.org/?lat=36.282163&lon=-118.006124
++X1 http://www.openstreetmap.org/?lat=36.293060&lon=-118.017240
+CryGeyRd http://www.openstreetmap.org/?lat=36.303523&lon=-118.022239
++X2 http://www.openstreetmap.org/?lat=36.314326&lon=-118.026933
++X3 http://www.openstreetmap.org/?lat=36.320174&lon=-118.027083
+US395_N http://www.openstreetmap.org/?lat=36.320219&lon=-118.027759

--- a/hwy_data/_systems/usaca.csv
+++ b/hwy_data/_systems/usaca.csv
@@ -125,7 +125,7 @@ usaca;CA;CA104;;;;ca.ca104;
 usaca;CA;CA107;;;;ca.ca107;
 usaca;CA;CA108;;;;ca.ca108;
 usaca;CA;CA108;Bus;Son;Sonora;ca.ca108busson;
-usaca;CA;CA108;Bus;Twa;Twain Hart;ca.ca108bustwa;
+usaca;CA;CA108;Bus;Twa;Twain Harte;ca.ca108bustwa;
 usaca;CA;CA108;Bus;Lon;Long Barn;ca.ca108buslon;
 usaca;CA;CA110;;;;ca.ca110;
 usaca;CA;CA111;;;Calexico;ca.ca111;

--- a/hwy_data/_systems/usaca_con.csv
+++ b/hwy_data/_systems/usaca_con.csv
@@ -125,7 +125,7 @@ usaca;CA104;;;ca.ca104
 usaca;CA107;;;ca.ca107
 usaca;CA108;;;ca.ca108
 usaca;CA108;Bus;Sonora;ca.ca108busson
-usaca;CA108;Bus;Twain Hart;ca.ca108bustwa
+usaca;CA108;Bus;Twain Harte;ca.ca108bustwa
 usaca;CA108;Bus;Long Barn;ca.ca108buslon
 usaca;CA110;;;ca.ca110
 usaca;CA111;;Calexico;ca.ca111

--- a/hwy_data/_systems/usasf.csv
+++ b/hwy_data/_systems/usasf.csv
@@ -1,6 +1,7 @@
 systemName;region;route;banner;abbrev;city;root;altRouteNames
 usasf;PA;AirCon;;;Airport Connector;pa.aircon;
 usasf;WA;AirExpy;;;Airport Expressway;wa.airexpy;
+usasf;CA;AlfHarHwy;;;Alfred Harrell Highway;ca.alfharhwy;
 usasf;NC;AllAmeFwy;;;All American Freeway;nc.allamefwy;
 usasf;OH;AtlBlvd;;;Atlantic Boulevard;oh.atlblvd;
 usasf;NJ;AtlBriCon;;;Atlantic City-Brigantine Connector;nj.atlbricon;

--- a/hwy_data/_systems/usasf_con.csv
+++ b/hwy_data/_systems/usasf_con.csv
@@ -1,6 +1,7 @@
 systemName;route;banner;groupName;roots
 usasf;AirCon;;Airport Connector;pa.aircon
 usasf;AirExpy;;Airport Expressway;wa.airexpy
+usasf;AlfHarHwy;;Alfred Harrell Highway;ca.alfharhwy
 usasf;AllAmeFwy;;All American Freeway;nc.allamefwy
 usasf;AtlBlvd;;Atlantic Boulevard;oh.atlblvd
 usasf;AtlBriCon;;Atlantic City-Brigantine Connector;nj.atlbricon

--- a/hwy_data/_systems/usausb.csv
+++ b/hwy_data/_systems/usausb.csv
@@ -1017,6 +1017,7 @@ usausb;TX;US380;Bus;Flo;Floyd, TX;tx.us380busflo;
 usausb;TX;US380;Trk;Den;Denton, TX;tx.us380trkden;
 usausb;SD;US385;Trk;Hil;Hill City, SD;sd.us385trkhil;
 usausb;CA;US395;Bus;Rid;Ridgecrest, CA;ca.us395busrid;
+usausb;CA;US395;Bus;Ola;Olancha, CA;ca.us395busola;
 usausb;NV;US395;Alt;Was;Washoe City, NV;nv.us395altwas;
 usausb;NV;US395;Bus;Car;Carson City, NV;nv.us395buscar;
 usausb;NV;US395;Bus;Ren;Reno, NV;nv.us395busren;

--- a/hwy_data/_systems/usausb_con.csv
+++ b/hwy_data/_systems/usausb_con.csv
@@ -1005,6 +1005,7 @@ usausb;US380;Bus;Floyd, TX;tx.us380busflo
 usausb;US380;Trk;Denton, TX;tx.us380trkden
 usausb;US385;Trk;Hill City, SD;sd.us385trkhil
 usausb;US395;Bus;Ridgecrest, CA;ca.us395busrid
+usausb;US395;Bus;Olancha, CA;ca.us395busola
 usausb;US395;Alt;Washoe City, NV;nv.us395altwas
 usausb;US395;Bus;Carson City, NV;nv.us395buscar
 usausb;US395;Bus;Reno, NV;nv.us395busren

--- a/updates.csv
+++ b/updates.csv
@@ -7281,6 +7281,8 @@ date;region;route;root;description
 2015-09-03;(USA) Arkansas;US 62 Business (Prairie Grove);ar.us062buspra;Added route
 2015-09-03;(USA) Arkansas;US 62 Business (Rogers);;Deleted route
 2015-09-03;(USA) Arkansas;US 63 Business (Jonesboro);;Deleted route
+2025-03-07;(USA) California;US 395 Business (Olancha);ca.us395busola;Added route along former alignment of US 395
+2025-03-07;(USA) California;Alfred Harrell Highway;ca.alfharhwy;Added route
 2025-02-27;(USA) California;I-10 Business Loop (Blythe);ca.i010blbly;Truncated from I-10 exit 241 west to 7th St. via US 95 and Hobsonway, and extended south to I-10 exit 240 via 7th St.
 2025-02-27;(USA) California;I-40 Business Loop (Needles);ca.i040blnee;Truncated from I-40 exit 142 via J St. to Broadway St., and extended north via Broadway and Needles Hwy. to I-40 exit 141
 2025-02-16;(USA) California;Colorado Freeway;ca.colfwy;Added state-maintained freeway, in Glendale CA


### PR DESCRIPTION
- Added US 395 Business in Olancha, CA along old alignment of US 395. Waypoints along US 395 and CA 190 updated to reflect change.
- Added Alfred Harrell Highway to usasf in Bakersfield, CA
- Fixed typo in indicator for CA 108 Business (Twain Harte)