### PR TITLE
CA I-380 and I-8 BL El Centro extended east

### DIFF
--- a/hwy_data/CA/usai/ca.i380.wpt
+++ b/hwy_data/CA/usai/ca.i380.wpt
@@ -1,4 +1,5 @@
 5A http://www.openstreetmap.org/?lat=37.627734&lon=-122.431464
 5C http://www.openstreetmap.org/?lat=37.632988&lon=-122.419125
 6 http://www.openstreetmap.org/?lat=37.636015&lon=-122.403751
-7 +999 http://www.openstreetmap.org/?lat=37.638304&lon=-122.400726
+7A +999 +7 http://www.openstreetmap.org/?lat=37.638304&lon=-122.400726
+7B http://www.openstreetmap.org/?lat=37.638551&lon=-122.397703

--- a/hwy_data/CA/usaib/ca.i008blelc.wpt
+++ b/hwy_data/CA/usaib/ca.i008blelc.wpt
@@ -5,4 +5,5 @@ JamRd +CA54 http://www.openstreetmap.org/?lat=32.795532&lon=-116.935736
 I-8(20A) http://www.openstreetmap.org/?lat=32.803106&lon=-116.927490
 Bro http://www.openstreetmap.org/?lat=32.807672&lon=-116.922040
 GreDr http://www.openstreetmap.org/?lat=32.812304&lon=-116.918521
-I-8_E http://www.openstreetmap.org/?lat=32.811789&lon=-116.917201
+LosCocRd http://www.openstreetmap.org/?lat=32.832361&lon=-116.905560
+I-8_E +I-8(23) http://www.openstreetmap.org/?lat=32.844550&lon=-116.881684

--- a/updates.csv
+++ b/updates.csv
@@ -8709,6 +8709,7 @@ date;region;route;root;description
 2015-09-03;(USA) Arkansas;US 62 Business (Prairie Grove);ar.us062buspra;Added route
 2015-09-03;(USA) Arkansas;US 62 Business (Rogers);;Deleted route
 2015-09-03;(USA) Arkansas;US 63 Business (Jonesboro);;Deleted route
+2026-08-13;(USA) California;I-8BL (El Centro);ca.i008blelc;East end moved to I-8 Exit 23 to match signs
 2026-08-13;(USA) California;CA 56;ca.ca056;West end moved to I-5 Exit 33A to match Caltrans logs
 2026-07-11;(USA) California;CA 263;ca.ca263;Route realigned at north end
 2026-06-10;(USA) California;CA 19;ca.ca019;Route truncated to extent of unsigned SR 164 per recent Caltrans documentation


### PR DESCRIPTION
- CA I-380 extended east to N Access Rd to match Caltrans logs
- CA I-8 BL El Centro extended east to match signs