### PR TITLE
VT 119 Relocation

### DIFF
--- a/hwy_data/VT/usaus/vt.us005.wpt
+++ b/hwy_data/VT/usaus/vt.us005.wpt
@@ -2,7 +2,7 @@ MA/VT http://www.openstreetmap.org/?lat=42.730118&lon=-72.573195
 TylHillRd http://www.openstreetmap.org/?lat=42.789252&lon=-72.566178
 GuiCenRd http://www.openstreetmap.org/?lat=42.817661&lon=-72.575265
 I-91(1) http://www.openstreetmap.org/?lat=42.835397&lon=-72.566704
-VT119/142 +VT142 http://www.openstreetmap.org/?lat=42.850839&lon=-72.557445
+VT142 +VT119/142 http://www.openstreetmap.org/?lat=42.850839&lon=-72.557445
 VT9_W http://www.openstreetmap.org/?lat=42.853379&lon=-72.558646
 VT30 http://www.openstreetmap.org/?lat=42.856808&lon=-72.560663
 I-91(3) http://www.openstreetmap.org/?lat=42.884942&lon=-72.556736

--- a/hwy_data/VT/usavt/vt.vt119.wpt
+++ b/hwy_data/VT/usavt/vt.vt119.wpt
@@ -1,2 +1,2 @@
-US5 http://www.openstreetmap.org/?lat=42.850839&lon=-72.557445
-VT/NH http://www.openstreetmap.org/?lat=42.851598&lon=-72.556087
+VT142 http://www.openstreetmap.org/?lat=42.848644&lon=-72.555647
+VT/NH http://www.openstreetmap.org/?lat=42.849128&lon=-72.554242

--- a/hwy_data/VT/usavt/vt.vt142.wpt
+++ b/hwy_data/VT/usavt/vt.vt142.wpt
@@ -2,4 +2,5 @@ MA/VT http://www.openstreetmap.org/?lat=42.727052&lon=-72.464565
 SteRd http://www.openstreetmap.org/?lat=42.760574&lon=-72.493737
 PondRd http://www.openstreetmap.org/?lat=42.762094&lon=-72.513982
 BroBroRd http://www.openstreetmap.org/?lat=42.819250&lon=-72.548105
+VT119 http://www.openstreetmap.org/?lat=42.848644&lon=-72.555647
 US5 http://www.openstreetmap.org/?lat=42.850839&lon=-72.557445

--- a/updates.csv
+++ b/updates.csv
@@ -9733,6 +9733,7 @@ date;region;route;root;description
 2017-05-17;(USA) Utah;UT 212;;Route Deleted
 2016-01-31;(USA) Utah;UT 7;ut.ut007;Extended east from Exit 10 (Warner Valley Road) to Sand Hollow Road, merged with former Sand Hollow segment
 2016-01-31;(USA) Utah;UT 7 (Sand Hollow);;Route deleted (merged into main route)
+2025-03-14;(USA) Vermont;VT 119;vt.vt119;Relocated onto new Brattleboro-Hinsdale Bridge between VT 142 and the New Hampshire line and now terminates at VT 142
 2024-10-23;(USA) Vermont;US 5 Alternate (Derby Line);vt.us005altder;New Route
 2016-08-16;(USA) Vermont;Vermont 7B (Clarendon);vt.vt007bcla;Truncated back to its northern junction with US 7
 2019-08-12;(USA) Virgin Islands;VI 752;vi.vi752;Extended west along what was previously mapped as part of VI 750


### PR DESCRIPTION
Related to VT 119 relocation onto the new Brattleboro-Hinsdale Bridge.  Per signage (verified by field check on 3/14/25), VT 119 terminates at VT 142 and not at US 5.
