### PR TITLE
IL 110 fix from Highway63 by email

### DIFF
--- a/hwy_data/IL/usail/il.il110.wpt
+++ b/hwy_data/IL/usail/il.il110.wpt
@@ -36,7 +36,7 @@ US136 http://www.openstreetmap.org/?lat=40.448229&lon=-90.738187
 +X33608 http://www.openstreetmap.org/?lat=40.472024&lon=-90.741749
 +X33609 http://www.openstreetmap.org/?lat=40.488280&lon=-90.719175
 +X33610 http://www.openstreetmap.org/?lat=40.502444&lon=-90.703297
-US67_N http://www.openstreetmap.org/?lat=40.503064&lon=-90.674564
+US67_S http://www.openstreetmap.org/?lat=40.503064&lon=-90.674564
 IL9 http://www.openstreetmap.org/?lat=40.550429&lon=-90.673728
 CR19 http://www.openstreetmap.org/?lat=40.660717&lon=-90.673084
 US67BusRos_S http://www.openstreetmap.org/?lat=40.713696&lon=-90.672998

--- a/updates.csv
+++ b/updates.csv
@@ -8466,6 +8466,7 @@ date;region;route;root;description
 2017-04-02;(USA) Idaho;US 95;id.us095;Moved east onto new alignment in Athol, between waypoints RemRd and *OldUS95_N
 2017-04-02;(USA) Idaho;US 95;id.us095;Relocated east from US 2 (5th Avenue), Cedar Street, 1st St, and Superior St onto new Sandpoint bypass between waypoints SupSt and US2/200
 2015-08-03;(USA) Idaho;ID 16;id.id016;Route extended at south end from ID44 to US20/26
+2026-05-11;(USA)Illinois;IL 110;il.il110;Corrected US67_N to US67_S at junction north of Macomb
 2026-05-09;(USA) Illinois;IL 390;il.il390;Reversed numbers of 7A (IL 19) and 7B (Gary Avenue)
 2025-05-30;(USA) Illinois;IL 64 Truck (Elmhurst);il.il064trkelm;Rerouted to follow IL 83 and US 20
 2024-07-09;(USA) Illinois;US 12;il.us012;Removed from Lee Street between Elk Boulevard and Rand Road and relocated onto Elk Boulevard and South Des Plaines River Road in Des Plaines


### PR DESCRIPTION
Fixes the erroneous label inherited from CHM, noted by the introduction of a different point in #9134 

Note that this is a newsworthy change as this essentially moves a point-in-use substantially.  It is in use by bhemphill, dharwood, justjake, scott_steiglitz, @ssoworld, superblu, and WY2WI.