### PR TITLE
IA/MO/WI/SD changes from Highway63 by email

### DIFF
--- a/hwy_data/IA/usaia/ia.ia136.wpt
+++ b/hwy_data/IA/usaia/ia.ia136.wpt
@@ -45,4 +45,4 @@ CRD35 http://www.openstreetmap.org/?lat=42.395985&lon=-91.118438
 CRD39 http://www.openstreetmap.org/?lat=42.397221&lon=-91.119490
 +X13 http://www.openstreetmap.org/?lat=42.409437&lon=-91.126292
 +X14 http://www.openstreetmap.org/?lat=42.424439&lon=-91.116593
-US20 http://www.openstreetmap.org/?lat=42.468900&lon=-91.114297
+US20/52 +US20 http://www.openstreetmap.org/?lat=42.468900&lon=-91.114297

--- a/hwy_data/MO/usai/mo.i064.wpt
+++ b/hwy_data/MO/usai/mo.i064.wpt
@@ -39,9 +39,9 @@ ForDr http://www.openstreetmap.org/?lat=38.631539&lon=-90.378728
 36B http://www.openstreetmap.org/?lat=38.631170&lon=-90.253265
 37 http://www.openstreetmap.org/?lat=38.631505&lon=-90.234790
 38A http://www.openstreetmap.org/?lat=38.630500&lon=-90.227494
-38B http://www.openstreetmap.org/?lat=38.629041&lon=-90.222130
+*Old38B http://www.openstreetmap.org/?lat=38.629041&lon=-90.222130
 38C http://www.openstreetmap.org/?lat=38.627518&lon=-90.217735
-39 +38D http://www.openstreetmap.org/?lat=38.626540&lon=-90.213611
+38B +39 +38D http://www.openstreetmap.org/?lat=38.626602&lon=-90.213718
 39A +39B http://www.openstreetmap.org/?lat=38.623643&lon=-90.202560
 40 +39C +40A http://www.openstreetmap.org/?lat=38.621799&lon=-90.194839
 40B +40C http://www.openstreetmap.org/?lat=38.620014&lon=-90.189654

--- a/hwy_data/MO/usanht/mo.lctrlsou.wpt
+++ b/hwy_data/MO/usanht/mo.lctrlsou.wpt
@@ -166,10 +166,10 @@ I-64(36A) http://www.openstreetmap.org/?lat=38.631237&lon=-90.265625
 I-64(36B) http://www.openstreetmap.org/?lat=38.631170&lon=-90.253265
 I-64(37) http://www.openstreetmap.org/?lat=38.631505&lon=-90.234790
 I-64(38A) http://www.openstreetmap.org/?lat=38.630500&lon=-90.227494
-I-64(38B) http://www.openstreetmap.org/?lat=38.629041&lon=-90.222130
+*I-64(Old38B) http://www.openstreetmap.org/?lat=38.629041&lon=-90.222130
 I-64(38C) http://www.openstreetmap.org/?lat=38.627518&lon=-90.217735
-I-64(39) http://www.openstreetmap.org/?lat=38.626540&lon=-90.213611
-I-64(39A) http://www.openstreetmap.org/?lat=38.623643&lon=-90.202560
-I-64(40) http://www.openstreetmap.org/?lat=38.621799&lon=-90.194839
-I-64(40B) http://www.openstreetmap.org/?lat=38.620014&lon=-90.189654
+I-64(38B) +I-64(39) +I-64(38D) http://www.openstreetmap.org/?lat=38.626602&lon=-90.213718
+I-64(39A) +I-64(39B) http://www.openstreetmap.org/?lat=38.623643&lon=-90.202560
+I-64(40) +I-64(39C) +I-64(40A) http://www.openstreetmap.org/?lat=38.621799&lon=-90.194839
+I-64(40B) +I-64(40C) http://www.openstreetmap.org/?lat=38.620014&lon=-90.189654
 MO/IL http://www.openstreetmap.org/?lat=38.618076&lon=-90.182693

--- a/hwy_data/MO/usatr/mo.grr.wpt
+++ b/hwy_data/MO/usatr/mo.grr.wpt
@@ -135,5 +135,5 @@ MOsT_Mar http://www.openstreetmap.org/?lat=39.702977&lon=-91.349430
 Bro http://www.openstreetmap.org/?lat=39.709209&lon=-91.356844
 RockSt http://www.openstreetmap.org/?lat=39.712849&lon=-91.359580
 GraAve http://www.openstreetmap.org/?lat=39.715209&lon=-91.371650
-I-72(152) http://www.openstreetmap.org/?lat=39.717140&lon=-91.372894
+I-72(157) +I-72(152) http://www.openstreetmap.org/?lat=39.717140&lon=-91.372894
 MO/IL http://www.openstreetmap.org/?lat=39.720261&lon=-91.358139

--- a/hwy_data/MO/usaus/mo.us040.wpt
+++ b/hwy_data/MO/usaus/mo.us040.wpt
@@ -158,9 +158,9 @@ I-64(36A) http://www.openstreetmap.org/?lat=38.631237&lon=-90.265625
 I-64(36B) http://www.openstreetmap.org/?lat=38.631170&lon=-90.253265
 I-64(37) http://www.openstreetmap.org/?lat=38.631505&lon=-90.234790
 I-64(38A) http://www.openstreetmap.org/?lat=38.630500&lon=-90.227494
-I-64(38B) http://www.openstreetmap.org/?lat=38.629041&lon=-90.222130
+*I-64(Old38B) http://www.openstreetmap.org/?lat=38.629041&lon=-90.222130
 I-64(38C) http://www.openstreetmap.org/?lat=38.627518&lon=-90.217735
-I-64(39) +I-64(38D) http://www.openstreetmap.org/?lat=38.626540&lon=-90.213611
+I-64(38B) +I-64(39) +I-64(38D) http://www.openstreetmap.org/?lat=38.626602&lon=-90.213718
 I-64(39A) +I-64(39B) http://www.openstreetmap.org/?lat=38.623643&lon=-90.202560
 I-64(40) +I-64(39C) +I-64(40A) http://www.openstreetmap.org/?lat=38.621799&lon=-90.194839
 I-64(40B) +I-64(40C) http://www.openstreetmap.org/?lat=38.620014&lon=-90.189654

--- a/hwy_data/MO/usaush/mo.us066his.wpt
+++ b/hwy_data/MO/usaush/mo.us066his.wpt
@@ -60,7 +60,7 @@ US160 http://www.openstreetmap.org/?lat=37.212216&lon=-93.348727
 I-44BL_SprW +SceAve http://www.openstreetmap.org/?lat=37.212011&lon=-93.330145
 MO13 http://www.openstreetmap.org/?lat=37.208559&lon=-93.312163
 CamAve http://www.openstreetmap.org/?lat=37.209004&lon=-93.294268
-JefAve http://www.openstreetmap.org/?lat=37.208901&lon=-93.289933
+JefAve_Spr http://www.openstreetmap.org/?lat=37.208901&lon=-93.289933
 NatAve http://www.openstreetmap.org/?lat=37.209585&lon=-93.275986
 US65Bus_S http://www.openstreetmap.org/?lat=37.209311&lon=-93.261867
 I-44BL_SprE +US65Bus http://www.openstreetmap.org/?lat=37.214626&lon=-93.261727

--- a/hwy_data/SD/usasd/sd.sd015.wpt
+++ b/hwy_data/SD/usasd/sd.sd015.wpt
@@ -2,7 +2,7 @@ I-29(150) http://www.openstreetmap.org/?lat=44.572616&lon=-96.762385
 SD28 http://www.openstreetmap.org/?lat=44.572784&lon=-96.682992
 CR314 http://www.openstreetmap.org/?lat=44.659710&lon=-96.682949
 SD22 http://www.openstreetmap.org/?lat=44.746764&lon=-96.682520
-CR309 http://www.openstreetmap.org/?lat=44.848111&lon=-96.682520
+CR3/309 http://www.openstreetmap.org/?lat=44.847959&lon=-96.682434
 US212_W http://www.openstreetmap.org/?lat=44.892029&lon=-96.684966
 476thAve http://www.openstreetmap.org/?lat=44.931539&lon=-96.677756
 US212_E http://www.openstreetmap.org/?lat=44.933210&lon=-96.638575
@@ -14,10 +14,10 @@ US12 http://www.openstreetmap.org/?lat=45.218929&lon=-96.640720
 SD109 http://www.openstreetmap.org/?lat=45.398721&lon=-96.637373
 +X01 http://www.openstreetmap.org/?lat=45.396401&lon=-96.687069
 +X02 http://www.openstreetmap.org/?lat=45.413033&lon=-96.716251
-CR11 http://www.openstreetmap.org/?lat=45.413229&lon=-96.760197
+CR11/24 http://www.openstreetmap.org/?lat=45.413229&lon=-96.760197
 CR4 http://www.openstreetmap.org/?lat=45.413018&lon=-96.821909
 SD123 http://www.openstreetmap.org/?lat=45.413003&lon=-96.861906
 CR26 http://www.openstreetmap.org/?lat=45.412732&lon=-96.958723
 +X03 http://www.openstreetmap.org/?lat=45.412799&lon=-96.986346
 I-29(213) http://www.openstreetmap.org/?lat=45.403301&lon=-97.020264
-458thAve +485thAve http://www.openstreetmap.org/?lat=45.398497&lon=-97.041435
+CR17/34 +485thAve +458thAve http://www.openstreetmap.org/?lat=45.398497&lon=-97.041435

--- a/hwy_data/SD/usaus/sd.us012.wpt
+++ b/hwy_data/SD/usaus/sd.us012.wpt
@@ -75,11 +75,12 @@ OldUS81 http://www.openstreetmap.org/?lat=45.326143&lon=-97.103176
 I-29 http://www.openstreetmap.org/?lat=45.314676&lon=-97.051249
 CR34 http://www.openstreetmap.org/?lat=45.311416&lon=-97.041614
 CR27 http://www.openstreetmap.org/?lat=45.311341&lon=-97.036507
-CR29 http://www.openstreetmap.org/?lat=45.310994&lon=-97.011294
+CR29 http://www.openstreetmap.org/?lat=45.310994&lon=-97.011375
 CR5 http://www.openstreetmap.org/?lat=45.286044&lon=-96.964710
-464thAve http://www.openstreetmap.org/?lat=45.269450&lon=-96.924734
-CR7 http://www.openstreetmap.org/?lat=45.268303&lon=-96.897268
+CR6_W http://www.openstreetmap.org/?lat=45.269450&lon=-96.924734
+CR7 http://www.openstreetmap.org/?lat=45.268333&lon=-96.897215
 SD123 http://www.openstreetmap.org/?lat=45.261053&lon=-96.862593
+CR6_E http://www.openstreetmap.org/?lat=45.254181&lon=-96.852669
 148thSt_W http://www.openstreetmap.org/?lat=45.240010&lon=-96.831779
 470thAve http://www.openstreetmap.org/?lat=45.239542&lon=-96.801310
 471stAve http://www.openstreetmap.org/?lat=45.226063&lon=-96.781654
@@ -88,8 +89,8 @@ MilAve_W http://www.openstreetmap.org/?lat=45.222224&lon=-96.665676
 +X09 http://www.openstreetmap.org/?lat=45.219020&lon=-96.656127
 SD15 http://www.openstreetmap.org/?lat=45.218929&lon=-96.640720
 9thSt http://www.openstreetmap.org/?lat=45.219020&lon=-96.626387
-149thSt http://www.openstreetmap.org/?lat=45.222889&lon=-96.618834
-482ndAve http://www.openstreetmap.org/?lat=45.248788&lon=-96.557980
+MilAve_E http://www.openstreetmap.org/?lat=45.222942&lon=-96.618903
+482ndAve http://www.openstreetmap.org/?lat=45.249075&lon=-96.558108
 CR39 http://www.openstreetmap.org/?lat=45.278963&lon=-96.494122
 SD109 http://www.openstreetmap.org/?lat=45.291298&lon=-96.467535
 CorAve http://www.openstreetmap.org/?lat=45.291539&lon=-96.461678

--- a/hwy_data/WI/usai/wi.i094.wpt
+++ b/hwy_data/WI/usai/wi.i094.wpt
@@ -100,12 +100,12 @@ CouRd http://www.openstreetmap.org/?lat=44.962847&lon=-92.741175
 304 http://www.openstreetmap.org/?lat=43.028926&lon=-88.047179
 305 http://www.openstreetmap.org/?lat=43.027198&lon=-88.035357
 306 http://www.openstreetmap.org/?lat=43.027495&lon=-88.017241
-307A http://www.openstreetmap.org/?lat=43.030000&lon=-87.998257
-307B http://www.openstreetmap.org/?lat=43.030314&lon=-87.986155
-308A http://www.openstreetmap.org/?lat=43.031004&lon=-87.978473
+307A http://www.openstreetmap.org/?lat=43.030063&lon=-87.999759
+307B http://www.openstreetmap.org/?lat=43.030455&lon=-87.986562
+308A http://www.openstreetmap.org/?lat=43.030957&lon=-87.978741
 308B http://www.openstreetmap.org/?lat=43.033106&lon=-87.969890
-309A http://www.openstreetmap.org/?lat=43.032165&lon=-87.957358
-309B http://www.openstreetmap.org/?lat=43.034235&lon=-87.947402
+309A http://www.openstreetmap.org/?lat=43.032188&lon=-87.957745
+309B http://www.openstreetmap.org/?lat=43.034196&lon=-87.947756
 310A http://www.openstreetmap.org/?lat=43.035498&lon=-87.932994
 310C +310 http://www.openstreetmap.org/?lat=43.035553&lon=-87.923326
 311 http://www.openstreetmap.org/?lat=43.021843&lon=-87.919893

--- a/hwy_data/WI/usatr/wi.lmct.wpt
+++ b/hwy_data/WI/usatr/wi.lmct.wpt
@@ -97,8 +97,10 @@ WI38 http://www.openstreetmap.org/?lat=42.731694&lon=-87.783809
 MainSt_RacS http://www.openstreetmap.org/?lat=42.726524&lon=-87.782693
 6th/7thSt http://www.openstreetmap.org/?lat=42.726012&lon=-87.788916
 WI20_W http://www.openstreetmap.org/?lat=42.720140&lon=-87.794060
+14thSt http://www.openstreetmap.org/?lat=42.715489&lon=-87.793787
+24thSt http://www.openstreetmap.org/?lat=42.699989&lon=-87.793615
 WI11 http://www.openstreetmap.org/?lat=42.697009&lon=-87.796469
-CoLineRd http://www.openstreetmap.org/?lat=42.667827&lon=-87.809172
+WI195 +CoLineRd http://www.openstreetmap.org/?lat=42.667827&lon=-87.809172
 12thSt_S http://www.openstreetmap.org/?lat=42.638758&lon=-87.818699
 CRS_Ken http://www.openstreetmap.org/?lat=42.598966&lon=-87.823119
 WI158 http://www.openstreetmap.org/?lat=42.588035&lon=-87.822990

--- a/hwy_data/WI/usatr/wi.lmct.wpt
+++ b/hwy_data/WI/usatr/wi.lmct.wpt
@@ -95,9 +95,8 @@ DouAve_S http://www.openstreetmap.org/?lat=42.735524&lon=-87.788551
 MainSt_RacN http://www.openstreetmap.org/?lat=42.735571&lon=-87.784796
 WI38 http://www.openstreetmap.org/?lat=42.731694&lon=-87.783809
 MainSt_RacS http://www.openstreetmap.org/?lat=42.726524&lon=-87.782693
+6th/7thSt http://www.openstreetmap.org/?lat=42.726012&lon=-87.788916
 WI20_W http://www.openstreetmap.org/?lat=42.720140&lon=-87.794060
-14thSt http://www.openstreetmap.org/?lat=42.715489&lon=-87.793787
-24thSt http://www.openstreetmap.org/?lat=42.699989&lon=-87.793615
 WI11 http://www.openstreetmap.org/?lat=42.697009&lon=-87.796469
 CoLineRd http://www.openstreetmap.org/?lat=42.667827&lon=-87.809172
 12thSt_S http://www.openstreetmap.org/?lat=42.638758&lon=-87.818699

--- a/hwy_data/WI/usaus/wi.us018.wpt
+++ b/hwy_data/WI/usaus/wi.us018.wpt
@@ -138,4 +138,4 @@ I-43 http://www.openstreetmap.org/?lat=43.044402&lon=-87.926030
 WI145_N http://www.openstreetmap.org/?lat=43.044334&lon=-87.918938
 WI145_S +WI145 http://www.openstreetmap.org/?lat=43.041434&lon=-87.918928
 WI32_N http://www.openstreetmap.org/?lat=43.042406&lon=-87.907491
-WI32_S http://www.openstreetmap.org/?lat=43.037435&lon=-87.906933
+WI32_S +LinMemDr http://www.openstreetmap.org/?lat=43.037435&lon=-87.906933

--- a/hwy_data/WI/usaus/wi.us151.wpt
+++ b/hwy_data/WI/usaus/wi.us151.wpt
@@ -71,8 +71,7 @@ WI113 http://www.openstreetmap.org/?lat=43.092177&lon=-89.359338
 WI30 http://www.openstreetmap.org/?lat=43.107249&lon=-89.338760
 US51 http://www.openstreetmap.org/?lat=43.116883&lon=-89.324534
 97 +I-90 http://www.openstreetmap.org/?lat=43.137070&lon=-89.295673
-98A +AmPkwy http://www.openstreetmap.org/?lat=43.144264&lon=-89.287380
-98B http://www.openstreetmap.org/?lat=43.149282&lon=-89.281147
+98 +98A +98B +AmPkwy http://www.openstreetmap.org/?lat=43.147294&lon=-89.283550
 100 http://www.openstreetmap.org/?lat=43.161516&lon=-89.267470
 101 +US151BusSun_S http://www.openstreetmap.org/?lat=43.175952&lon=-89.249496
 102 +WI19 http://www.openstreetmap.org/?lat=43.187405&lon=-89.233274

--- a/hwy_data/WI/usawi/wi.wi057.wpt
+++ b/hwy_data/WI/usawi/wi.wi057.wpt
@@ -1,10 +1,11 @@
 WI59 http://www.openstreetmap.org/?lat=43.022204&lon=-87.947788
-I-94 http://www.openstreetmap.org/?lat=43.034235&lon=-87.947402
+I-94 http://www.openstreetmap.org/?lat=43.034196&lon=-87.947756
 US18_W http://www.openstreetmap.org/?lat=43.044429&lon=-87.947617
 US18_E http://www.openstreetmap.org/?lat=43.044241&lon=-87.937789
 WI145 http://www.openstreetmap.org/?lat=43.059591&lon=-87.937617
 WI190_W http://www.openstreetmap.org/?lat=43.089733&lon=-87.937016
 WI190_E http://www.openstreetmap.org/?lat=43.089466&lon=-87.922790
+I-43 http://www.openstreetmap.org/?lat=43.091464&lon=-87.924013
 HamAve http://www.openstreetmap.org/?lat=43.104304&lon=-87.931266
 SilSprDr http://www.openstreetmap.org/?lat=43.118998&lon=-87.934914
 CRS_Mil http://www.openstreetmap.org/?lat=43.133406&lon=-87.932403


### PR DESCRIPTION
Additional notes from the email submission:

Iowa IA 136: Renamed north end US20/52
Missouri Great River Road: Corrected I-72(152) to I-72(157).
Wisconsin Lake Michigan Circle Trail: Added 6th/7thSt in Racine.
Wisconsin I-94: Reset 307A, 307B, 308A, 309A, 309B
Wisconsin US 18: Restored LinMemDr as alt label for endpoint
Wisconsin US 151: Collapsed 98A and 98B into single exit 98
Wisconsin WI 57: Added I-43. Reset I-94.
South Dakota SD 15: Renamed CR309->CR3/309, CR11->CR11/24, 458thAve -> CR17/34
South Dakota US 12: Renamed 464thAve->CR6_W, 149thSt->MilAve_E, CR37->CR39. Added CR6_E.

I don't think anything here needs an updates entry but I did not look carefully.