### PR TITLE
Update bc.bc097c.wpt

### DIFF
--- a/hwy_data/BC/canbc/bc.bc097c.wpt
+++ b/hwy_data/BC/canbc/bc.bc097c.wpt
@@ -68,7 +68,5 @@ BriSt http://www.openstreetmap.org/?lat=50.725927&lon=-121.280522
 CorRd http://www.openstreetmap.org/?lat=50.727899&lon=-121.282926
 GovSt http://www.openstreetmap.org/?lat=50.736781&lon=-121.281820
 +x44 http://www.openstreetmap.org/?lat=50.767299&lon=-121.297045
-BC1 http://www.openstreetmap.org/?lat=50.773108&lon=-121.311121
-+x1(BC1) http://www.openstreetmap.org/?lat=50.784327&lon=-121.312451
-+x2(BC1) http://www.openstreetmap.org/?lat=50.797876&lon=-121.323481
+BC1_W +BC1 http://www.openstreetmap.org/?lat=50.773108&lon=-121.311121
 BC1/97 http://www.openstreetmap.org/?lat=50.808972&lon=-121.325283


### PR DESCRIPTION
Un-breaks concurrency with TCH1/BC1, by removing unneeded shaping points in BC97 route file.

Also, in BC97 route file, BC1 -> BC1_W +BC1.