### PR TITLE
AR 265 Pea Ridge deleted, AR 224 Swifton truncated

### DIFF
--- a/hwy_data/AR/usaar/ar.ar094.wpt
+++ b/hwy_data/AR/usaar/ar.ar094.wpt
@@ -2,7 +2,7 @@ AR340 http://www.openstreetmap.org/?lat=36.497977&lon=-94.180901
 +X384153 http://www.openstreetmap.org/?lat=36.479141&lon=-94.147422
 DonMcARd http://www.openstreetmap.org/?lat=36.477945&lon=-94.140079
 McNRd http://www.openstreetmap.org/?lat=36.457654&lon=-94.139964
-AR265 http://www.openstreetmap.org/?lat=36.456772&lon=-94.123293
+HayRd +AR265 http://www.openstreetmap.org/?lat=36.456772&lon=-94.123293
 AR72_E http://www.openstreetmap.org/?lat=36.453801&lon=-94.115090
 AR72_W http://www.openstreetmap.org/?lat=36.442104&lon=-94.116430
 US62/12_E http://www.openstreetmap.org/?lat=36.355193&lon=-94.116268

--- a/hwy_data/AR/usaar/ar.ar224.wpt
+++ b/hwy_data/AR/usaar/ar.ar224.wpt
@@ -2,5 +2,4 @@ AR367 http://www.openstreetmap.org/?lat=35.748408&lon=-91.185702
 CR637 http://www.openstreetmap.org/?lat=35.747836&lon=-91.143951
 CR615 http://www.openstreetmap.org/?lat=35.788111&lon=-91.142406
 CR614 http://www.openstreetmap.org/?lat=35.788337&lon=-91.124693
-AR226 http://www.openstreetmap.org/?lat=35.799166&lon=-91.124316
-SwiLim http://www.openstreetmap.org/?lat=35.817571&lon=-91.124012
+AR226 +SwiLim http://www.openstreetmap.org/?lat=35.799166&lon=-91.124316

--- a/hwy_data/AR/usaar/ar.ar265pea.wpt
+++ b/hwy_data/AR/usaar/ar.ar265pea.wpt
@@ -1,2 +1,0 @@
-AR94 http://www.openstreetmap.org/?lat=36.456772&lon=-94.123293
-AR/MO http://www.openstreetmap.org/?lat=36.498727&lon=-94.111556

--- a/hwy_data/_systems/usaar.csv
+++ b/hwy_data/_systems/usaar.csv
@@ -510,7 +510,6 @@ usaar;AR;AR263;;;;ar.ar263;
 usaar;AR;AR264;;Sil;Siloam Springs;ar.ar264sil;
 usaar;AR;AR264;;;Lowell;ar.ar264;
 usaar;AR;AR265;;;Fayetteville;ar.ar265;
-usaar;AR;AR265;;Pea;Pea Ridge;ar.ar265pea;
 usaar;AR;AR266;;;;ar.ar266;
 usaar;AR;AR267;;Bee;Beebe;ar.ar267bee;
 usaar;AR;AR267;;;Searcy;ar.ar267;

--- a/hwy_data/_systems/usaar_con.csv
+++ b/hwy_data/_systems/usaar_con.csv
@@ -507,7 +507,6 @@ usaar;AR263;;;ar.ar263
 usaar;AR264;;Siloam Springs;ar.ar264sil
 usaar;AR264;;Lowell;ar.ar264
 usaar;AR265;;Fayetteville;ar.ar265
-usaar;AR265;;Pea Ridge;ar.ar265pea
 usaar;AR266;;;ar.ar266
 usaar;AR267;;Beebe;ar.ar267bee
 usaar;AR267;;Searcy;ar.ar267

--- a/updates.csv
+++ b/updates.csv
@@ -8029,6 +8029,8 @@ date;region;route;root;description
 2017-05-17;(USA) Arizona;Sky Harbor Boulevard;az.skyharblvd;New Route
 2015-08-03;(USA) Arizona;I-11 Future (Hoover Dam);az.i011futhoo;New Route
 2015-08-03;(USA) Arizona;I-11 Future (Kingman);az.i011futkin;New Route
+2025-12-20;(USA) Arkansas;AR 224 (Swifton);ar.ar224;Route truncated to AR 226.
+2026-05-16;(USA) Arkansas;AR 265 (Pea Ridge);;Route deleted.
 2026-01-10;(USA) Arkansas;US 62 Business (Prairie Grove);ar.us062buspra;Route truncated to Battlefield Park Road in Prairie Grove.
 2025-12-20;(USA) Arkansas;AR 83S ((West) Monticello);ar.ar083swmo;New route.
 2025-12-18;(USA) Arkansas;AR 170 (Farmington);ar.ar170far;Route truncated to the Farmington City Limit boundary.


### PR DESCRIPTION
AR 265 is removed in Pea Ridge as confirmed by @cenlaroads on the forum. AR 224 in Swifton was recently truncated as well.

This successfully passed datacheck before making this pull request. Please let me know if there's any issues.

~ Ethan