### PR TITLE
Update qc.qc185.wpt

### DIFF
--- a/hwy_data/QC/canqc/qc.qc185.wpt
+++ b/hwy_data/QC/canqc/qc.qc185.wpt
@@ -1,3 +1,3 @@
 *ChSav +47 http://www.openstreetmap.org/?lat=47.678036&lon=-69.022862
-RangVau_W http://www.openstreetmap.org/?lat=47.667645&lon=-69.051747
+*RangVau_W http://www.openstreetmap.org/?lat=47.668408&lon=-69.051915
 56(85) +*RteGerRoy_A http://www.openstreetmap.org/?lat=47.686820&lon=-69.084217


### PR DESCRIPTION
Marks RangVau_W waypoint (not in use) as closed intersection. Last I was there, QC 185 hasn't yet been shortened or absorbed by A-85.