### PR TITLE
Fixing bad end tags

### DIFF
--- a/hwy_data/OR/usausb/or.us030bussth.wpt
+++ b/hwy_data/OR/usausb/or.us030bussth.wpt
@@ -1,4 +1,4 @@
-US30BStH_N http://www.openstreetmap.org/?lat=45.859771&lon=-122.820454
+US30_W +US30BStH_N http://www.openstreetmap.org/?lat=45.859771&lon=-122.820454
 N18thSt http://www.openstreetmap.org/?lat=45.859511&lon=-122.816066
 15thSt http://www.openstreetmap.org/?lat=45.860361&lon=-122.813029
 4thSt http://www.openstreetmap.org/?lat=45.865158&lon=-122.802397
@@ -8,4 +8,4 @@ S4thSt http://www.openstreetmap.org/?lat=45.863286&lon=-122.801549
 PlySt http://www.openstreetmap.org/?lat=45.855508&lon=-122.809017
 S18thSt http://www.openstreetmap.org/?lat=45.851895&lon=-122.812761
 OldPorRd http://www.openstreetmap.org/?lat=45.846331&lon=-122.820695
-US30BStH_S http://www.openstreetmap.org/?lat=45.848637&lon=-122.831611
+US30_E +US30BStH_S http://www.openstreetmap.org/?lat=45.848637&lon=-122.831611


### PR DESCRIPTION
Corrected self-referencing end tags to parent route:  US30BStH_N -> US30_W
US30BStH_S -> US30_E
Original tags preserved as alts, as they are in use.