### PR TITLE
RI route 120 point addition

### DIFF
--- a/hwy_data/RI/usari/ri.ri120.wpt
+++ b/hwy_data/RI/usari/ri.ri120.wpt
@@ -1,3 +1,4 @@
 RI122 http://www.openstreetmap.org/?lat=41.976140&lon=-71.457841
 RI114 http://www.openstreetmap.org/?lat=41.982765&lon=-71.409376
+AttRd http://www.openstreetmap.org/?lat=41.977749&lon=-71.391258
 RI/MA http://www.openstreetmap.org/?lat=41.971442&lon=-71.381419


### PR DESCRIPTION
Added a point on Rhode Island state route 120 at North Attleboro Road.