### PR TITLE
LA Route Truncations

### DIFF
--- a/hwy_data/LA/usala/la.la0035.wpt
+++ b/hwy_data/LA/usala/la.la0035.wpt
@@ -10,7 +10,7 @@ LA699 http://www.openstreetmap.org/?lat=30.079307&lon=-92.276230
 LA92_W http://www.openstreetmap.org/?lat=30.108751&lon=-92.276444
 LA705 http://www.openstreetmap.org/?lat=30.123526&lon=-92.276058
 LA92_E http://www.openstreetmap.org/?lat=30.123452&lon=-92.267475
-LA342 http://www.openstreetmap.org/?lat=30.169581&lon=-92.268548
+LA342 http://www.openstreetmap.org/?lat=30.169574&lon=-92.268532
 US90_W http://www.openstreetmap.org/?lat=30.227369&lon=-92.269385
 US90_E http://www.openstreetmap.org/?lat=30.235100&lon=-92.268827
 LA98_E http://www.openstreetmap.org/?lat=30.241959&lon=-92.269717

--- a/hwy_data/LA/usala/la.la00931.wpt
+++ b/hwy_data/LA/usala/la.la00931.wpt
@@ -1,2 +1,2 @@
-LA342 http://www.openstreetmap.org/?lat=30.181230&lon=-92.091898
+ConSt +LA342 http://www.openstreetmap.org/?lat=30.195790&lon=-92.092024
 End http://www.openstreetmap.org/?lat=30.207858&lon=-92.092161

--- a/hwy_data/LA/usala/la.la0342.wpt
+++ b/hwy_data/LA/usala/la.la0342.wpt
@@ -1,8 +1,8 @@
-LA35 http://www.openstreetmap.org/?lat=30.169581&lon=-92.268548
-LA700 http://www.openstreetmap.org/?lat=30.162160&lon=-92.243185
+LA35 http://www.openstreetmap.org/?lat=30.169574&lon=-92.268532
+LA700 http://www.openstreetmap.org/?lat=30.162239&lon=-92.243137
 LA719 http://www.openstreetmap.org/?lat=30.159043&lon=-92.209454
-LA343 http://www.openstreetmap.org/?lat=30.159191&lon=-92.175679
-FieRd_S http://www.openstreetmap.org/?lat=30.159377&lon=-92.141798
+LA343 http://www.openstreetmap.org/?lat=30.159224&lon=-92.175677
+FieRd_S http://www.openstreetmap.org/?lat=30.159388&lon=-92.141776
 LA724_S http://www.openstreetmap.org/?lat=30.166631&lon=-92.141819
-LA724_N http://www.openstreetmap.org/?lat=30.181137&lon=-92.141926
-LA93-1 http://www.openstreetmap.org/?lat=30.181230&lon=-92.091898
+LA724_N http://www.openstreetmap.org/?lat=30.181112&lon=-92.141964
+End +LA93-1 http://www.openstreetmap.org/?lat=30.181153&lon=-92.140666

--- a/hwy_data/LA/usala/la.la0343.wpt
+++ b/hwy_data/LA/usala/la.la0343.wpt
@@ -5,7 +5,7 @@ LA697 http://www.openstreetmap.org/?lat=30.042847&lon=-92.183281
 LA699_W http://www.openstreetmap.org/?lat=30.078973&lon=-92.183533
 LA699_E http://www.openstreetmap.org/?lat=30.079103&lon=-92.175229
 LA92 http://www.openstreetmap.org/?lat=30.108324&lon=-92.175314
-LA342 http://www.openstreetmap.org/?lat=30.159191&lon=-92.175679
+LA342 http://www.openstreetmap.org/?lat=30.159224&lon=-92.175677
 LA720 http://www.openstreetmap.org/?lat=30.195409&lon=-92.175711
 US90 http://www.openstreetmap.org/?lat=30.235007&lon=-92.176065
 TanRd http://www.openstreetmap.org/?lat=30.277368&lon=-92.176377

--- a/hwy_data/LA/usala/la.la0700.wpt
+++ b/hwy_data/LA/usala/la.la0700.wpt
@@ -3,4 +3,4 @@ MireRd http://www.openstreetmap.org/?lat=30.035309&lon=-92.243850
 LA699 http://www.openstreetmap.org/?lat=30.078991&lon=-92.242327
 LA92_E http://www.openstreetmap.org/?lat=30.108176&lon=-92.242563
 LA92_W http://www.openstreetmap.org/?lat=30.123136&lon=-92.242155
-LA342 http://www.openstreetmap.org/?lat=30.162160&lon=-92.243185
+LA342 http://www.openstreetmap.org/?lat=30.162239&lon=-92.243137

--- a/hwy_data/LA/usala/la.la0724.wpt
+++ b/hwy_data/LA/usala/la.la0724.wpt
@@ -1,6 +1,6 @@
 DuhRd_E http://www.openstreetmap.org/?lat=30.166928&lon=-92.101339
 LA342_W http://www.openstreetmap.org/?lat=30.166631&lon=-92.141819
-LA342_E http://www.openstreetmap.org/?lat=30.181137&lon=-92.141926
+LA342_E http://www.openstreetmap.org/?lat=30.181112&lon=-92.141964
 US90 http://www.openstreetmap.org/?lat=30.234988&lon=-92.142087
 FieRd_N http://www.openstreetmap.org/?lat=30.258937&lon=-92.141916
 RueBonSec_E http://www.openstreetmap.org/?lat=30.258567&lon=-92.133558

--- a/hwy_data/LA/usala/la.la3246.wpt
+++ b/hwy_data/LA/usala/la.la3246.wpt
@@ -1,5 +1,4 @@
-HigRd +LA42 http://www.openstreetmap.org/?lat=30.350806&lon=-91.083441
-PerRd http://www.openstreetmap.org/?lat=30.368173&lon=-91.074514
-SieMar http://www.openstreetmap.org/?lat=30.376393&lon=-91.068817
+PerRd +HigRd +LA42 http://www.openstreetmap.org/?lat=30.368238&lon=-91.074463
+SieMar http://www.openstreetmap.org/?lat=30.376404&lon=-91.068828
 I-10 http://www.openstreetmap.org/?lat=30.382205&lon=-91.065996
 US61/73 http://www.openstreetmap.org/?lat=30.398968&lon=-91.054250

--- a/updates.csv
+++ b/updates.csv
@@ -8272,6 +8272,9 @@ date;region;route;root;description
 2015-11-24;(USA) Kentucky;I-69;ky.i069;Extended at north end from exit 106 to exit 148
 2015-11-24;(USA) Kentucky;I-69 Future (Madisonville);;Truncated at north end from Audubon Parkway to KY425
 2015-11-24;(USA) Kentucky;I-69 Future (Madisonville);;Route deleted (merged into main I-69)
+2025-05-29;(USA) Louisiana;LA 93-1;la.la00931;Truncated at south end from Ridge Rd. (former LA 342) to W. Congress St.
+2025-05-29;(USA) Louisiana;LA 342;la.la0342;Truncated at east end from Rue de Belier (former LA 93-1) to a point east of LA 724
+2025-05-29;(USA) Louisiana;LA 3246;la.la3246;Truncated at south end from Highland Rd. to Perkins Rd.
 2025-05-28;(USA) Louisiana;LA 98;la.la0098;Truncated at east end from Sawmill Hwy to LA 176
 2025-05-28;(USA) Louisiana;LA 426;;Route deleted
 2025-05-25;(USA) Louisiana;LA 89;la.la0089;Truncated at north end from Church St. to Chemin Metairie Pkwy


### PR DESCRIPTION
LA 93-1, 342, and 3246 truncated
LA DOTD Road Transfer maps and GSV imagery confirm truncations 