### PR TITLE
Update bc.bc097.wpt

### DIFF
--- a/hwy_data/BC/canbc/bc.bc097.wpt
+++ b/hwy_data/BC/canbc/bc.bc097.wpt
@@ -1,4 +1,4 @@
-USA/CAN +WA/BC http://www.openstreetmap.org/?lat=49.000000&lon=-119.461663
+USA/CAN +WA/BC http://www.openstreetmap.org/?lat=49.000091&lon=-119.462757
 32Ave http://www.openstreetmap.org/?lat=49.012765&lon=-119.464388
 BC3 http://www.openstreetmap.org/?lat=49.035754&lon=-119.476898
 148Ave http://www.openstreetmap.org/?lat=49.054386&lon=-119.505115


### PR DESCRIPTION
Fixes NMP with WA US97 at the international border, by copying US97's border point coordinates to the BC97 route file. No change needed to wa.us097.wpt.