### PR TITLE
LA 89 Truncated

### DIFF
--- a/hwy_data/LA/usala/la.la0088.wpt
+++ b/hwy_data/LA/usala/la.la0088.wpt
@@ -1,4 +1,4 @@
-LA89 http://www.openstreetmap.org/?lat=30.043538&lon=-91.958399
+LA89 http://www.openstreetmap.org/?lat=30.043576&lon=-91.958367
 US90 http://www.openstreetmap.org/?lat=30.051042&lon=-91.929131
 SanRd http://www.openstreetmap.org/?lat=30.045303&lon=-91.912495
 LA182 http://www.openstreetmap.org/?lat=30.061550&lon=-91.881741

--- a/hwy_data/LA/usala/la.la0089.wpt
+++ b/hwy_data/LA/usala/la.la0089.wpt
@@ -1,10 +1,8 @@
 LA14 http://www.openstreetmap.org/?lat=29.952982&lon=-91.997420
-+X638095 http://www.openstreetmap.org/?lat=29.985048&lon=-91.995199
-LA682 http://www.openstreetmap.org/?lat=30.002814&lon=-91.982152
-LA88 http://www.openstreetmap.org/?lat=30.043538&lon=-91.958399
-AusRd_S http://www.openstreetmap.org/?lat=30.043538&lon=-91.981659
+RobRd http://www.openstreetmap.org/?lat=29.981094&lon=-91.996137
+LA682 http://www.openstreetmap.org/?lat=30.002837&lon=-91.982163
+LA88 http://www.openstreetmap.org/?lat=30.043576&lon=-91.958367
+AusRd_S http://www.openstreetmap.org/?lat=30.043550&lon=-91.981651
 PiatRd_E http://www.openstreetmap.org/?lat=30.065575&lon=-91.982158
-GuiRd_S http://www.openstreetmap.org/?lat=30.065547&lon=-91.990607
-CheMetPkwy http://www.openstreetmap.org/?lat=30.084367&lon=-91.990612
-AveB_W http://www.openstreetmap.org/?lat=30.095868&lon=-91.991690
-ChuSt http://www.openstreetmap.org/?lat=30.098207&lon=-91.991701
+GuiRd_S http://www.openstreetmap.org/?lat=30.065566&lon=-91.990588
+CheMetPkwy +AveB_W +ChuSt http://www.openstreetmap.org/?lat=30.084411&lon=-91.990612

--- a/hwy_data/LA/usala/la.la0682.wpt
+++ b/hwy_data/LA/usala/la.la0682.wpt
@@ -1,2 +1,2 @@
-LA89 http://www.openstreetmap.org/?lat=30.002814&lon=-91.982152
+LA89 http://www.openstreetmap.org/?lat=30.002837&lon=-91.982163
 JefIslRd http://www.openstreetmap.org/?lat=29.984314&lon=-91.956961

--- a/updates.csv
+++ b/updates.csv
@@ -8270,6 +8270,7 @@ date;region;route;root;description
 2015-11-24;(USA) Kentucky;I-69;ky.i069;Extended at north end from exit 106 to exit 148
 2015-11-24;(USA) Kentucky;I-69 Future (Madisonville);;Truncated at north end from Audubon Parkway to KY425
 2015-11-24;(USA) Kentucky;I-69 Future (Madisonville);;Route deleted (merged into main I-69)
+2025-05-25;(USA) Louisiana;LA 89;la.la0089;Truncated at north end from Church St. to Chemin Metairie Pkwy
 2025-05-13;(USA) Louisiana;LA 3105;la.la3105;Truncated at south end from Arthur Ray Teague Pkwy to US 71
 2025-03-16;(USA) Louisiana;LA 124;la.la0124;Extended at east end from the western junction with LA 3102 to the eastern junction with LA 3102 (note that the easternmost point is physically west of the previous point)
 2025-03-16;(USA) Louisiana;LA 338;la.la0338;Truncated at south end from LA 14 Business to LA 14


### PR DESCRIPTION
Truncated route based on LA DOTD road transfer maps and updated GSV imagery showing signs have been removed.