### PR TITLE
AR 13 Truncation (White County)

### DIFF
--- a/hwy_data/AR/usaar/ar.ar013.wpt
+++ b/hwy_data/AR/usaar/ar.ar013.wpt
@@ -14,5 +14,4 @@ WalChaRd http://www.openstreetmap.org/?lat=34.912993&lon=-91.748843
 AR38 http://www.openstreetmap.org/?lat=34.989754&lon=-91.736804
 WriRd http://www.openstreetmap.org/?lat=35.010116&lon=-91.744954
 +X642668 http://www.openstreetmap.org/?lat=35.038372&lon=-91.827791
-AR267 http://www.openstreetmap.org/?lat=35.038399&lon=-91.833793
-VinRd http://www.openstreetmap.org/?lat=35.067499&lon=-91.833592
+AR267 +VinRd http://www.openstreetmap.org/?lat=35.038399&lon=-91.833793

--- a/updates.csv
+++ b/updates.csv
@@ -8139,6 +8139,7 @@ date;region;route;root;description
 2017-05-17;(USA) Arizona;Sky Harbor Boulevard;az.skyharblvd;New Route
 2015-08-03;(USA) Arizona;I-11 Future (Hoover Dam);az.i011futhoo;New Route
 2015-08-03;(USA) Arizona;I-11 Future (Kingman);az.i011futkin;New Route
+2026-06-17;(USA) Arkansas;AR 13;ar.ar013;Route truncated to AR 267 from Campground Road.
 2026-05-28;(USA) Arkansas;AR 23W;ar.ar023w;Route added.
 2026-05-28;(USA) Arkansas;AR 270;ar.ar270;Route added.
 2026-05-27;(USA) Arkansas;I-440;ar.i440;Route extended to US 67/167.


### PR DESCRIPTION
Route truncated to AR 267 south of Beebe, previously ended at Campground Road. 