### PR TITLE
Update qc.qc138.wpt

### DIFF
--- a/hwy_data/QC/canqc/qc.qc138.wpt
+++ b/hwy_data/QC/canqc/qc.qc138.wpt
@@ -211,6 +211,4 @@ RueJer http://www.openstreetmap.org/?lat=50.133952&lon=-61.800296
 +X341514 http://www.openstreetmap.org/?lat=50.177286&lon=-61.378781
 +X167219 http://www.openstreetmap.org/?lat=50.186299&lon=-61.365134
 +X828921 http://www.openstreetmap.org/?lat=50.194212&lon=-61.301104
-ChJacCar_S http://www.openstreetmap.org/?lat=50.189078&lon=-61.271986
-AerKeg http://www.openstreetmap.org/?lat=50.194242&lon=-61.267202
-End http://www.openstreetmap.org/?lat=50.197197&lon=-61.256027
+ChJacCar http://www.openstreetmap.org/?lat=50.189078&lon=-61.271986


### PR DESCRIPTION
Short truncation of QC 138 in Kegaska, to remove segment to Kegaska's airport (apparently to be bypassed by future QC 138 extension east to La Romaine).

Updates entry in PR #8644.