### PR TITLE
MO Updates from Highway63

### DIFF
--- a/hwy_data/MO/usaib/mo.i029blstj.wpt
+++ b/hwy_data/MO/usaib/mo.i029blstj.wpt
@@ -3,6 +3,7 @@ US169 http://www.openstreetmap.org/?lat=39.733495&lon=-94.801154
 AgeRd http://www.openstreetmap.org/?lat=39.733726&lon=-94.824586
 MO371 http://www.openstreetmap.org/?lat=39.734353&lon=-94.833984
 US36 http://www.openstreetmap.org/?lat=39.749186&lon=-94.848608
+PennSt http://www.openstreetmap.org/?lat=39.756294&lon=-94.848694
 EdmSt http://www.openstreetmap.org/?lat=39.765863&lon=-94.848833
 FarSt http://www.openstreetmap.org/?lat=39.769162&lon=-94.846773
 22ndAve http://www.openstreetmap.org/?lat=39.775363&lon=-94.834199

--- a/hwy_data/MO/usamo/mo.mo005.wpt
+++ b/hwy_data/MO/usamo/mo.mo005.wpt
@@ -62,8 +62,8 @@ MO7/5Bus +MO5BusCam_S http://www.openstreetmap.org/?lat=37.991005&lon=-92.711091
 US54 http://www.openstreetmap.org/?lat=38.015116&lon=-92.735381
 +X20 http://www.openstreetmap.org/?lat=38.024650&lon=-92.759457
 WatRd http://www.openstreetmap.org/?lat=38.035501&lon=-92.768297
-OldMO5_S http://www.openstreetmap.org/?lat=38.062706&lon=-92.791171
-LR577 http://www.openstreetmap.org/?lat=38.069523&lon=-92.800441
+*OldMO5_S http://www.openstreetmap.org/?lat=38.062706&lon=-92.791171
+HarRd http://www.openstreetmap.org/?lat=38.069523&lon=-92.800441
 OldMO5_N http://www.openstreetmap.org/?lat=38.076862&lon=-92.802758
 +X21 http://www.openstreetmap.org/?lat=38.089158&lon=-92.805505
 MO7_N http://www.openstreetmap.org/?lat=38.097939&lon=-92.821212

--- a/hwy_data/MO/usamo/mo.mo005.wpt
+++ b/hwy_data/MO/usamo/mo.mo005.wpt
@@ -55,10 +55,10 @@ MOsYY_Lac http://www.openstreetmap.org/?lat=37.698746&lon=-92.667918
 MOsBB_Lac http://www.openstreetmap.org/?lat=37.783435&lon=-92.678776
 MOsE_Lac http://www.openstreetmap.org/?lat=37.824396&lon=-92.690620
 +X18 http://www.openstreetmap.org/?lat=37.848799&lon=-92.704611
-MOsP_Cam http://www.openstreetmap.org/?lat=37.907604&lon=-92.700233
-+X19 http://www.openstreetmap.org/?lat=37.948563&lon=-92.711906
-MO7_S http://www.openstreetmap.org/?lat=37.981044&lon=-92.698088
-MO5BusCam_S http://www.openstreetmap.org/?lat=37.991005&lon=-92.711091
+OlaDr http://www.openstreetmap.org/?lat=37.882407&lon=-92.702765
+MouHorRd http://www.openstreetmap.org/?lat=37.906723&lon=-92.701778
++X19 http://www.openstreetmap.org/?lat=37.940001&lon=-92.715597
+MO7/5Bus +MO5BusCam_S http://www.openstreetmap.org/?lat=37.991005&lon=-92.711091
 US54 http://www.openstreetmap.org/?lat=38.015116&lon=-92.735381
 +X20 http://www.openstreetmap.org/?lat=38.024650&lon=-92.759457
 WatRd http://www.openstreetmap.org/?lat=38.035501&lon=-92.768297

--- a/hwy_data/MO/usamo/mo.mo007.wpt
+++ b/hwy_data/MO/usamo/mo.mo007.wpt
@@ -21,13 +21,13 @@ MOsE_Cam http://www.openstreetmap.org/?lat=37.968950&lon=-92.592430
 MOsV_Cam http://www.openstreetmap.org/?lat=37.985120&lon=-92.660151
 +X12 http://www.openstreetmap.org/?lat=37.987826&lon=-92.674270
 +X13 http://www.openstreetmap.org/?lat=37.980892&lon=-92.679076
-MO5_S http://www.openstreetmap.org/?lat=37.981044&lon=-92.698088
-MO5BusCam_S http://www.openstreetmap.org/?lat=37.991005&lon=-92.711091
+OldMO5_CamS +MO5_S http://www.openstreetmap.org/?lat=37.981044&lon=-92.698088
+MO5/5Bus +MO5BusCam_S http://www.openstreetmap.org/?lat=37.991005&lon=-92.711091
 US54 http://www.openstreetmap.org/?lat=38.015116&lon=-92.735381
 +X14 http://www.openstreetmap.org/?lat=38.024650&lon=-92.759457
 WatRd http://www.openstreetmap.org/?lat=38.035501&lon=-92.768297
-OldMO5_S http://www.openstreetmap.org/?lat=38.062706&lon=-92.791171
-LR577 http://www.openstreetmap.org/?lat=38.069523&lon=-92.800441
+*OldMO5_S http://www.openstreetmap.org/?lat=38.062706&lon=-92.791171
+HarRd http://www.openstreetmap.org/?lat=38.069523&lon=-92.800441
 OldMO5_N http://www.openstreetmap.org/?lat=38.076862&lon=-92.802758
 +X15 http://www.openstreetmap.org/?lat=38.089158&lon=-92.805505
 MO5_N http://www.openstreetmap.org/?lat=38.097939&lon=-92.821212

--- a/hwy_data/MO/usamo/mo.mo007.wpt
+++ b/hwy_data/MO/usamo/mo.mo007.wpt
@@ -50,7 +50,7 @@ WilDr http://www.openstreetmap.org/?lat=38.195671&lon=-93.324856
 MO83 http://www.openstreetmap.org/?lat=38.231582&lon=-93.358566
 MainSt http://www.openstreetmap.org/?lat=38.242604&lon=-93.360347
 US65 +US65/65Spr http://www.openstreetmap.org/?lat=38.253499&lon=-93.364413
-ComSt +US65Spr_S http://www.openstreetmap.org/?lat=38.253111&lon=-93.367063
+ComSt http://www.openstreetmap.org/?lat=38.253111&lon=-93.367063
 MainSt_W http://www.openstreetmap.org/?lat=38.244803&lon=-93.385806
 +X21 http://www.openstreetmap.org/?lat=38.231674&lon=-93.448162
 MOsZ_Ben http://www.openstreetmap.org/?lat=38.236343&lon=-93.462110

--- a/hwy_data/MO/usamo/mo.mo041.wpt
+++ b/hwy_data/MO/usamo/mo.mo041.wpt
@@ -17,6 +17,7 @@ US65Bus/240 http://www.openstreetmap.org/?lat=39.130401&lon=-93.208319
 +X04 http://www.openstreetmap.org/?lat=39.177749&lon=-93.220282
 MO122 http://www.openstreetmap.org/?lat=39.231937&lon=-93.218350
 MOsC http://www.openstreetmap.org/?lat=39.302259&lon=-93.224573
+MecSt http://www.openstreetmap.org/?lat=39.323534&lon=-93.223200
 MOsF http://www.openstreetmap.org/?lat=39.326696&lon=-93.223200
 +X05 http://www.openstreetmap.org/?lat=39.367118&lon=-93.242855
 US24 http://www.openstreetmap.org/?lat=39.381731&lon=-93.242769

--- a/hwy_data/MO/usamo/mo.mo179.wpt
+++ b/hwy_data/MO/usamo/mo.mo179.wpt
@@ -1,5 +1,6 @@
 US54 http://www.openstreetmap.org/?lat=38.540202&lon=-92.208971
 MOsC http://www.openstreetmap.org/?lat=38.546521&lon=-92.224474
+MisDr http://www.openstreetmap.org/?lat=38.559694&lon=-92.227285
 EdgDr http://www.openstreetmap.org/?lat=38.571153&lon=-92.228508
 US50Bus http://www.openstreetmap.org/?lat=38.580270&lon=-92.231244
 US50 http://www.openstreetmap.org/?lat=38.581755&lon=-92.231373

--- a/hwy_data/MO/usaus/mo.us059.wpt
+++ b/hwy_data/MO/usaus/mo.us059.wpt
@@ -1,6 +1,6 @@
 KS/MO http://www.openstreetmap.org/?lat=39.559412&lon=-95.113116
 SWMorRd http://www.openstreetmap.org/?lat=39.557133&lon=-95.100628
-MO45/273 +MO45 http://www.openstreetmap.org/?lat=39.556620&lon=-95.046051
+MO45/273 http://www.openstreetmap.org/?lat=39.556620&lon=-95.046051
 MO116 http://www.openstreetmap.org/?lat=39.586343&lon=-95.033948
 +X01 http://www.openstreetmap.org/?lat=39.610912&lon=-95.013714
 MOsKK http://www.openstreetmap.org/?lat=39.632597&lon=-94.974318
@@ -24,6 +24,8 @@ I-29(56) http://www.openstreetmap.org/?lat=39.885800&lon=-94.856858
 MOsT_And http://www.openstreetmap.org/?lat=39.922483&lon=-94.860206
 US71/71Bus http://www.openstreetmap.org/?lat=39.961654&lon=-94.861364
 +X04 http://www.openstreetmap.org/?lat=39.966563&lon=-94.871922
+MOsCC http://www.openstreetmap.org/?lat=39.966703&lon=-94.908314
+MOsH http://www.openstreetmap.org/?lat=39.967122&lon=-94.965134
 I-29(65) http://www.openstreetmap.org/?lat=39.968175&lon=-94.974060
 I-29(67) http://www.openstreetmap.org/?lat=39.974621&lon=-95.015473
 MOsB/O http://www.openstreetmap.org/?lat=39.968536&lon=-95.085897
@@ -51,7 +53,7 @@ MO111Spr +MO111_N http://www.openstreetmap.org/?lat=40.193954&lon=-95.369933
 +X13 http://www.openstreetmap.org/?lat=40.233985&lon=-95.370383
 300thSt http://www.openstreetmap.org/?lat=40.292228&lon=-95.369740
 MO46 http://www.openstreetmap.org/?lat=40.335578&lon=-95.369782
-MOsJ_Atc +MOsJ http://www.openstreetmap.org/?lat=40.339111&lon=-95.395532
+MOsJ_Atc http://www.openstreetmap.org/?lat=40.339111&lon=-95.395532
 US136_W http://www.openstreetmap.org/?lat=40.423077&lon=-95.397120
 +X14 http://www.openstreetmap.org/?lat=40.423543&lon=-95.388322
 US136_E http://www.openstreetmap.org/?lat=40.437769&lon=-95.387635

--- a/hwy_data/MO/usaus/mo.us065.wpt
+++ b/hwy_data/MO/usaus/mo.us065.wpt
@@ -37,8 +37,10 @@ MO125 http://www.openstreetmap.org/?lat=37.385657&lon=-93.159117
 MOsAA_Dal http://www.openstreetmap.org/?lat=37.422611&lon=-93.145072
 MO215 http://www.openstreetmap.org/?lat=37.459564&lon=-93.139697
 MO38 http://www.openstreetmap.org/?lat=37.517394&lon=-93.138152
-+X09 http://www.openstreetmap.org/?lat=37.568698&lon=-93.137712
-+X10 http://www.openstreetmap.org/?lat=37.623307&lon=-93.104582
+AshSt_S http://www.openstreetmap.org/?lat=37.569004&lon=-93.138142
++X09 http://www.openstreetmap.org/?lat=37.574141&lon=-93.138185
+GolfCouRd http://www.openstreetmap.org/?lat=37.590185&lon=-93.130288
+AshSt_N http://www.openstreetmap.org/?lat=37.625925&lon=-93.104668
 MO32 +MO32/73 http://www.openstreetmap.org/?lat=37.640522&lon=-93.104260
 MO73 http://www.openstreetmap.org/?lat=37.667712&lon=-93.103380
 VicRd http://www.openstreetmap.org/?lat=37.695885&lon=-93.103434

--- a/hwy_data/MO/usaus/mo.us067.wpt
+++ b/hwy_data/MO/usaus/mo.us067.wpt
@@ -14,8 +14,8 @@ US60/67Bus +US67BusPop/60 http://www.openstreetmap.org/?lat=36.794792&lon=-90.44
 US60_W http://www.openstreetmap.org/?lat=36.841576&lon=-90.498451
 +X03 http://www.openstreetmap.org/?lat=36.860800&lon=-90.508480
 +X04 http://www.openstreetmap.org/?lat=36.886100&lon=-90.499400
-MOsO_But +X05 http://www.openstreetmap.org/?lat=36.919990&lon=-90.462750
-+X05a http://www.openstreetmap.org/?lat=36.929890&lon=-90.456830
+MOsO_But http://www.openstreetmap.org/?lat=36.919990&lon=-90.462750
++X05 http://www.openstreetmap.org/?lat=36.929890&lon=-90.456830
 MO49/172 http://www.openstreetmap.org/?lat=36.942310&lon=-90.455560
 +X06 http://www.openstreetmap.org/?lat=36.981815&lon=-90.445890
 MOsF http://www.openstreetmap.org/?lat=37.050656&lon=-90.480738
@@ -41,7 +41,7 @@ MOsJJ http://www.openstreetmap.org/?lat=37.409147&lon=-90.313926
 +X13 http://www.openstreetmap.org/?lat=37.433397&lon=-90.297575
 MurMillRd http://www.openstreetmap.org/?lat=37.473377&lon=-90.301394
 US67BusChe_S http://www.openstreetmap.org/?lat=37.486353&lon=-90.306523
-US67BusChe_N +US67BusFre_S http://www.openstreetmap.org/?lat=37.491681&lon=-90.307574
+US67BusChe_N http://www.openstreetmap.org/?lat=37.491681&lon=-90.307574
 US67BusFre/E http://www.openstreetmap.org/?lat=37.521742&lon=-90.313550
 +X13a http://www.openstreetmap.org/?lat=37.547436&lon=-90.324268
 US67BusFre/72 http://www.openstreetmap.org/?lat=37.564370&lon=-90.321565
@@ -52,10 +52,11 @@ MO221 http://www.openstreetmap.org/?lat=37.771775&lon=-90.445236
 MapSt http://www.openstreetmap.org/?lat=37.787505&lon=-90.443959
 MO32_E http://www.openstreetmap.org/?lat=37.797145&lon=-90.443101
 FairDr http://www.openstreetmap.org/?lat=37.822967&lon=-90.461361
-US67BusDes/32 +US67BusPar/32 http://www.openstreetmap.org/?lat=37.838962&lon=-90.484471
+US67BusDes/32 http://www.openstreetmap.org/?lat=37.838962&lon=-90.484471
 ParDr http://www.openstreetmap.org/?lat=37.864385&lon=-90.493441
 US67BusDes/8 http://www.openstreetmap.org/?lat=37.880942&lon=-90.509566
-MO47 +MO47/K http://www.openstreetmap.org/?lat=37.922179&lon=-90.538416
+OldOrcRd http://www.openstreetmap.org/?lat=37.912073&lon=-90.530777
+MO47 http://www.openstreetmap.org/?lat=37.922179&lon=-90.538416
 +X14 http://www.openstreetmap.org/?lat=37.954993&lon=-90.551634
 +X15 http://www.openstreetmap.org/?lat=37.991259&lon=-90.526915
 MOsY_StF http://www.openstreetmap.org/?lat=38.010932&lon=-90.487615
@@ -69,7 +70,7 @@ SunRd http://www.openstreetmap.org/?lat=38.147855&lon=-90.465342
 MOsCC_Jef http://www.openstreetmap.org/?lat=38.191632&lon=-90.415238
 I-55(174) http://www.openstreetmap.org/?lat=38.197273&lon=-90.400057
 US61_S http://www.openstreetmap.org/?lat=38.201303&lon=-90.395851
-MOsA_Jef +MOsA_Cry http://www.openstreetmap.org/?lat=38.211108&lon=-90.392504
+MOsA_Jef http://www.openstreetmap.org/?lat=38.211108&lon=-90.392504
 MainSt_Cry http://www.openstreetmap.org/?lat=38.218980&lon=-90.385140
 MisAve http://www.openstreetmap.org/?lat=38.229770&lon=-90.386840
 +X17 http://www.openstreetmap.org/?lat=38.244399&lon=-90.396194
@@ -83,7 +84,7 @@ MOsZ_Jef http://www.openstreetmap.org/?lat=38.291174&lon=-90.396109
 +X20 http://www.openstreetmap.org/?lat=38.341219&lon=-90.393448
 MOsM_Jef http://www.openstreetmap.org/?lat=38.343516&lon=-90.385981
 SulSprRd http://www.openstreetmap.org/?lat=38.343600&lon=-90.382515
-MainSt_Imp +ImpMainSt http://www.openstreetmap.org/?lat=38.368899&lon=-90.376142
+MainSt_Imp http://www.openstreetmap.org/?lat=38.368899&lon=-90.376142
 MO231 http://www.openstreetmap.org/?lat=38.405009&lon=-90.377011
 RicRd http://www.openstreetmap.org/?lat=38.409894&lon=-90.381496
 SJCRd http://www.openstreetmap.org/?lat=38.414467&lon=-90.378417
@@ -94,7 +95,7 @@ ButHillRd http://www.openstreetmap.org/?lat=38.485450&lon=-90.348794
 MatRd http://www.openstreetmap.org/?lat=38.494360&lon=-90.344814
 ForRd http://www.openstreetmap.org/?lat=38.501296&lon=-90.332294
 I-255 http://www.openstreetmap.org/?lat=38.502605&lon=-90.330362
-US50_E +US50 http://www.openstreetmap.org/?lat=38.505939&lon=-90.325974
+US50_E http://www.openstreetmap.org/?lat=38.505939&lon=-90.325974
 I-55(197) http://www.openstreetmap.org/?lat=38.511370&lon=-90.335823
 MO21 http://www.openstreetmap.org/?lat=38.523761&lon=-90.354481
 BapChuRd http://www.openstreetmap.org/?lat=38.525230&lon=-90.361487
@@ -126,8 +127,8 @@ WasSt http://www.openstreetmap.org/?lat=38.796800&lon=-90.338849
 PatRd http://www.openstreetmap.org/?lat=38.800069&lon=-90.333849
 StFerSt http://www.openstreetmap.org/?lat=38.799224&lon=-90.328249
 NewFloRd http://www.openstreetmap.org/?lat=38.800128&lon=-90.315943
-MOsAC_StL +MOsAC http://www.openstreetmap.org/?lat=38.809224&lon=-90.298980
-OldHFRd +OHalFerRd http://www.openstreetmap.org/?lat=38.815954&lon=-90.280881
+MOsAC_StL http://www.openstreetmap.org/?lat=38.809224&lon=-90.298980
+OldHFRd http://www.openstreetmap.org/?lat=38.815954&lon=-90.280881
 OldJamRd http://www.openstreetmap.org/?lat=38.823042&lon=-90.249778
 MO367 http://www.openstreetmap.org/?lat=38.818244&lon=-90.231475
 BelBr http://www.openstreetmap.org/?lat=38.838605&lon=-90.237923

--- a/hwy_data/MO/usaus/mo.us071.wpt
+++ b/hwy_data/MO/usaus/mo.us071.wpt
@@ -2,47 +2,47 @@ AR/MO http://www.openstreetmap.org/?lat=36.499339&lon=-94.269487
 MOsOO http://www.openstreetmap.org/?lat=36.503643&lon=-94.276836
 *CRSE7137 http://www.openstreetmap.org/?lat=36.537821&lon=-94.300772
 MO90 http://www.openstreetmap.org/?lat=36.543751&lon=-94.320127
-+X01 http://www.openstreetmap.org/?lat=36.54791&lon=-94.32999
-+X02 http://www.openstreetmap.org/?lat=36.55471&lon=-94.33393
++X01 http://www.openstreetmap.org/?lat=36.547910&lon=-94.329990
++X02 http://www.openstreetmap.org/?lat=36.554710&lon=-94.333930
 US71BusAnd_S http://www.openstreetmap.org/?lat=36.567253&lon=-94.361229
 I-49(4) http://www.openstreetmap.org/?lat=36.566822&lon=-94.382944
 I-49(5) http://www.openstreetmap.org/?lat=36.580505&lon=-94.393888
-I-49(7) http://www.openstreetmap.org/?lat=36.60423&lon=-94.40861
+I-49(7) http://www.openstreetmap.org/?lat=36.604230&lon=-94.408610
 *OldUS71Bus http://www.openstreetmap.org/?lat=36.617586&lon=-94.413779
 I-49(10) http://www.openstreetmap.org/?lat=36.648494&lon=-94.419765
 I-49(15) http://www.openstreetmap.org/?lat=36.721790&lon=-94.418939
 I-49(17) http://www.openstreetmap.org/?lat=36.738265&lon=-94.425881
 I-49(20) http://www.openstreetmap.org/?lat=36.788941&lon=-94.421611
-I-49(24) +US60 http://www.openstreetmap.org/?lat=36.840168&lon=-94.415495
+I-49(24) http://www.openstreetmap.org/?lat=36.840168&lon=-94.415495
 I-49(27) http://www.openstreetmap.org/?lat=36.880582&lon=-94.431052
 I-49(30) http://www.openstreetmap.org/?lat=36.924045&lon=-94.430108
 I-49(33) http://www.openstreetmap.org/?lat=36.967689&lon=-94.429808
-I-49(35) +MOsV_New http://www.openstreetmap.org/?lat=36.996598&lon=-94.431481
+I-49(35) http://www.openstreetmap.org/?lat=36.996598&lon=-94.431481
 I-49(39A) http://www.openstreetmap.org/?lat=37.054466&lon=-94.426460
 I-49(39B) http://www.openstreetmap.org/?lat=37.061410&lon=-94.426589
 I-44(13) http://www.openstreetmap.org/?lat=37.069221&lon=-94.404133
 I-44(15) http://www.openstreetmap.org/?lat=37.081777&lon=-94.365922
 I-49(46) http://www.openstreetmap.org/?lat=37.081784&lon=-94.312134
 I-49(47) http://www.openstreetmap.org/?lat=37.096256&lon=-94.311994
-I-49(49) +MO571 http://www.openstreetmap.org/?lat=37.133045&lon=-94.313807
+I-49(49) http://www.openstreetmap.org/?lat=37.133045&lon=-94.313807
 I-49(50) http://www.openstreetmap.org/?lat=37.140263&lon=-94.322777
-I-49(51) http://www.openstreetmap.org/?lat=37.15484&lon=-94.33179
+I-49(51) http://www.openstreetmap.org/?lat=37.154840&lon=-94.331790
 I-49(53) +US71BusJop/96 http://www.openstreetmap.org/?lat=37.178894&lon=-94.333506
-+X07 http://www.openstreetmap.org/?lat=37.20107&lon=-94.33484
-I-49(55) +CivWarAve http://www.openstreetmap.org/?lat=37.204500&lon=-94.326725
++X07 http://www.openstreetmap.org/?lat=37.201070&lon=-94.334840
+I-49(55) http://www.openstreetmap.org/?lat=37.204500&lon=-94.326725
 I-49(56) http://www.openstreetmap.org/?lat=37.205842&lon=-94.307252
 I-49(63) http://www.openstreetmap.org/?lat=37.296144&lon=-94.303379
-+X08 http://www.openstreetmap.org/?lat=37.324&lon=-94.30209
-I-49(66) +MOsH/K http://www.openstreetmap.org/?lat=37.339626&lon=-94.292243
-+X09 http://www.openstreetmap.org/?lat=37.35651&lon=-94.30102
-I-49(70) +MO126 http://www.openstreetmap.org/?lat=37.398468&lon=-94.299849
++X08 http://www.openstreetmap.org/?lat=37.324000&lon=-94.302090
+I-49(66) http://www.openstreetmap.org/?lat=37.339626&lon=-94.292243
++X09 http://www.openstreetmap.org/?lat=37.356510&lon=-94.301020
+I-49(70) http://www.openstreetmap.org/?lat=37.398468&lon=-94.299849
 I-49(74) http://www.openstreetmap.org/?lat=37.456660&lon=-94.298691
 I-49(77) http://www.openstreetmap.org/?lat=37.493826&lon=-94.299860
 I-49(80) http://www.openstreetmap.org/?lat=37.544867&lon=-94.295697
 I-49(83) http://www.openstreetmap.org/?lat=37.588569&lon=-94.293669
-+X10 http://www.openstreetmap.org/?lat=37.61787&lon=-94.29312
-+X11 http://www.openstreetmap.org/?lat=37.64971&lon=-94.30831
-I-49(88) +MOsB/N http://www.openstreetmap.org/?lat=37.662047&lon=-94.309055
++X10 http://www.openstreetmap.org/?lat=37.617870&lon=-94.293120
++X11 http://www.openstreetmap.org/?lat=37.649710&lon=-94.308310
+I-49(88) http://www.openstreetmap.org/?lat=37.662047&lon=-94.309055
 I-49(91) http://www.openstreetmap.org/?lat=37.705842&lon=-94.308486
 *MOsBB_Ver http://www.openstreetmap.org/?lat=37.720593&lon=-94.308100
 I-49(95) http://www.openstreetmap.org/?lat=37.762742&lon=-94.312992
@@ -56,16 +56,16 @@ I-49(107) http://www.openstreetmap.org/?lat=37.910626&lon=-94.349202
 +X16 http://www.openstreetmap.org/?lat=37.929474&lon=-94.369383
 I-49(110) http://www.openstreetmap.org/?lat=37.952903&lon=-94.367999
 I-49(112) http://www.openstreetmap.org/?lat=37.978312&lon=-94.368482
-I-49(116) http://www.openstreetmap.org/?lat=38.0392&lon=-94.36728
+I-49(116) http://www.openstreetmap.org/?lat=38.039200&lon=-94.367280
 *OldMOsTT http://www.openstreetmap.org/?lat=38.048775&lon=-94.355468
 I-49(120) http://www.openstreetmap.org/?lat=38.097256&lon=-94.348923
 I-49(129) http://www.openstreetmap.org/?lat=38.220852&lon=-94.350543
 I-49(130) http://www.openstreetmap.org/?lat=38.239958&lon=-94.352249
-I-49(131) +MO52_N http://www.openstreetmap.org/?lat=38.257138&lon=-94.358203
+I-49(131) http://www.openstreetmap.org/?lat=38.257138&lon=-94.358203
 +X19 http://www.openstreetmap.org/?lat=38.295562&lon=-94.356766
 I-49(136) http://www.openstreetmap.org/?lat=38.322038&lon=-94.343462
 I-49(141) http://www.openstreetmap.org/?lat=38.394314&lon=-94.341123
-I-49(144) http://www.openstreetmap.org/?lat=38.43056&lon=-94.34299
+I-49(144) http://www.openstreetmap.org/?lat=38.430560&lon=-94.342990
 I-49(147) +MOsA/B_Cas http://www.openstreetmap.org/?lat=38.479403&lon=-94.341338
 +X21 http://www.openstreetmap.org/?lat=38.508046&lon=-94.341745
 +X22 http://www.openstreetmap.org/?lat=38.525120&lon=-94.352646
@@ -75,42 +75,42 @@ I-49(157) +MO7_S http://www.openstreetmap.org/?lat=38.617315&lon=-94.348451
 I-49(158) http://www.openstreetmap.org/?lat=38.636827&lon=-94.354084
 I-49(159) http://www.openstreetmap.org/?lat=38.653628&lon=-94.365993
 I-49(160) http://www.openstreetmap.org/?lat=38.660925&lon=-94.369093
-+X25 http://www.openstreetmap.org/?lat=38.66655&lon=-94.40063
++X25 http://www.openstreetmap.org/?lat=38.666550&lon=-94.400630
 +X26 http://www.openstreetmap.org/?lat=38.678240&lon=-94.419508
 I-49(167) http://www.openstreetmap.org/?lat=38.723128&lon=-94.455096
 I-49(168) http://www.openstreetmap.org/?lat=38.739669&lon=-94.470639
 +X28 http://www.openstreetmap.org/?lat=38.764223&lon=-94.490318
-I-49(172) http://www.openstreetmap.org/?lat=38.7861&lon=-94.49705
+I-49(172) http://www.openstreetmap.org/?lat=38.786100&lon=-94.497050
 I-49(174) http://www.openstreetmap.org/?lat=38.813295&lon=-94.503826
 I-49(175) http://www.openstreetmap.org/?lat=38.825333&lon=-94.520617
 I-49(176) http://www.openstreetmap.org/?lat=38.843660&lon=-94.529479
 I-49(177) http://www.openstreetmap.org/?lat=38.857898&lon=-94.528030
 I-49(178) http://www.openstreetmap.org/?lat=38.870537&lon=-94.526474
 I-49(179) http://www.openstreetmap.org/?lat=38.888870&lon=-94.525176
-I-49(180) http://www.openstreetmap.org/?lat=38.90314&lon=-94.52416
-I-49(181) +BlueRidBlvd http://www.openstreetmap.org/?lat=38.908233&lon=-94.523835
+I-49(180) http://www.openstreetmap.org/?lat=38.903140&lon=-94.524160
+I-49(181) http://www.openstreetmap.org/?lat=38.908233&lon=-94.523835
 I-49(181A) http://www.openstreetmap.org/?lat=38.916314&lon=-94.526786
-I-49(182) http://www.openstreetmap.org/?lat=38.92429&lon=-94.52763
+I-49(182) http://www.openstreetmap.org/?lat=38.924290&lon=-94.527630
 I-470(1A) http://www.openstreetmap.org/?lat=38.932340&lon=-94.528084
-I-435 +I-470(0) http://www.openstreetmap.org/?lat=38.94142&lon=-94.53685
+I-435 +I-470(0) http://www.openstreetmap.org/?lat=38.941420&lon=-94.536850
 MOsW http://www.openstreetmap.org/?lat=38.953811&lon=-94.540046
 BlueRivRd http://www.openstreetmap.org/?lat=38.970879&lon=-94.545797
 58thSt http://www.openstreetmap.org/?lat=38.974090&lon=-94.545947
 75thSt +E75thSt http://www.openstreetmap.org/?lat=38.990545&lon=-94.552717
 GreBlvd http://www.openstreetmap.org/?lat=38.998000&lon=-94.555442
 MeyBlvd http://www.openstreetmap.org/?lat=39.007430&lon=-94.554820
-63rdSt +E63rdSt http://www.openstreetmap.org/?lat=39.012432&lon=-94.554584
+63rdSt http://www.openstreetmap.org/?lat=39.012432&lon=-94.554584
 55thSt http://www.openstreetmap.org/?lat=39.026469&lon=-94.553779
-+X31 http://www.openstreetmap.org/?lat=39.03559&lon=-94.55381
++X31 http://www.openstreetmap.org/?lat=39.035590&lon=-94.553810
 US56 http://www.openstreetmap.org/?lat=39.040828&lon=-94.559165
 BushCreBlvd http://www.openstreetmap.org/?lat=39.043020&lon=-94.560152
 39thSt http://www.openstreetmap.org/?lat=39.055643&lon=-94.561300
 LinBlvd http://www.openstreetmap.org/?lat=39.068322&lon=-94.560356
-29thSt +E29thSt http://www.openstreetmap.org/?lat=39.073794&lon=-94.561279
+29thSt http://www.openstreetmap.org/?lat=39.073794&lon=-94.561279
 Pas http://www.openstreetmap.org/?lat=39.083197&lon=-94.566321
-22ndSt +E22ndSt http://www.openstreetmap.org/?lat=39.086154&lon=-94.570484
-I-70(2L) http://www.openstreetmap.org/?lat=39.097029&lon=-94.571900
-I-70(2J) http://www.openstreetmap.org/?lat=39.100825&lon=-94.572287
+22ndSt http://www.openstreetmap.org/?lat=39.086154&lon=-94.570484
+I-70(2L) http://www.openstreetmap.org/?lat=39.096957&lon=-94.572325
+I-70(2J) http://www.openstreetmap.org/?lat=39.101241&lon=-94.572562
 I-70(2H) http://www.openstreetmap.org/?lat=39.105954&lon=-94.570999
 I-35(4A) http://www.openstreetmap.org/?lat=39.110783&lon=-94.564347
 I-35(4B) http://www.openstreetmap.org/?lat=39.118474&lon=-94.564219
@@ -135,8 +135,8 @@ I-29(12) http://www.openstreetmap.org/?lat=39.296148&lon=-94.685154
 I-29(13) http://www.openstreetmap.org/?lat=39.310959&lon=-94.687600
 I-29(14) http://www.openstreetmap.org/?lat=39.319425&lon=-94.694724
 I-29(15) http://www.openstreetmap.org/?lat=39.328787&lon=-94.711204
-I-29(17) http://www.openstreetmap.org/?lat=39.345549&lon=-94.747982
-I-29(18) http://www.openstreetmap.org/?lat=39.353646&lon=-94.761930
+I-29(17) http://www.openstreetmap.org/?lat=39.353646&lon=-94.761930
+I-29(18) http://www.openstreetmap.org/?lat=39.353580&lon=-94.761543
 I-29(19) http://www.openstreetmap.org/?lat=39.368213&lon=-94.771843
 I-29(20) http://www.openstreetmap.org/?lat=39.385496&lon=-94.789342
 I-29(25) http://www.openstreetmap.org/?lat=39.450974&lon=-94.788322
@@ -150,10 +150,10 @@ I-29(50) http://www.openstreetmap.org/?lat=39.814989&lon=-94.803686
 I-29(53) http://www.openstreetmap.org/?lat=39.858035&lon=-94.810295
 I-29(56) http://www.openstreetmap.org/?lat=39.885800&lon=-94.856858
 MOsT http://www.openstreetmap.org/?lat=39.922483&lon=-94.860206
-US59/71Bus +US71BusSav/59 http://www.openstreetmap.org/?lat=39.961654&lon=-94.861364
-CR60 http://www.openstreetmap.org/?lat=39.98126&lon=-94.87896
+US59/71Bus http://www.openstreetmap.org/?lat=39.961654&lon=-94.861364
+CR60 http://www.openstreetmap.org/?lat=39.981260&lon=-94.878960
 MO48 http://www.openstreetmap.org/?lat=40.039887&lon=-94.879314
-+X33 http://www.openstreetmap.org/?lat=40.06067&lon=-94.87025
++X33 http://www.openstreetmap.org/?lat=40.060670&lon=-94.870250
 MOsY http://www.openstreetmap.org/?lat=40.091632&lon=-94.869947
 MOsB_S http://www.openstreetmap.org/?lat=40.113937&lon=-94.870033
 MOsM http://www.openstreetmap.org/?lat=40.171495&lon=-94.869089
@@ -161,7 +161,7 @@ MOsA http://www.openstreetmap.org/?lat=40.200314&lon=-94.867909
 MOsU http://www.openstreetmap.org/?lat=40.258479&lon=-94.866954
 ImpDr http://www.openstreetmap.org/?lat=40.278404&lon=-94.875108
 US71BusMar_S http://www.openstreetmap.org/?lat=40.313951&lon=-94.872833
-US136/46 +US136_E http://www.openstreetmap.org/?lat=40.345080&lon=-94.852170
+US136/46 http://www.openstreetmap.org/?lat=40.345080&lon=-94.852170
 MO148 http://www.openstreetmap.org/?lat=40.374977&lon=-94.853929
 US71Bus http://www.openstreetmap.org/?lat=40.386991&lon=-94.870409
 MOsFF http://www.openstreetmap.org/?lat=40.389606&lon=-94.929342
@@ -170,7 +170,7 @@ MOsFF http://www.openstreetmap.org/?lat=40.389606&lon=-94.929342
 MOsAB http://www.openstreetmap.org/?lat=40.419786&lon=-95.005345
 210thSt_W http://www.openstreetmap.org/?lat=40.419982&lon=-95.022050
 US136_W http://www.openstreetmap.org/?lat=40.441632&lon=-95.025151
-MOsB_N +MOsB_Nod http://www.openstreetmap.org/?lat=40.503015&lon=-95.030826
+MOsB_N http://www.openstreetmap.org/?lat=40.503015&lon=-95.030826
 MOsC http://www.openstreetmap.org/?lat=40.510390&lon=-95.030826
 MOsJJ http://www.openstreetmap.org/?lat=40.553820&lon=-95.030708
 MOsD http://www.openstreetmap.org/?lat=40.564921&lon=-95.030751

--- a/updates.csv
+++ b/updates.csv
@@ -8636,6 +8636,8 @@ date;region;route;root;description
 2017-04-24;(USA) Mississippi;I-22;ms.i022;New Route
 2017-04-24;(USA) Mississippi;I-22 Future (Tupelo);ms.i022;Route deleted
 2015-10-25;(USA) Mississippi;I-269;ms.i269;Added route
+2025-07-12;(USA) Missouri;MO 5;mo.mo005;Removed from old road through Decaturville, between Camdenton and the Ozark County line, and relocated onto new alignment to the west between OlaDr and MO7/5Bus.
+2025-07-12;(USA) Missouri;US 65;mo.us065;Removed from Ash Street south of Buffalo and relocated onto new alignment immediately to the west between AshSt_S and AshSt_N.
 2025-05-30;(USA) Missouri;MO 92 Spur (Tracy);mo.mo092sprtra;Created route
 2024-04-08;(USA) Missouri;I-435;mo.i435;Corrected exit for East 63rd Street from 66A->66B and corrected MO 350 exit from 66B->66A
 2024-01-10;(USA) Missouri;MO 32 Business (Park Hills);mo.mo032buspar;Reactivated route.


### PR DESCRIPTION
I-29 BL (St. Joseph): Added PennSt.
US 59: Added MOsCC, MOsH.
US 65: Removed from Ash Street south of Buffalo and relocated onto new alignment immediately to the west.
US 67: Added OldOrcRd.
US 71: Reset I-70(2J) and I-70(2L).
MO 5: Removed from old road through Decaturville, between Camdenton and the Ozark County line, and relocated onto new alignment to the west. Removed MOsP_Cam and MO7_S. OldMO5_S>-*OldMO5_S. LR577>-HarRd.
MO 7: Renamed MO5BusCam_S->MO5/5Bus. Renamed MO5_S->OldMO5_CamS.  OldMO5_S>-*OldMO5_S.  LR577>-HarRd.
MO 41: Added MecSt.
MO 179: Added MisDr.