### PR TITLE
IL changes from Highway63 by email

### DIFF
--- a/hwy_data/IL/usaus/il.us024.wpt
+++ b/hwy_data/IL/usaus/il.us024.wpt
@@ -68,7 +68,7 @@ I-39 http://www.openstreetmap.org/?lat=40.736820&lon=-89.034448
 IL251 http://www.openstreetmap.org/?lat=40.736982&lon=-89.024878
 CenSt_Gri http://www.openstreetmap.org/?lat=40.739649&lon=-88.881283
 I-55 http://www.openstreetmap.org/?lat=40.741177&lon=-88.737645
-US66His +OldUS66 http://www.openstreetmap.org/?lat=40.741535&lon=-88.729448
+US66His +OldUS66 http://www.openstreetmap.org/?lat=40.741396&lon=-88.729416
 MorSt http://www.openstreetmap.org/?lat=40.741518&lon=-88.723301
 DivSt http://www.openstreetmap.org/?lat=40.741600&lon=-88.718634
 CR13 http://www.openstreetmap.org/?lat=40.742445&lon=-88.622761

--- a/hwy_data/IL/usaush/il.us066his.wpt
+++ b/hwy_data/IL/usaush/il.us066his.wpt
@@ -167,6 +167,7 @@ CenSt_S http://www.openstreetmap.org/?lat=41.189563&lon=-88.305166
 WasSt_W http://www.openstreetmap.org/?lat=41.190192&lon=-88.305069
 IL53_GarN http://www.openstreetmap.org/?lat=41.190249&lon=-88.301282
 SCHRd http://www.openstreetmap.org/?lat=41.192962&lon=-88.301411
+MitSt http://www.openstreetmap.org/?lat=41.222528&lon=-88.264096
 IL113 http://www.openstreetmap.org/?lat=41.263775&lon=-88.211203
 RivRd http://www.openstreetmap.org/?lat=41.305118&lon=-88.158975
 IL102 http://www.openstreetmap.org/?lat=41.307826&lon=-88.146830

--- a/hwy_data/IL/usaush/il.us066hiscar.wpt
+++ b/hwy_data/IL/usaush/il.us066hiscar.wpt
@@ -7,6 +7,8 @@ CR19 http://www.openstreetmap.org/?lat=39.012115&lon=-89.791431
 +04X13 http://www.openstreetmap.org/?lat=39.024752&lon=-89.790788
 StaBunRd http://www.openstreetmap.org/?lat=39.028377&lon=-89.795337
 +04X14 http://www.openstreetmap.org/?lat=39.034886&lon=-89.801517
+FriLn_S http://www.openstreetmap.org/?lat=39.068963&lon=-89.809349
+FriLn_N http://www.openstreetmap.org/?lat=39.072295&lon=-89.811194
 CR26 http://www.openstreetmap.org/?lat=39.078275&lon=-89.811387
 IL138_E http://www.openstreetmap.org/?lat=39.093132&lon=-89.811687
 IL4/138 http://www.openstreetmap.org/?lat=39.093956&lon=-89.811934
@@ -16,6 +18,7 @@ EasAve_W http://www.openstreetmap.org/?lat=39.122303&lon=-89.816451
 MacSt_S http://www.openstreetmap.org/?lat=39.125200&lon=-89.814885
 IL16_W http://www.openstreetmap.org/?lat=39.129894&lon=-89.819584
 IL16_E http://www.openstreetmap.org/?lat=39.134155&lon=-89.812245
+IL4_DeeC http://www.openstreetmap.org/?lat=39.206569&lon=-89.813082
 IL4_DeeS http://www.openstreetmap.org/?lat=39.215398&lon=-89.813125
 LinLn http://www.openstreetmap.org/?lat=39.217293&lon=-89.816279
 +X02 http://www.openstreetmap.org/?lat=39.223477&lon=-89.815764


### PR DESCRIPTION
Description from Highway63's email:

Illinois US 66 Historic: Added MitSt (point sync IL 53)
Illinois US 66 Historic (Carlinville): Added FriLn_N, FriLn_S, IL4_DeeC (point sync IL 4)
Illinois US 24: point sync US 66 Historic in Chenoa
