### PR TITLE
Update nt.nt009.wpt

### DIFF
--- a/hwy_data/NT/cannt/nt.nt009.wpt
+++ b/hwy_data/NT/cannt/nt.nt009.wpt
@@ -2,7 +2,8 @@ NT3 http://www.openstreetmap.org/?lat=62.481591&lon=-116.485136
 +X144807 http://www.openstreetmap.org/?lat=62.487468&lon=-116.572838
 +X108645 http://www.openstreetmap.org/?lat=62.484177&lon=-116.634121
 +X743917 http://www.openstreetmap.org/?lat=62.537028&lon=-116.797371
-+X261115 http://www.openstreetmap.org/?lat=62.646156&lon=-116.877365
++X395446 http://www.openstreetmap.org/?lat=62.602881&lon=-116.846037
++X898466 http://www.openstreetmap.org/?lat=62.631659&lon=-116.831617
 +X456210 http://www.openstreetmap.org/?lat=62.661138&lon=-116.842175
 +X501768 http://www.openstreetmap.org/?lat=62.707379&lon=-116.856937
 +X203262 http://www.openstreetmap.org/?lat=62.776647&lon=-116.810546


### PR DESCRIPTION
Correction to middle of route trace, between shaping points +X743917 and +X456210, to conform to current OSM routing. Visible points at both ends of route unaffected. No Updates entry needed, since no users have traveled this route yet.